### PR TITLE
Fixes microgrids cucumber tests

### DIFF
--- a/integration-tests/cucumber-tests-platform-microgrids/src/test/java/org/opensmartgridplatform/cucumber/platform/microgrids/glue/steps/database/core/RtuDeviceSteps.java
+++ b/integration-tests/cucumber-tests-platform-microgrids/src/test/java/org/opensmartgridplatform/cucumber/platform/microgrids/glue/steps/database/core/RtuDeviceSteps.java
@@ -8,18 +8,20 @@
 package org.opensmartgridplatform.cucumber.platform.microgrids.glue.steps.database.core;
 
 import static org.opensmartgridplatform.cucumber.core.ReadSettingsHelper.getString;
+import static org.opensmartgridplatform.cucumber.platform.PlatformKeys.KEY_LAST_COMMUNICATION_TIME;
 
 import java.util.Map;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.transaction.annotation.Transactional;
-
+import org.joda.time.DateTime;
+import org.opensmartgridplatform.cucumber.core.DateTimeHelper;
 import org.opensmartgridplatform.cucumber.platform.PlatformKeys;
 import org.opensmartgridplatform.cucumber.platform.glue.steps.database.core.BaseDeviceSteps;
 import org.opensmartgridplatform.domain.core.entities.Device;
-import org.opensmartgridplatform.domain.core.repositories.DeviceRepository;
 import org.opensmartgridplatform.domain.core.entities.RtuDevice;
+import org.opensmartgridplatform.domain.core.repositories.DeviceRepository;
 import org.opensmartgridplatform.domain.core.repositories.RtuDeviceRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
 import cucumber.api.java.en.Given;
 
@@ -40,6 +42,7 @@ public class RtuDeviceSteps extends BaseDeviceSteps {
 
         final String deviceIdentification = getString(settings, PlatformKeys.KEY_DEVICE_IDENTIFICATION);
         final RtuDevice rtuDevice = new RtuDevice(deviceIdentification);
+        rtuDevice.messageReceived(this.getLastCommunicationTime(settings).toDate());
         return this.rtuDeviceRespository.save(rtuDevice);
     }
 
@@ -47,5 +50,12 @@ public class RtuDeviceSteps extends BaseDeviceSteps {
     public Device updateRtuDevice(final Map<String, String> settings) throws Throwable {
         return this.updateDevice(this.deviceRespository
                 .findByDeviceIdentification(getString(settings, PlatformKeys.KEY_DEVICE_IDENTIFICATION)), settings);
+    }
+
+    private DateTime getLastCommunicationTime(final Map<String, String> settings) {
+        if (settings.containsKey(KEY_LAST_COMMUNICATION_TIME)) {
+            return (DateTimeHelper.getDateTime(settings.get(KEY_LAST_COMMUNICATION_TIME)));
+        }
+        return DateTime.now();
     }
 }

--- a/integration-tests/cucumber-tests-platform-microgrids/src/test/resources/features/osgp-adapter-ws-microgrids/ConnectionReestablish.feature
+++ b/integration-tests/cucumber-tests-platform-microgrids/src/test/resources/features/osgp-adapter-ws-microgrids/ConnectionReestablish.feature
@@ -5,8 +5,9 @@ Feature: Microgrids Re-establish Connection
 
   Scenario: Connection lost and reestablished
     Given an rtu iec61850 device
-      | DeviceIdentification | RTU-PAMPUS |
-      | Port                 |      62102 |
+      | DeviceIdentification  | RTU-PAMPUS |
+      | Port                  |      62102 |
+      | LastCommunicationTime | yesterday  |
     When the OSGP connection is lost with the RTU device
     Then I should receive a notification
     And the get data response should be returned

--- a/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/PlatformKeys.java
+++ b/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/PlatformKeys.java
@@ -231,7 +231,7 @@ public class PlatformKeys extends Keys {
     public static final String KEY_VERSION = "Version";
     public static final String KEY_RESPONSE_URL = "ResponseUrl";
 
-    public static final String LAST_COMMUNICATION_TIME = "LastCommunicationTime";
+    public static final String KEY_LAST_COMMUNICATION_TIME = "LastCommunicationTime";
     public static final String LOGIN_ATTEMPT_COUNT = "LoginAttemptCount";
     public static final String LONG_INTERVAL = "LongInterval";
     public static final String MANUFACTURER_CODE = "ManufacturerCode";

--- a/osgp/platform/osgp-domain-core/src/main/java/org/opensmartgridplatform/domain/core/entities/RtuDevice.java
+++ b/osgp/platform/osgp-domain-core/src/main/java/org/opensmartgridplatform/domain/core/entities/RtuDevice.java
@@ -33,6 +33,10 @@ public class RtuDevice extends Device {
         this.lastCommunicationTime = new Date();
     }
 
+    public void messageReceived(final Date date) {
+        this.lastCommunicationTime = date;
+    }
+
     public Date getLastCommunicationTime() {
         return this.lastCommunicationTime;
     }


### PR DESCRIPTION
Makes sure last communication date for an RTU device is set,
preventing notifications from the communication restore mechanism,
causing failing tests:
```
org.junit.ComparisonFailure: System[1/1] type expected:<[GAS_FURNACE]>
but was:<[RTU]>
```

last communication time defaults to DateTime.now(), but could be
overridden in feature files