### PR TITLE
FLEX-5037 ~ Changes email step in pipeline scripts.

### DIFF
--- a/jenkins/pipeline/osgp-nightly-build.groovy
+++ b/jenkins/pipeline/osgp-nightly-build.groovy
@@ -96,7 +96,6 @@ pipeline {
                 body: '${DEFAULT_CONTENT}',
                 to: '${DEFAULT_RECIPIENTS}',
                 from: '${DEFAULT_REPLYTO}')
-            }
         }
         cleanup {
             // Delete workspace folder.

--- a/jenkins/pipeline/osgp-nightly-build.groovy
+++ b/jenkins/pipeline/osgp-nightly-build.groovy
@@ -94,6 +94,7 @@ pipeline {
             emailext (
                 subject: '${DEFAULT_SUBJECT}',
                 body: '${DEFAULT_CONTENT}',
+                recipientProviders: [[$class: 'DevelopersRecipientProvider'], [$class: 'RequesterRecipientProvider']],
                 to: '${DEFAULT_RECIPIENTS}',
                 from: '${DEFAULT_REPLYTO}')
         }

--- a/jenkins/pipeline/osgp-nightly-build.groovy
+++ b/jenkins/pipeline/osgp-nightly-build.groovy
@@ -91,7 +91,12 @@ pipeline {
             build job: 'Destroy an AWS System', parameters: [string(name: 'SERVERNAME', value: servername), string(name: 'PLAYBOOK', value: playbook)]            
         }
         failure {
-            step([$class: 'Mailer', notifyEveryUnstableBuild: true, recipients: 'kevin.smeets@cgi.com,ruud.lemmers@cgi.com,sander.van.der.heijden@cgi.com', sendToIndividuals: false])
+            emailext (
+                subject: '${DEFAULT_SUBJECT}',
+                body: '${DEFAULT_CONTENT}',
+                to: '${DEFAULT_RECIPIENTS}',
+                from: '${DEFAULT_REPLYTO}')
+            }
         }
         cleanup {
             // Delete workspace folder.

--- a/jenkins/pipeline/osgp-pr-build.groovy
+++ b/jenkins/pipeline/osgp-pr-build.groovy
@@ -191,7 +191,13 @@ echo Found cucumber tags: [$EXTRACTED_TAGS]'''
         }
         failure {
             // Mail everyone that the job failed
-            step([$class: 'Mailer', notifyEveryUnstableBuild: true, recipients: 'kevin.smeets@cgi.com,ruud.lemmers@cgi.com,sander.van.der.heijden@cgi.com', sendToIndividuals: false])
+            emailext (
+                subject: '${DEFAULT_SUBJECT}',
+                body: '${DEFAULT_CONTENT}',
+                to: '${DEFAULT_RECIPIENTS}',
+                from: '${DEFAULT_REPLYTO}')
+            }
+
             step([$class: 'GitHubSetCommitStatusBuilder', contextSource: [$class: 'ManuallyEnteredCommitContextSource']])
         }
         cleanup {

--- a/jenkins/pipeline/osgp-pr-build.groovy
+++ b/jenkins/pipeline/osgp-pr-build.groovy
@@ -196,7 +196,6 @@ echo Found cucumber tags: [$EXTRACTED_TAGS]'''
                 body: '${DEFAULT_CONTENT}',
                 to: '${DEFAULT_RECIPIENTS}',
                 from: '${DEFAULT_REPLYTO}')
-            }
 
             step([$class: 'GitHubSetCommitStatusBuilder', contextSource: [$class: 'ManuallyEnteredCommitContextSource']])
         }

--- a/jenkins/pipeline/osgp-pr-build.groovy
+++ b/jenkins/pipeline/osgp-pr-build.groovy
@@ -194,6 +194,7 @@ echo Found cucumber tags: [$EXTRACTED_TAGS]'''
             emailext (
                 subject: '${DEFAULT_SUBJECT}',
                 body: '${DEFAULT_CONTENT}',
+                recipientProviders: [[$class: 'DevelopersRecipientProvider'], [$class: 'RequesterRecipientProvider']],
                 to: '${DEFAULT_RECIPIENTS}',
                 from: '${DEFAULT_REPLYTO}')
 

--- a/osgp/shared/shared/src/test/java/org/opensmartgridplatform/shared/XMLGregorianCalendarToDateTimeConverterTest.java
+++ b/osgp/shared/shared/src/test/java/org/opensmartgridplatform/shared/XMLGregorianCalendarToDateTimeConverterTest.java
@@ -67,6 +67,11 @@ public class XMLGregorianCalendarToDateTimeConverterTest {
     }
 
     @Test
+    public void makeSureThisTestFails() {
+        Assert.fail("Make sure this test fails!");
+    }
+
+    @Test
     public void mapXMLGregorianCalenderWithTimeZoneToDateTime() throws DatatypeConfigurationException {
         final String withTimeZone = "2010-06-30T01:20:30+02:00";
         final DateTime dateTime = DateTime.parse(withTimeZone);

--- a/osgp/shared/shared/src/test/java/org/opensmartgridplatform/shared/XMLGregorianCalendarToDateTimeConverterTest.java
+++ b/osgp/shared/shared/src/test/java/org/opensmartgridplatform/shared/XMLGregorianCalendarToDateTimeConverterTest.java
@@ -67,11 +67,6 @@ public class XMLGregorianCalendarToDateTimeConverterTest {
     }
 
     @Test
-    public void makeSureThisTestFails() {
-        Assert.fail("Make sure this test fails!");
-    }
-
-    @Test
     public void mapXMLGregorianCalenderWithTimeZoneToDateTime() throws DatatypeConfigurationException {
         final String withTimeZone = "2010-06-30T01:20:30+02:00";
         final DateTime dateTime = DateTime.parse(withTimeZone);


### PR DESCRIPTION
Instead of using the 'Mailer' plugin, use the 'Email-ext' plugin. This seems to prevent problems with credentials for Gmail.