### PR TITLE
Bump protobuf from 2.4.1 to 2.5.0

### DIFF
--- a/integration-tests/parent-integration-tests/pom.xml
+++ b/integration-tests/parent-integration-tests/pom.xml
@@ -57,7 +57,7 @@
     <spring.security.version>4.2.13.RELEASE</spring.security.version>
     <servlet.version>3.0.1</servlet.version>
     <servlet.jstl.version>1.2</servlet.jstl.version>
-    <protobuf.version>2.4.1</protobuf.version>
+    <protobuf.version>2.5.0</protobuf.version>
     <postgresql.version>9.3-1102-jdbc41</postgresql.version>
     <hibernate.version>4.2.16.Final</hibernate.version>
     <hibernate.validator.version>4.3.1.Final</hibernate.validator.version>

--- a/osgp/protocol-adapter-oslp/oslp/pom.xml
+++ b/osgp/protocol-adapter-oslp/oslp/pom.xml
@@ -57,7 +57,7 @@
       <plugin>
         <groupId>com.github.igor-petruk.protobuf</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>
-        <version>0.6.2</version>
+        <version>0.6.5</version>
         <executions>
           <execution>
             <goals>

--- a/osgp/protocol-adapter-oslp/parent-pa-oslp/pom.xml
+++ b/osgp/protocol-adapter-oslp/parent-pa-oslp/pom.xml
@@ -53,7 +53,7 @@
     <spring.security.version>4.2.13.RELEASE</spring.security.version>
     <servlet.version>3.0.1</servlet.version>
     <servlet.jstl.version>1.2</servlet.jstl.version>
-    <protobuf.version>2.4.1</protobuf.version>
+    <protobuf.version>2.5.0</protobuf.version>
     <hibernate.version>4.2.16.Final</hibernate.version>
     <hibernate.validator.version>4.3.1.Final</hibernate.validator.version>
     <junit.version>4.11</junit.version>


### PR DESCRIPTION
While running `mvn clean install -DskipTests` it fails for some unclear reason:

