### PR TITLE
FLEX-4633 ~ Increases time to live and max connections

### DIFF
--- a/osgp/platform/osgp-adapter-domain-core/src/main/resources/osgp-adapter-domain-core.properties
+++ b/osgp/platform/osgp-adapter-domain-core/src/main/resources/osgp-adapter-domain-core.properties
@@ -109,8 +109,8 @@ jms.common.domain.to.ws.requests.queue=ws-core.1_0.domain-core.1_0.requests
 jms.common.domain.to.ws.requests.explicit.qos.enabled=true
 # Set delivery persistent
 jms.common.domain.to.ws.requests.delivery.persistent=true
-# Set Time to live in ms (600000 = 10 min)
-jms.common.domain.to.ws.requests.time.to.live=600000
+# Set Time to live in ms (3600000 = 1 hour)
+jms.common.domain.to.ws.requests.time.to.live=3600000
 
 # --- REDELIVERY POLICY ---
 # Set initial redelivery delay in ms (60000 = 1 min)

--- a/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/application/config/ApplicationContext.java
+++ b/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/application/config/ApplicationContext.java
@@ -7,15 +7,6 @@
  */
 package org.opensmartgridplatform.core.application.config;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
-import org.springframework.jms.core.JmsTemplate;
-import org.springframework.transaction.annotation.EnableTransactionManagement;
-
 import org.opensmartgridplatform.core.domain.model.domain.DomainRequestService;
 import org.opensmartgridplatform.core.domain.model.domain.DomainResponseService;
 import org.opensmartgridplatform.core.domain.model.protocol.ProtocolRequestService;
@@ -25,17 +16,22 @@ import org.opensmartgridplatform.core.infra.jms.domain.in.DomainRequestMessageSe
 import org.opensmartgridplatform.core.infra.jms.protocol.ProtocolRequestMessageSender;
 import org.opensmartgridplatform.core.infra.jms.protocol.in.ProtocolResponseMessageSender;
 import org.opensmartgridplatform.core.infra.messaging.CoreLogItemRequestMessageSender;
-import org.opensmartgridplatform.shared.application.config.jms.JmsConfiguration;
-import org.opensmartgridplatform.shared.application.config.jms.JmsConfigurationFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 /**
- * An application context Java configuration class. The usage of Java configuration requires Spring Framework 3.0
+ * An application context Java configuration class. The usage of Java
+ * configuration requires Spring Framework 3.0
  */
 @Configuration
-@ComponentScan(basePackages = {"org.opensmartgridplatform.domain.core", "org.opensmartgridplatform.core"})
+@ComponentScan(basePackages = { "org.opensmartgridplatform.domain.core", "org.opensmartgridplatform.core" })
 @EnableTransactionManagement()
 @Import({ MessagingConfig.class })
-
 public class ApplicationContext {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ApplicationContext.class);
