### PR TITLE
Bump Jackson due to known CVE's

### DIFF
--- a/integration-tests/parent-integration-tests/pom.xml
+++ b/integration-tests/parent-integration-tests/pom.xml
@@ -70,8 +70,8 @@
     <apache.commons.lang.version>3.3.2</apache.commons.lang.version>
     <apache.httpcomponents.version>4.3.6</apache.httpcomponents.version>
     <apache.httpcomponents.httpcore.version>4.4.6</apache.httpcomponents.httpcore.version>
-    <jackson.version>2.9.10</jackson.version>
-    <jackson-databind.version>2.9.10</jackson-databind.version>
+    <jackson.version>2.10.0</jackson.version>
+    <jackson-databind.version>2.10.0</jackson-databind.version>
     <commons.codec.version>1.9</commons.codec.version>
     <orika.version>1.5.1</orika.version>
     <netty.version>3.9.4.Final</netty.version>

--- a/osgp/protocol-adapter-oslp/parent-pa-oslp/pom.xml
+++ b/osgp/protocol-adapter-oslp/parent-pa-oslp/pom.xml
@@ -70,8 +70,8 @@
     <maven.site.plugin>3.7.1</maven.site.plugin>
     <apache.activemq.version>5.15.9</apache.activemq.version>
     <commons.pool.version>1.6</commons.pool.version>
-    <jackson.version>2.9.10</jackson.version>
-    <jackson-databind.version>2.9.10</jackson-databind.version>
+    <jackson.version>2.10.0</jackson.version>
+    <jackson-databind.version>2.10.0</jackson-databind.version>
     <proton-jms.version>0.7</proton-jms.version>
     <logback.version>1.2.3</logback.version>
     <logback.ext.version>0.1.4</logback.ext.version>

--- a/osgp/shared/parent-shared/pom.xml
+++ b/osgp/shared/parent-shared/pom.xml
@@ -64,8 +64,8 @@
     <slf4j.version>1.7.7</slf4j.version>
     <apache.commons.lang.version>3.3.2</apache.commons.lang.version>
     <apache.httpcomponents.version>4.3.6</apache.httpcomponents.version>
-    <jackson.version>2.9.10</jackson.version>
-    <jackson-databind.version>2.9.10</jackson-databind.version>
+    <jackson.version>2.10.0</jackson.version>
+    <jackson-databind.version>2.10.0</jackson-databind.version>
     <commons.codec.version>1.9</commons.codec.version>
     <orika.version>1.5.1</orika.version>
     <jxr.version>2.5</jxr.version>


### PR DESCRIPTION
Interesting project. While going through the code, I've noticed that you're using an old version of Jackson which has some known vulnerabilities.

Fixes the following CVE's:
https://www.cvedetails.com/cve/CVE-2019-16942/
https://www.cvedetails.com/cve/CVE-2019-16943/