### PR TITLE
FLEX-4964 ~ Updates jackson-databind version to 2.9.9.1.

### DIFF
--- a/integration-tests/parent-integration-tests/pom.xml
+++ b/integration-tests/parent-integration-tests/pom.xml
@@ -71,6 +71,7 @@
     <apache.httpcomponents.version>4.3.6</apache.httpcomponents.version>
     <apache.httpcomponents.httpcore.version>4.4.6</apache.httpcomponents.httpcore.version>
     <jackson.version>2.9.9</jackson.version>
+    <jackson-databind.version>2.9.9.1</jackson-databind.version>
     <commons.codec.version>1.9</commons.codec.version>
     <orika.version>1.5.1</orika.version>
     <netty.version>3.9.4.Final</netty.version>
@@ -555,7 +556,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>${jackson.version}</version>
+        <version>${jackson-databind.version}</version>
       </dependency>
 
       <!-- Jakarta commons codec -->

--- a/osgp/protocol-adapter-oslp/parent-pa-oslp/pom.xml
+++ b/osgp/protocol-adapter-oslp/parent-pa-oslp/pom.xml
@@ -71,6 +71,7 @@
     <apache.activemq.version>5.15.9</apache.activemq.version>
     <commons.pool.version>1.6</commons.pool.version>
     <jackson.version>2.9.9</jackson.version>
+    <jackson-databind.version>2.9.9.1</jackson-databind.version>
     <proton-jms.version>0.7</proton-jms.version>
     <logback.version>1.2.3</logback.version>
     <logback.ext.version>0.1.4</logback.ext.version>

--- a/osgp/protocol-adapter-oslp/web-device-simulator/pom.xml
+++ b/osgp/protocol-adapter-oslp/web-device-simulator/pom.xml
@@ -86,7 +86,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${jackson.version}</version>
+      <version>${jackson-databind.version}</version>
     </dependency>
 
     <!-- Guava for Joiner class -->

--- a/osgp/shared/parent-shared/pom.xml
+++ b/osgp/shared/parent-shared/pom.xml
@@ -65,6 +65,7 @@
     <apache.commons.lang.version>3.3.2</apache.commons.lang.version>
     <apache.httpcomponents.version>4.3.6</apache.httpcomponents.version>
     <jackson.version>2.9.9</jackson.version>
+    <jackson-databind.version>2.9.9.1</jackson-databind.version>
     <commons.codec.version>1.9</commons.codec.version>
     <orika.version>1.5.1</orika.version>
     <jxr.version>2.5</jxr.version>
@@ -261,7 +262,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>${jackson.version}</version>
+        <version>${jackson-databind.version}</version>
       </dependency>
 
       <!-- Jakarta commons codec -->

--- a/public-lighting-demo-app/parent-os-webapps/pom.xml
+++ b/public-lighting-demo-app/parent-os-webapps/pom.xml
@@ -63,7 +63,6 @@
     <jxr.version>2.5</jxr.version>
     <maven.project.info.reports.plugin.version>3.0.0</maven.project.info.reports.plugin.version>
     <maven.site.plugin>3.7.1</maven.site.plugin>
-    <jackson.jaxrs.version>2.8.6</jackson.jaxrs.version>
     <maven.compiler.plugin.version>3.2</maven.compiler.plugin.version>
     <license.maven.plugin>2.11</license.maven.plugin>
     <maven.javadoc.version>2.10.4</maven.javadoc.version>


### PR DESCRIPTION
Fixes CVE-2019-12814 https://nvd.nist.gov/vuln/detail/CVE-2019-12814#vulnCurrentDescriptionTitle