### PR TITLE
OC-477 Fixes JMS property name constant

### DIFF
--- a/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/application/config/ProtocolMessagingConfig.java
+++ b/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/application/config/ProtocolMessagingConfig.java
@@ -39,7 +39,7 @@ public class ProtocolMessagingConfig extends AbstractConfig {
 
     // JMS Settings
     private static final String PROPERTY_NAME_JMS_ACTIVEMQ_BROKER_URL = "jms.protocol.activemq.broker.url";
-    private static final String PROPERTY_NAME_JMS_ACTIVEMQ_MESSAGEGROUP_CACHESIZE = "jms.protocol.activemq.messageroup.cachesize";
+    private static final String PROPERTY_NAME_JMS_ACTIVEMQ_MESSAGEGROUP_CACHESIZE = "jms.protocol.activemq.messagegroup.cachesize";
 
     private static final String PROPERTY_NAME_JMS_DEFAULT_INITIAL_REDELIVERY_DELAY = "jms.protocol.default.initial.redelivery.delay";
     private static final String PROPERTY_NAME_JMS_DEFAULT_MAXIMUM_REDELIVERIES = "jms.protocol.default.maximum.redeliveries";


### PR DESCRIPTION
Fixes a spelling error (messageroup - messagegroup) in the value of
PROPERTY_NAME_JMS_ACTIVEMQ_MESSAGEGROUP_CACHESIZE that caused the
default value to be applied at start up if the property was set with the
correct spelling.