### PR TITLE
FLEX-4975 ~ Updates jackson-databind version to 2.9.9.2.

### DIFF
--- a/integration-tests/parent-integration-tests/pom.xml
+++ b/integration-tests/parent-integration-tests/pom.xml
@@ -71,7 +71,7 @@
     <apache.httpcomponents.version>4.3.6</apache.httpcomponents.version>
     <apache.httpcomponents.httpcore.version>4.4.6</apache.httpcomponents.httpcore.version>
     <jackson.version>2.9.9</jackson.version>
-    <jackson-databind.version>2.9.9.1</jackson-databind.version>
+    <jackson-databind.version>2.9.9.2</jackson-databind.version>
     <commons.codec.version>1.9</commons.codec.version>
     <orika.version>1.5.1</orika.version>
     <netty.version>3.9.4.Final</netty.version>

--- a/osgp/protocol-adapter-oslp/parent-pa-oslp/pom.xml
+++ b/osgp/protocol-adapter-oslp/parent-pa-oslp/pom.xml
@@ -71,7 +71,7 @@
     <apache.activemq.version>5.15.9</apache.activemq.version>
     <commons.pool.version>1.6</commons.pool.version>
     <jackson.version>2.9.9</jackson.version>
-    <jackson-databind.version>2.9.9.1</jackson-databind.version>
+    <jackson-databind.version>2.9.9.2</jackson-databind.version>
     <proton-jms.version>0.7</proton-jms.version>
     <logback.version>1.2.3</logback.version>
     <logback.ext.version>0.1.4</logback.ext.version>

--- a/osgp/shared/parent-shared/pom.xml
+++ b/osgp/shared/parent-shared/pom.xml
@@ -65,7 +65,7 @@
     <apache.commons.lang.version>3.3.2</apache.commons.lang.version>
     <apache.httpcomponents.version>4.3.6</apache.httpcomponents.version>
     <jackson.version>2.9.9</jackson.version>
-    <jackson-databind.version>2.9.9.1</jackson-databind.version>
+    <jackson-databind.version>2.9.9.2</jackson-databind.version>
     <commons.codec.version>1.9</commons.codec.version>
     <orika.version>1.5.1</orika.version>
     <jxr.version>2.5</jxr.version>


### PR DESCRIPTION
Fixes CVE-2019-14379 and CVE-2019-14439.