### PR TITLE
Add missing properties files references

### DIFF
--- a/osgp/platform/osgp-adapter-ws-core/src/main/webapp/META-INF/context.xml
+++ b/osgp/platform/osgp-adapter-ws-core/src/main/webapp/META-INF/context.xml
@@ -40,4 +40,11 @@
   <Environment name="osgp/AdapterWsCore/log-config"
     value="/etc/osp/osgp-adapter-ws-core-logback.xml" type="java.lang.String"
     override="true" />
+  
+    <Environment name="osgp/DomainLogging/config"
+    value="/etc/osp/osgp-domain-logging.properties" type="java.lang.String"
+    override="true" />
+  <Environment name="osgp/AdapterWsSharedDb/config"
+    value="/etc/osp/osgp-adapter-ws-shared-db.properties" type="java.lang.String"
+    override="true" />
 </Context>


### PR DESCRIPTION
To be able to set custom properties for used libraries in osgp-ws-core, it is required to add a reference to these properties files.