```
[INFO] -------------------< org.opensmartgridplatform:oslp >-------------------
[INFO] Building oslp 4.38.0-SNAPSHOT                                    [17/65]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ oslp ---
[INFO] Deleting /Users/fokkodriesprong/Desktop/open-smart-grid-platform/osgp/protocol-adapter-oslp/oslp/target
[INFO] 
[INFO] --- protobuf-maven-plugin:0.6.2:run (default) @ oslp ---
[INFO] Protobuf dependency version 2.4.1
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for open-smart-grid-platform 4.38.0-SNAPSHOT:
[INFO] 
[INFO] parent-shared ...................................... SUCCESS [  0.291 s]
[INFO] shared ............................................. SUCCESS [  4.809 s]
[INFO] osgp-dto ........................................... SUCCESS [  2.951 s]
[INFO] osgp-ws-core ....................................... SUCCESS [  3.360 s]
[INFO] osgp-ws-admin ...................................... SUCCESS [  0.912 s]
[INFO] osgp-ws-microgrids ................................. SUCCESS [  0.934 s]
[INFO] osgp-ws-distributionautomation ..................... SUCCESS [  1.015 s]
[INFO] osgp-ws-publiclighting ............................. SUCCESS [  1.042 s]
[INFO] osgp-ws-tariffswitching ............................ SUCCESS [  0.913 s]
[INFO] osgp-ws-smartmetering .............................. SUCCESS [  3.173 s]
[INFO] parent-pa-iec61850 ................................. SUCCESS [  0.006 s]
[INFO] osgp-iec61850 ...................................... SUCCESS [  1.699 s]
[INFO] osgp-core-db-api-iec61850 .......................... SUCCESS [  1.026 s]
[INFO] osgp-protocol-adapter-iec61850 ..................... SUCCESS [  7.373 s]
[INFO] osgp-protocol-simulator-iec61850 ................... SUCCESS [  5.850 s]
[INFO] parent-pa-oslp ..................................... SUCCESS [  0.008 s]
[INFO] oslp ............................................... FAILURE [  0.645 s]
[INFO] osgp-web-device-simulator .......................... SKIPPED
[INFO] osgp-core-db-api ................................... SKIPPED
[INFO] osgp-protocol-adapter-oslp-elster .................. SKIPPED
[INFO] signing-server ..................................... SKIPPED
[INFO] parent-pa-dlms ..................................... SKIPPED
[INFO] osgp-dlms .......................................... SKIPPED
[INFO] jasper-interface ................................... SKIPPED
[INFO] osgp-protocol-adapter-dlms ......................... SKIPPED
[INFO] parent-pa-iec60870 ................................. SKIPPED
[INFO] osgp-iec60870 ...................................... SKIPPED
[INFO] osgp-protocol-adapter-iec60870 ..................... SKIPPED
[INFO] osgp-protocol-simulator-iec60870 ................... SKIPPED
[INFO] parent-platform .................................... SKIPPED
[INFO] osgp-domain-core ................................... SKIPPED
[INFO] osgp-domain-logging ................................ SKIPPED
[INFO] osgp-domain-microgrids ............................. SKIPPED
[INFO] osgp-domain-distributionautomation ................. SKIPPED
[INFO] osgp-adapter-domain-shared ......................... SKIPPED
[INFO] osgp-adapter-domain-admin .......................... SKIPPED
[INFO] osgp-adapter-domain-core ........................... SKIPPED
[INFO] osgp-adapter-domain-microgrids ..................... SKIPPED
[INFO] osgp-adapter-domain-distributionautomation ......... SKIPPED
[INFO] osgp-adapter-domain-publiclighting ................. SKIPPED
[INFO] osgp-adapter-domain-tariffswitching ................ SKIPPED
[INFO] osgp-adapter-domain-smartmetering .................. SKIPPED
[INFO] osgp-adapter-ws-shared ............................. SKIPPED
[INFO] osgp-adapter-ws-shared-db .......................... SKIPPED
[INFO] osgp-adapter-ws-core ............................... SKIPPED
[INFO] osgp-adapter-ws-admin .............................. SKIPPED
[INFO] osgp-adapter-ws-publiclighting ..................... SKIPPED
[INFO] osgp-adapter-ws-tariffswitching .................... SKIPPED
[INFO] osgp-adapter-ws-smartmetering ...................... SKIPPED
[INFO] osgp-adapter-ws-microgrids ......................... SKIPPED
[INFO] osgp-adapter-ws-distributionautomation ............. SKIPPED
[INFO] osgp-core .......................................... SKIPPED
[INFO] osgp-logging ....................................... SKIPPED
[INFO] parent-integration-tests ........................... SKIPPED
[INFO] cucumber-tests-core ................................ SKIPPED
[INFO] cucumber-tests-execution ........................... SKIPPED
[INFO] cucumber-tests-platform ............................ SKIPPED
[INFO] cucumber-tests-platform-common ..................... SKIPPED
[INFO] cucumber-tests-platform-distributionautomation ..... SKIPPED
[INFO] cucumber-tests-platform-microgrids ................. SKIPPED
[INFO] cucumber-tests-platform-publiclighting ............. SKIPPED
[INFO] cucumber-tests-platform-smartmetering .............. SKIPPED
[INFO] os-webapps ......................................... SKIPPED
[INFO] osgp-web-demo-app .................................. SKIPPED
[INFO] open-smart-grid-platform ........................... SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  36.492 s
[INFO] Finished at: 2019-10-15T16:20:51+02:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal com.github.igor-petruk.protobuf:protobuf-maven-plugin:0.6.2:run (default) on project oslp: 'protoc' failed. Exit code 0 -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <args> -rf :oslp
```

When updating to 2.5.0 everything works fine. Looking at the changelog: https://github.com/protocolbuffers/protobuf/releases/tag/v2.5.0
it looks like there are some small changes on performance.