### PR TITLE
Feature/slim 2182 selective access periodic meter reads

### DIFF
--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/monitoring/GetPeriodicMeterReads.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/monitoring/GetPeriodicMeterReads.feature
@@ -8,12 +8,12 @@ Feature: SmartMetering Monitoring - Get Periodic Meter Reads
     Given a dlms device
       | DeviceIdentification     | TEST1024000000001 |
       | DeviceType               | SMART_METER_E     |
-      | SelectiveAccessSupported | false              |
+      | SelectiveAccessSupported | true              |
     And a dlms device
       | DeviceIdentification        | TESTG102400000001 |
       | DeviceType                  | SMART_METER_G     |
       | GatewayDeviceIdentification | TEST1024000000001 |
-      | Channel                     |                 1 |
+      | Channel                     | 1                 |
 
   Scenario Outline: Get the periodic meter reads from a device
     When the get "<PeriodType>" meter reads request is received

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/monitoring/GetPeriodicMeterReads.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/monitoring/GetPeriodicMeterReads.feature
@@ -8,7 +8,7 @@ Feature: SmartMetering Monitoring - Get Periodic Meter Reads
     Given a dlms device
       | DeviceIdentification     | TEST1024000000001 |
       | DeviceType               | SMART_METER_E     |
-      | SelectiveAccessSupported | true              |
+      | SelectiveAccessSupported | false              |
     And a dlms device
       | DeviceIdentification        | TESTG102400000001 |
       | DeviceType                  | SMART_METER_G     |

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/dlmsobjectconfig/DlmsObjectConfigService.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/dlmsobjectconfig/DlmsObjectConfigService.java
@@ -33,8 +33,6 @@ import org.springframework.stereotype.Service;
 @Service
 public class DlmsObjectConfigService {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(DlmsObjectConfigService.class);
-
     private final DlmsHelper dlmsHelper;
     private final List<DlmsObjectConfig> dlmsObjectConfigs;
 
@@ -111,7 +109,6 @@ public class DlmsObjectConfigService {
         final DlmsObject object = addressRequest.getDlmsObject();
         final DateTime from = addressRequest.getFrom();
         final DateTime to = addressRequest.getTo();
-        final DlmsDevice device = addressRequest.getDevice();
 
         if (!(object instanceof DlmsProfile) || from == null || to == null) {
             return null;

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/dlmsobjectconfig/DlmsObjectConfigService.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/dlmsobjectconfig/DlmsObjectConfigService.java
@@ -115,10 +115,6 @@ public class DlmsObjectConfigService {
 
         if (!(object instanceof DlmsProfile) || from == null || to == null) {
             return null;
-        } else if (!device.isSelectiveAccessSupported()) {
-            LOGGER.info("Device does not support selective access, returning all captureobjects as selected objects");
-            selectedObjects.addAll(((DlmsProfile) object).getCaptureObjects());
-            return null;
         } else {
             final int accessSelector = 1;
 
@@ -141,13 +137,13 @@ public class DlmsObjectConfigService {
 
             final DlmsProfile profile = (DlmsProfile) object;
 
-            if (!protocol.isSelectValuesInSelectiveAccessSupported()) {
-                // If selecting values is not supported, then all values are selected (and the objectDefinitions list
-                // should be empty)
-                selectedObjects.addAll(profile.getCaptureObjects());
-            } else {
+            if (protocol.isSelectValuesInSelectiveAccessSupported() && addressRequest.getDevice().isSelectiveAccessSupported()) {
                 objectDefinitions = this.getObjectDefinitions(addressRequest.getChannel(),
                         addressRequest.getFilterMedium(), protocol, profile, selectedObjects);
+            } else {
+                // If selecting values is not supported, then all values are selected (and the objectDefinitions list
+                // should be empty)
+                selectedObjects.addAll(((DlmsProfile) object).getCaptureObjects());
             }
         }
 

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/dlmsobjectconfig/DlmsObjectConfigService.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/dlmsobjectconfig/DlmsObjectConfigService.java
@@ -1,9 +1,9 @@
 /**
  * Copyright 2019 Smart Society Services B.V.
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
  */
 package org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.dlmsobjectconfig;
@@ -45,15 +45,15 @@ public class DlmsObjectConfigService {
     }
 
     public Optional<AttributeAddress> findAttributeAddress(final DlmsDevice device, final DlmsObjectType type,
-            final Integer channel) {
+                                                           final Integer channel) {
         // Note: channel can be null.
         return this.findAttributeAddressForProfile(device, type, channel, null, null, null)
                 .map(AttributeAddressForProfile::getAttributeAddress);
     }
 
     public Optional<AttributeAddressForProfile> findAttributeAddressForProfile(final DlmsDevice device,
-            final DlmsObjectType type, final Integer channel, final DateTime from, final DateTime to,
-            final Medium filterMedium) {
+                                                                               final DlmsObjectType type, final Integer channel, final DateTime from, final DateTime to,
+                                                                               final Medium filterMedium) {
         return this.findDlmsObject(Protocol.forDevice(device), type,
                 filterMedium)
                 .map(dlmsObject -> this.getAttributeAddressForProfile(new AddressRequest(device, dlmsObject, channel,
@@ -61,7 +61,7 @@ public class DlmsObjectConfigService {
     }
 
     public Optional<DlmsObject> findDlmsObject(final Protocol protocol, final DlmsObjectType type,
-            final Medium filterMedium) {
+                                               final Medium filterMedium) {
         return this.dlmsObjectConfigs.stream()
                 .filter(config -> config.contains(protocol))
                 .findAny()
@@ -69,7 +69,7 @@ public class DlmsObjectConfigService {
     }
 
     public List<AttributeAddress> getAttributeAddressesForScalerUnit(final AttributeAddressForProfile attributeAddressForProfile,
-            final Integer channel) {
+                                                                     final Integer channel) {
         final List<AttributeAddress> attributeAddresses = new ArrayList<>();
 
         // Get all Registers from the list of selected objects for which the default attribute is captured.
@@ -106,7 +106,7 @@ public class DlmsObjectConfigService {
     }
 
     private SelectiveAccessDescription getAccessDescription(final AddressRequest addressRequest,
-            final List<DlmsCaptureObject> selectedObjects) {
+                                                            final List<DlmsCaptureObject> selectedObjects) {
 
         final DlmsObject object = addressRequest.getDlmsObject();
         final DateTime from = addressRequest.getFrom();
@@ -136,22 +136,15 @@ public class DlmsObjectConfigService {
         if (object instanceof DlmsProfile && ((DlmsProfile) object).getCaptureObjects() != null) {
 
             final DlmsProfile profile = (DlmsProfile) object;
-
-            if (protocol.isSelectValuesInSelectiveAccessSupported() && addressRequest.getDevice().isSelectiveAccessSupported()) {
-                objectDefinitions = this.getObjectDefinitions(addressRequest.getChannel(),
-                        addressRequest.getFilterMedium(), protocol, profile, selectedObjects);
-            } else {
-                // If selecting values is not supported, then all values are selected (and the objectDefinitions list
-                // should be empty)
-                selectedObjects.addAll(((DlmsProfile) object).getCaptureObjects());
-            }
+            objectDefinitions = this.getObjectDefinitions(addressRequest.getChannel(),
+                    addressRequest.getFilterMedium(), protocol, profile, selectedObjects);
         }
 
         return DataObject.newArrayData(objectDefinitions);
     }
 
     private List<DataObject> getObjectDefinitions(final Integer channel, final Medium filterMedium,
-            final Protocol protocol, final DlmsProfile profile, final List<DlmsCaptureObject> selectedObjects) {
+                                                  final Protocol protocol, final DlmsProfile profile, final List<DlmsCaptureObject> selectedObjects) {
         final List<DataObject> objectDefinitions = new ArrayList<>();
 
         for (final DlmsCaptureObject captureObject : profile.getCaptureObjects()) {

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/entities/Protocol.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/entities/Protocol.java
@@ -11,7 +11,7 @@ package org.opensmartgridplatform.adapter.protocol.dlms.domain.entities;
 public enum Protocol {
 
     DSMR_4_2_2("DSMR", "4.2.2", true),
-    SMR_5_0("SMR", "5.0", false),
+    SMR_5_0("SMR", "5.0", true),
     SMR_5_1("SMR", "5.1", true),
     OTHER_PROTOCOL("?","?", true);
 

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/entities/Protocol.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/entities/Protocol.java
@@ -12,7 +12,7 @@ public enum Protocol {
 
     DSMR_4_2_2("DSMR", "4.2.2", true),
     SMR_5_0("SMR", "5.0", false),
-    SMR_5_1("SMR", "5.1", false),
+    SMR_5_1("SMR", "5.1", true),
     OTHER_PROTOCOL("?","?", true);
 
     private final String name;

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/dlmsobjectconfig/DlmsObjectConfigServiceTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/dlmsobjectconfig/DlmsObjectConfigServiceTest.java
@@ -242,63 +242,6 @@ public class DlmsObjectConfigServiceTest {
         assertThat(attributeAddressForProfile.get().getSelectedObjects()).isEqualTo(this.captureObjectsCombined);
     }
 
-    //@Test
-    public void testProfileWithSelectiveAccessNotSupported() throws Exception {
-        // Filtering is not possible when selective access not supported, so all values will be returned.
-
-        // SETUP
-        final Integer channel = 1;
-        final Medium filterMedium = Medium.GAS;
-
-        // Selective access not supported
-        final SelectiveAccessDescription access = null;
-
-        final AttributeAddress expectedAddress = new AttributeAddress(this.profileCombined.getClassId(),
-                this.profileCombined.getObisCodeAsString(), this.profileCombined.getDefaultAttributeId(), access);
-
-        // CALL
-        final Optional<AttributeAddressForProfile> attributeAddressForProfile =
-                this.service.findAttributeAddressForProfile(
-                this.device422_noSelectiveAccess, DlmsObjectType.DAILY_LOAD_PROFILE, channel, this.from, this.to,
-                filterMedium);
-
-        // VERIFY
-        AttributeAddressAssert.is(attributeAddressForProfile.get().getAttributeAddress(), expectedAddress);
-
-        // All values should be returned.
-        assertThat(attributeAddressForProfile.get().getSelectedObjects()).isEqualTo(this.captureObjectsCombined);
-    }
-
-    //@Test
-    public void testProfileWithSelectingValuesNotSupported() throws Exception {
-        // Filtering is not possible when selecting values is not supported, so all values will be returned.
-
-        // SETUP
-        final Integer channel = 1;
-        final Medium filterMedium = Medium.GAS;
-
-        // Selecting values is not supported
-        final DataObject selectedValues = DataObject.newArrayData(Collections.emptyList());
-
-        final DataObject accessParams = this.getAccessParams(selectedValues);
-
-        final SelectiveAccessDescription access = new SelectiveAccessDescription(1, accessParams);
-
-        final AttributeAddress expectedAddress = new AttributeAddress(this.profileCombined.getClassId(),
-                this.profileCombined.getObisCodeAsString(), this.profileCombined.getDefaultAttributeId(), access);
-
-        // CALL
-        final Optional<AttributeAddressForProfile> attributeAddressForProfile =
-                this.service.findAttributeAddressForProfile(
-                this.device51, DlmsObjectType.DAILY_LOAD_PROFILE, channel, this.from, this.to, filterMedium);
-
-        // VERIFY
-        AttributeAddressAssert.is(attributeAddressForProfile.get().getAttributeAddress(), expectedAddress);
-
-        // All values should be returned.
-        assertThat(attributeAddressForProfile.get().getSelectedObjects()).isEqualTo(this.captureObjectsCombined);
-    }
-
     private ObisCode getObisCodeWithChannel(final String obisAsString, final Integer channel) {
         String obisWithChannel = obisAsString;
 

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/dlmsobjectconfig/DlmsObjectConfigServiceTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/dlmsobjectconfig/DlmsObjectConfigServiceTest.java
@@ -242,7 +242,7 @@ public class DlmsObjectConfigServiceTest {
         assertThat(attributeAddressForProfile.get().getSelectedObjects()).isEqualTo(this.captureObjectsCombined);
     }
 
-    @Test
+    //@Test
     public void testProfileWithSelectiveAccessNotSupported() throws Exception {
         // Filtering is not possible when selective access not supported, so all values will be returned.
 
@@ -269,7 +269,7 @@ public class DlmsObjectConfigServiceTest {
         assertThat(attributeAddressForProfile.get().getSelectedObjects()).isEqualTo(this.captureObjectsCombined);
     }
 
-    @Test
+    //@Test
     public void testProfileWithSelectingValuesNotSupported() throws Exception {
         // Filtering is not possible when selecting values is not supported, so all values will be returned.
 

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/entities/ProtocolTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/entities/ProtocolTest.java
@@ -52,8 +52,8 @@ public class ProtocolTest {
     @Test
     public void testIsSelectingValuesSupported() {
         assertThat(Protocol.DSMR_4_2_2.isSelectValuesInSelectiveAccessSupported()).isEqualTo(true);
-        assertThat(Protocol.SMR_5_0.isSelectValuesInSelectiveAccessSupported()).isEqualTo(false);
-        assertThat(Protocol.SMR_5_1.isSelectValuesInSelectiveAccessSupported()).isEqualTo(false);
+        assertThat(Protocol.SMR_5_0.isSelectValuesInSelectiveAccessSupported()).isEqualTo(true);
+        assertThat(Protocol.SMR_5_1.isSelectValuesInSelectiveAccessSupported()).isEqualTo(true);
         assertThat(Protocol.OTHER_PROTOCOL.isSelectValuesInSelectiveAccessSupported()).isEqualTo(true);
     }
 


### PR DESCRIPTION
Bij GetPeriodicMeterReads wordt een lege SelectiveAccessDescription teruggegeven als Selective Access niet wordt ondersteund in het device. Dit is niet de bedoeling en werkt bij FindEvents en GetProfileGenericData ook niet zo. 

Vervolgens wordt er in GetPeriodicMeterReads bij het checken van isSelectiveAccessSupported wederom afgeweken van de andere operaties. Er wordt namelijk gekeken of het protocol van het betreffende device selectValuesInSelectiveAccessSupported is. Maar als DSMR4.2.2 SelectiveAccess ondersteunt kan een device met dit protocol dit nog steeds niet doen. Maar daar kijkt de code nu niet naar, in tegenstelling tot de andere operaties.

Nadat ik dit heb aangepast krijg ik geen OTHER_REASON meer, maar een OBJECT_UNDEFINED voor GetPeriodicMeterReads SelectiveAccessSupported=false. Dit betekent: "Combination of classId, obisCode and attributeId does not exist".



Fix:
- Reverted selective access logic in DlmsObjectConfigService.java, introduced in https://github.com/OSGP/open-smart-grid-platform/pull/66/commits/6793fdd975ba8634696c78d496f6b5aead1d8cb7
- Disabled related unit tests testProfileWithSelectiveAccessNotSupported, introduced in https://github.com/OSGP/open-smart-grid-platform/commit/6793fdd975ba8634696c78d496f6b5aead1d8cb7#diff-19110bcf9805e2a1e51f30948ffb50d6