### PR TITLE
Add event code 231

### DIFF
--- a/osgp/platform/osgp-adapter-ws-smartmetering/src/test/java/org/opensmartgridplatform/adapter/ws/smartmetering/application/mapping/ListEventMappingTest.java
+++ b/osgp/platform/osgp-adapter-ws-smartmetering/src/test/java/org/opensmartgridplatform/adapter/ws/smartmetering/application/mapping/ListEventMappingTest.java
@@ -54,7 +54,8 @@ public class ListEventMappingTest {
                     new Event(DateTime.now(), EventType.FIRMWARE_READY_FOR_ACTIVATION.getValue(), null),
                     new Event(DateTime.now(), EventType.FIRMWARE_ACTIVATED.getValue(), null),
                     new Event(DateTime.now(), EventType.PASSIVE_TARIFF_UPDATED.getValue(), null),
-                    new Event(DateTime.now(), EventType.SUCCESSFUL_SELFCHECK_AFTER_FIRMWARE_UPDATE.getValue(), null));
+                    new Event(DateTime.now(), EventType.SUCCESSFUL_SELFCHECK_AFTER_FIRMWARE_UPDATE.getValue(), null),
+                    new Event(DateTime.now(), EventType.MANUFACTURER_SPECIFIC_231.getValue(), null));
 
     private static final List<Event> FRAUD_DETECTION_EVENTS = Arrays.asList(
             new Event(DateTime.now(), EventType.TERMINAL_COVER_REMOVED.getValue(), null),

--- a/osgp/platform/osgp-domain-core/src/main/java/org/opensmartgridplatform/domain/core/valueobjects/smartmetering/EventType.java
+++ b/osgp/platform/osgp-domain-core/src/main/java/org/opensmartgridplatform/domain/core/valueobjects/smartmetering/EventType.java
@@ -95,7 +95,8 @@ public enum EventType {
     FRAUD_ATTEMPT_M_BUS_CHANNEL_4(133),
     CLOCK_ADJUSTED_M_BUS_CHANNEL_4(134),
     NEW_M_BUS_DEVICE_DISCOVERED_CHANNEL_4(135),
-    PERMANENT_ERROR_FROM_M_BUS_DEVICE_CHANNEL_4(136);
+    PERMANENT_ERROR_FROM_M_BUS_DEVICE_CHANNEL_4(136),
+    MANUFACTURER_SPECIFIC_231(231);
 
     private static final EventType[] VALUES = EventType.values();
     private static final Map<Integer, EventType> lookup = new HashMap<>();

--- a/osgp/shared/osgp-ws-smartmetering/src/main/resources/schemas/sm-management.xsd
+++ b/osgp/shared/osgp-ws-smartmetering/src/main/resources/schemas/sm-management.xsd
@@ -504,6 +504,8 @@
         the M_BUS device. The Permanent error can be a self-check error, or any other 
         fatal device error that requires a service action -->
       <xsd:enumeration value="PERMANENT_ERROR_FROM_M_BUS_DEVICE_CHANNEL_4"/>
+      <!-- 231 - Indicates a manufacturer specific code -->
+      <xsd:enumeration value="MANUFACTURER_SPECIFIC_231"/>
 
     </xsd:restriction>
   </xsd:simpleType>


### PR DESCRIPTION
When reading the Standard Event log of the Iskra meter with Id E0033006878667817, the he-ui displays a nullpointer exception in the result of the operation.

This nullpointer is caused by the manufacturer specific code 231 the Iska meter sends in its log. This code is not known in OSGP, causing the unmarchalling to fail.

In this PR code 231 is added, solving the problem for this particular event code. In the OSGP-applications repo there is another PR for added this event code.

Please note that the (D)SMR contains more event codes not known by OSGP (the complete range for manufacturer specific codes 230-249 and other ranges reserved for future use and backwards compatibility). It should be decided whether all these codes need to be added, or that a general way of processing unknown codes should be implemented.