@@ -66,16 +62,6 @@ public class ApplicationContext {
     DomainRequestService domainRequestMessageSender() {
         LOGGER.debug("Creating bean: domainRequestMessageSender");
         return new DomainRequestMessageSender();
-    }
-
-    @Bean
-    public JmsConfiguration coreLogItemRequestJmsConfiguration(final JmsConfigurationFactory jmsConfigurationFactory) {
-        return jmsConfigurationFactory.initializeConfiguration("jms.dlms.log.item.requests");
-    }
-
-    @Bean
-    public JmsTemplate coreLogItemRequestsJmsTemplate(final JmsConfiguration coreLogItemRequestJmsConfiguration) {
-        return coreLogItemRequestJmsConfiguration.getJmsTemplate();
     }
 
     @Bean

--- a/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/application/config/MessagingConfig.java
+++ b/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/application/config/MessagingConfig.java
@@ -8,15 +8,14 @@
 
 package org.opensmartgridplatform.core.application.config;
 
+import org.opensmartgridplatform.shared.application.config.AbstractMessagingConfig;
+import org.opensmartgridplatform.shared.application.config.jms.JmsConfiguration;
+import org.opensmartgridplatform.shared.application.config.jms.JmsConfigurationFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.jms.core.JmsTemplate;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
-
-import org.opensmartgridplatform.shared.application.config.AbstractMessagingConfig;
-import org.opensmartgridplatform.shared.application.config.jms.JmsConfiguration;
-import org.opensmartgridplatform.shared.application.config.jms.JmsConfigurationFactory;
 
 /**
  * An application context Java configuration class.
@@ -32,11 +31,12 @@ public class MessagingConfig extends AbstractMessagingConfig {
     // === JMS SETTINGS ===
     @Bean
     public JmsConfiguration coreLogItemRequestJmsConfiguration(final JmsConfigurationFactory jmsConfigurationFactory) {
-        return jmsConfigurationFactory.initializeConfiguration("jms.dlms.log.item.requests");
+        return jmsConfigurationFactory.initializeConfiguration("jms.log.item.requests");
     }
 
     @Bean
     public JmsTemplate coreLogItemRequestsJmsTemplate(final JmsConfiguration coreLogItemRequestJmsConfiguration) {
         return coreLogItemRequestJmsConfiguration.getJmsTemplate();
     }
+
 }

--- a/osgp/platform/osgp-core/src/main/resources/osgp-core.properties
+++ b/osgp/platform/osgp-core/src/main/resources/osgp-core.properties
@@ -119,17 +119,6 @@ jms.outgoing.protocol.responses.delivery.persistent=true
 jms.outgoing.protocol.responses.time.to.live=3600000
 
 # =========================================================
-# ===   JMS Settings: Protocol Logging Requests         ===
-# =========================================================
-
-# --- DEFAULT DESTINATION ---
-jms.incoming.protocol.log.item.requests.queue=osgp.logging.protocol
-
-# JMS Settings for receiving Protocol Logging Requests
-jms.incoming.protocol.log.item.requests.concurrent.consumers=2
-jms.incoming.protocol.log.item.requests.max.concurrent.consumers=10
-
-# =========================================================
 # ===   SCHEDULING CONFIG                               ===
 # =========================================================
 scheduling.scheduled.tasks.cron.expression=0 */5 * * * *
@@ -145,14 +134,14 @@ jms.get.power.usage.history.request.time.to.live=3600000
 max.retry.count=3
 
 # =========================================================
-# ===   JMS Settings: Dlms Log Item Requests            ===
+# ===   JMS Settings: Log Item Requests                 ===
 # =========================================================
 
 # --- DEFAULT DESTINATION ---
-jms.dlms.log.item.requests.queue=osgp.logging.protocol
+jms.log.item.requests.queue=osgp.logging.protocol
 
 # --- DELIVERY OPTIONS ---
-jms.dlms.log.item.requests.time.to.live=3600000
+jms.log.item.requests.time.to.live=3600000
 
 # --- DELIVERY OPTIONS ---
 # Set explicitQosEnabled to true to enable the use of deliveryMode, priority, and timeToLive

--- a/osgp/protocol-adapter-iec61850/osgp-protocol-adapter-iec61850/src/main/resources/osgp-adapter-protocol-iec61850.properties
+++ b/osgp/protocol-adapter-iec61850/osgp-protocol-adapter-iec61850/src/main/resources/osgp-adapter-protocol-iec61850.properties
@@ -157,7 +157,8 @@ jms.iec61850.log.item.requests.queue=osgp.logging.protocol
 # --- DELIVERY OPTIONS ---
 jms.iec61850.log.item.requests.explicit.qos.enabled=true
 jms.iec61850.log.item.requests.delivery.persistent=true
-jms.iec61850.log.item.requests.time.to.live=180000
+# Set Time to live in ms (86400000 = 1 day)
+jms.iec61850.log.item.requests.time.to.live=86400000
 jms.iec61850.log.item.requests.receive.timeout=10
 
 # =========================================================

--- a/osgp/protocol-adapter-oslp/osgp-adapter-protocol-oslp-elster/src/main/resources/osgp-adapter-protocol-oslp-elster.properties
+++ b/osgp/protocol-adapter-oslp/osgp-adapter-protocol-oslp-elster/src/main/resources/osgp-adapter-protocol-oslp-elster.properties
@@ -147,8 +147,8 @@ jms.oslp.log.item.requests.queue=osgp.logging.protocol
 jms.oslp.log.item.requests.explicit.qos.enabled=true
 # Set delivery persistent
 jms.oslp.log.item.requests.delivery.persistent=true
-# Set Time to live in ms (180000 = 3 minutes)
-jms.oslp.log.item.requests.time.to.live=180000
+# Set Time to live in ms (86400000 = 1 day)
+jms.oslp.log.item.requests.time.to.live=86400000
 # Set receive timeout
 jms.oslp.log.item.requests.receive.timeout=10
 


### PR DESCRIPTION
* Increases the time to live for messages sent to the osgp.logging.protocol queue from 3 minutes to 1 day.
* Increases the time to live for messages sent to the ws-core.1_0.domain-core.1_0.requests queue from 10 minutes to 1 hour.
* Sets MaxConnPerRoute and MaxConnTotal for http message senders.
* Removes obsolete entries for jms.incoming.protocol.log.item.requests.queue from osgp-core.properties.
* Renames properties in osgp-core for jms.dlms.log.item.requests to jms.log.item.requests, because they are not specific for DLMS.
