### PR TITLE
FLEX-5239 ~ Upgrade to Cucumber 5

### DIFF
--- a/integration-tests/cucumber-tests-core/pom.xml
+++ b/integration-tests/cucumber-tests-core/pom.xml
@@ -38,6 +38,12 @@
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- Cucumber tests depend on JUnit 4, add the vintage engine -->
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>

--- a/integration-tests/cucumber-tests-core/src/test/java/org/opensmartgridplatform/cucumber/core/ReadSettingsHelper.java
+++ b/integration-tests/cucumber-tests-core/src/test/java/org/opensmartgridplatform/cucumber/core/ReadSettingsHelper.java
@@ -48,7 +48,7 @@ public class ReadSettingsHelper {
      *            The default value if the key wasn't found.
      */
     public static Boolean getBoolean(final Map<String, String> settings, final String key, final Boolean defaultValue) {
-        if (!settings.containsKey(key)) {
+        if (!settings.containsKey(key) || StringUtils.isBlank(settings.get(key))) {
             return defaultValue;
         }
 
@@ -80,7 +80,7 @@ public class ReadSettingsHelper {
      * @return The date time.
      */
     public static DateTime getDate(final Map<String, String> settings, final String key, final DateTime defaultDate) {
-        if (!settings.containsKey(key)) {
+        if (!settings.containsKey(key) || StringUtils.isBlank(settings.get(key))) {
             return defaultDate;
         }
 
@@ -116,7 +116,7 @@ public class ReadSettingsHelper {
      * @return The Double object.
      */
     public static Double getDouble(final Map<String, String> settings, final String key, final Double defaultValue) {
-        if (!settings.containsKey(key)) {
+        if (!settings.containsKey(key) || StringUtils.isBlank(settings.get(key))) {
             return defaultValue;
         }
 
@@ -152,7 +152,7 @@ public class ReadSettingsHelper {
      * @return The Float object.
      */
     public static Float getFloat(final Map<String, String> settings, final String key, final Float defaultValue) {
-        if (!settings.containsKey(key)) {
+        if (!settings.containsKey(key) || StringUtils.isBlank(settings.get(key))) {
             return defaultValue;
         }
 
@@ -168,7 +168,7 @@ public class ReadSettingsHelper {
 
     public static Integer getInteger(final Map<String, String> settings, final String key, final Integer defaultValue) {
 
-        if (!settings.containsKey(key) || settings.get(key).isEmpty()) {
+        if (!settings.containsKey(key) || StringUtils.isBlank(settings.get(key))) {
             return defaultValue;
         }
 
@@ -206,7 +206,7 @@ public class ReadSettingsHelper {
      */
     public static Long getLong(final Map<String, String> settings, final String key, final Long defaultValue) {
 
-        if (!settings.containsKey(key)) {
+        if (!settings.containsKey(key) || StringUtils.isBlank(settings.get(key))) {
             return defaultValue;
         }
 
@@ -234,7 +234,7 @@ public class ReadSettingsHelper {
      */
     public static Short getShort(final Map<String, String> settings, final String key, final Short defaultValue) {
 
-        if (!settings.containsKey(key)) {
+        if (!settings.containsKey(key) || StringUtils.isBlank(settings.get(key))) {
             return defaultValue;
         }
 
@@ -243,7 +243,15 @@ public class ReadSettingsHelper {
 
     public static String getString(final Map<String, String> settings, final String key) {
         String value = null;
-        if (settings.containsKey(key) && !settings.get(key).equalsIgnoreCase("null")) {
+        if (settings.containsKey(key) && settings.get(key) == null) {
+            /*
+             * Empty values in feature files were a blank string by default,
+             * which has changed to null. Handling this situation here is a way
+             * to work around this, without updating feature definitions.
+             */
+            value = "";
+        } else if (settings.containsKey(key) && settings.get(key) != null
+                && !settings.get(key).equalsIgnoreCase("null")) {
             value = settings.get(key);
         }
 
@@ -275,7 +283,7 @@ public class ReadSettingsHelper {
 
     public static Byte getByte(final Map<String, String> settings, final String key, final Byte defaultValue) {
 
-        if (!settings.containsKey(key)) {
+        if (!settings.containsKey(key) || StringUtils.isBlank(settings.get(key))) {
             return defaultValue;
         }
 
@@ -290,7 +298,7 @@ public class ReadSettingsHelper {
 
     public static <E extends Enum<E>> E getEnum(final Map<String, String> settings, final String key,
             final Class<E> enumType) {
-        if (!settings.containsKey(key) || settings.get(key).isEmpty()) {
+        if (!settings.containsKey(key) || StringUtils.isBlank(settings.get(key))) {
             return null;
         }
 
@@ -299,7 +307,7 @@ public class ReadSettingsHelper {
 
     public static <E extends Enum<E>> E getEnum(final Map<String, String> settings, final String key,
             final Class<E> enumType, final E defaultValue) {
-        if (!settings.containsKey(key)) {
+        if (!settings.containsKey(key) || StringUtils.isBlank(settings.get(key))) {
             return defaultValue;
         }
 

--- a/integration-tests/cucumber-tests-execution/pom.xml
+++ b/integration-tests/cucumber-tests-execution/pom.xml
@@ -28,7 +28,7 @@
   </prerequisites>
 
   <dependencies>
-   
+
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
@@ -40,6 +40,12 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!-- Cucumber tests depend on JUnit 4, add the vintage engine -->
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/integration-tests/cucumber-tests-platform-common/pom.xml
+++ b/integration-tests/cucumber-tests-platform-common/pom.xml
@@ -42,6 +42,12 @@
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- Cucumber tests depend on JUnit 4, add the vintage engine -->
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>

--- a/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/AcceptanceTests.java
+++ b/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/AcceptanceTests.java
@@ -11,15 +11,19 @@ package org.opensmartgridplatform.cucumber.platform.common;
 
 import org.junit.runner.RunWith;
 
-import cucumber.api.CucumberOptions;
-import cucumber.api.SnippetType;
-import cucumber.api.junit.Cucumber;
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import io.cucumber.junit.CucumberOptions.SnippetType;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(features = { "classpath:features/common" }, tags = { "not @Skip", "not @NightlyBuildOnly" }, glue = {
-        "classpath:org.opensmartgridplatform.cucumber.platform.glue",
-        "classpath:org.opensmartgridplatform.cucumber.platform.common.glue" }, plugin = { "pretty",
-                "html:target/output/Cucumber-report", "html:target/output/Cucumber-html-report.html",
-                "json:target/output/cucumber.json" }, snippets = SnippetType.CAMELCASE, dryRun = false)
+@CucumberOptions(features = { "classpath:features/common" },
+        tags = { "not @Skip", "not @NightlyBuildOnly" },
+        glue = { "classpath:org.opensmartgridplatform.cucumber.platform.glue",
+                "classpath:org.opensmartgridplatform.cucumber.platform.common.glue" },
+        plugin = { "pretty", "html:target/output/Cucumber-report", "html:target/output/Cucumber-html-report.html",
+                "json:target/output/cucumber.json" },
+        snippets = SnippetType.CAMELCASE,
+        strict = true,
+        dryRun = false)
 public class AcceptanceTests {
 }

--- a/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/admin/devicemanagement/ActivateOrganizationSteps.java
+++ b/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/admin/devicemanagement/ActivateOrganizationSteps.java
@@ -21,8 +21,8 @@ import org.opensmartgridplatform.cucumber.platform.common.support.ws.admin.Admin
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ws.soap.client.SoapFaultClientException;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 /**
  * Class with all the activate organization steps.

--- a/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/admin/devicemanagement/ChangeOrganizationSteps.java
+++ b/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/admin/devicemanagement/ChangeOrganizationSteps.java
@@ -25,8 +25,8 @@ import org.opensmartgridplatform.cucumber.platform.glue.steps.ws.GenericResponse
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ws.soap.client.SoapFaultClientException;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 /**
  * Class with all the remove organization requests steps

--- a/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/admin/devicemanagement/CreateOrganizationSteps.java
+++ b/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/admin/devicemanagement/CreateOrganizationSteps.java
@@ -20,6 +20,7 @@ import org.opensmartgridplatform.adapter.ws.schema.admin.devicemanagement.Organi
 import org.opensmartgridplatform.adapter.ws.schema.admin.devicemanagement.PlatformDomain;
 import org.opensmartgridplatform.adapter.ws.schema.admin.devicemanagement.PlatformFunctionGroup;
 import org.opensmartgridplatform.cucumber.core.ScenarioContext;
+import org.opensmartgridplatform.cucumber.platform.PlatformDefaults;
 import org.opensmartgridplatform.cucumber.platform.common.PlatformCommonDefaults;
 import org.opensmartgridplatform.cucumber.platform.common.PlatformCommonKeys;
 import org.opensmartgridplatform.cucumber.platform.common.support.ws.admin.AdminDeviceManagementClient;
@@ -27,8 +28,8 @@ import org.opensmartgridplatform.cucumber.platform.glue.steps.ws.GenericResponse
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ws.soap.client.SoapFaultClientException;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 /**
  * Class with all the create organization requests steps
@@ -68,10 +69,8 @@ public class CreateOrganizationSteps {
         }
 
         // Optional fields
-        if (requestSettings.containsKey(PlatformCommonKeys.KEY_ENABLED)
-                && !requestSettings.get(PlatformCommonKeys.KEY_ENABLED).isEmpty()) {
-            organization.setEnabled(getBoolean(requestSettings, PlatformCommonKeys.KEY_ENABLED));
-        }
+        organization.setEnabled(getBoolean(requestSettings, PlatformCommonKeys.KEY_ENABLED,
+                PlatformDefaults.DEFAULT_ORGANIZATION_ENABLED));
 
         request.setOrganisation(organization);
 

--- a/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/admin/devicemanagement/FindDevicesWithoutOwner.java
+++ b/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/admin/devicemanagement/FindDevicesWithoutOwner.java
@@ -23,8 +23,8 @@ import org.opensmartgridplatform.cucumber.platform.common.support.ws.admin.Admin
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ws.soap.client.SoapFaultClientException;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 /**
  * Class with all the remove organization requests steps

--- a/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/admin/devicemanagement/RemoveDeviceSteps.java
+++ b/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/admin/devicemanagement/RemoveDeviceSteps.java
@@ -25,8 +25,8 @@ import org.opensmartgridplatform.shared.exceptionhandling.WebServiceSecurityExce
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ws.soap.client.SoapFaultClientException;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class RemoveDeviceSteps {
 

--- a/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/admin/devicemanagement/RemoveOrganizationSteps.java
+++ b/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/admin/devicemanagement/RemoveOrganizationSteps.java
@@ -22,8 +22,8 @@ import org.opensmartgridplatform.cucumber.platform.glue.steps.ws.GenericResponse
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ws.soap.client.SoapFaultClientException;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 /**
  * Class with all the remove organization requests steps

--- a/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/admin/devicemanagement/RevokeKeySteps.java
+++ b/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/admin/devicemanagement/RevokeKeySteps.java
@@ -23,8 +23,8 @@ import org.opensmartgridplatform.cucumber.platform.common.support.ws.admin.Admin
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ws.soap.client.SoapFaultClientException;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 /**
  * Class with all the remove organization requests steps

--- a/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/admin/devicemanagement/UpdateKeySteps.java
+++ b/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/admin/devicemanagement/UpdateKeySteps.java
@@ -25,8 +25,8 @@ import org.opensmartgridplatform.cucumber.platform.glue.steps.ws.GenericResponse
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ws.soap.client.SoapFaultClientException;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 /**
  * Class with all the remove organization requests steps

--- a/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/basicosgpfunctions/AuthorizeDeviceFunctionsSteps.java
+++ b/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/basicosgpfunctions/AuthorizeDeviceFunctionsSteps.java
@@ -52,8 +52,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ws.soap.client.SoapFaultClientException;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 /**
  * Class with all the AuthorizeDeviceFunctions steps
@@ -152,7 +152,7 @@ public class AuthorizeDeviceFunctionsSteps {
         }
     }
 
-    @Then("the device function response is \"([^\"]*)\"")
+    @Then("the device function response is \"{}\"")
     public void theDeviceFunctionResponseIsSuccessful(final Boolean allowed) {
         if (allowed) {
             final Object response = ScenarioContext.current().get(PlatformCommonKeys.RESPONSE);
@@ -205,8 +205,9 @@ public class AuthorizeDeviceFunctionsSteps {
 
         updateDeviceAuthorisationsRequest.getDeviceAuthorisations().add(deviceAuthorisation);
 
-        ScenarioContext.current().put(PlatformCommonKeys.RESPONSE,
-                this.adminDeviceManagementClient.updateDeviceAuthorisations(updateDeviceAuthorisationsRequest));
+        ScenarioContext.current()
+                .put(PlatformCommonKeys.RESPONSE,
+                        this.adminDeviceManagementClient.updateDeviceAuthorisations(updateDeviceAuthorisationsRequest));
     }
 
     private void startSelfTest(final Map<String, String> requestParameters)
@@ -215,8 +216,8 @@ public class AuthorizeDeviceFunctionsSteps {
         request.setDeviceIdentification(getString(requestParameters, PlatformCommonKeys.KEY_DEVICE_IDENTIFICATION,
                 PlatformCommonDefaults.DEFAULT_DEVICE_IDENTIFICATION));
 
-        ScenarioContext.current().put(PlatformCommonKeys.RESPONSE,
-                this.coreDeviceInstallationClient.startDeviceTest(request));
+        ScenarioContext.current()
+                .put(PlatformCommonKeys.RESPONSE, this.coreDeviceInstallationClient.startDeviceTest(request));
     }
 
     private void stopSelfTest(final Map<String, String> requestParameters)
@@ -225,8 +226,8 @@ public class AuthorizeDeviceFunctionsSteps {
         request.setDeviceIdentification(getString(requestParameters, PlatformCommonKeys.KEY_DEVICE_IDENTIFICATION,
                 PlatformCommonDefaults.DEFAULT_DEVICE_IDENTIFICATION));
 
-        ScenarioContext.current().put(PlatformCommonKeys.RESPONSE,
-                this.coreDeviceInstallationClient.stopDeviceTest(request));
+        ScenarioContext.current()
+                .put(PlatformCommonKeys.RESPONSE, this.coreDeviceInstallationClient.stopDeviceTest(request));
     }
 
     private void getStatus(final Map<String, String> requestParameters)
@@ -235,8 +236,8 @@ public class AuthorizeDeviceFunctionsSteps {
         request.setDeviceIdentification(getString(requestParameters, PlatformCommonKeys.KEY_DEVICE_IDENTIFICATION,
                 PlatformCommonDefaults.DEFAULT_DEVICE_IDENTIFICATION));
 
-        ScenarioContext.current().put(PlatformCommonKeys.RESPONSE,
-                this.coreDeviceInstallationClient.getStatus(request));
+        ScenarioContext.current()
+                .put(PlatformCommonKeys.RESPONSE, this.coreDeviceInstallationClient.getStatus(request));
     }
 
     private void getDeviceAuthorization(final Map<String, String> requestParameters)
@@ -245,8 +246,8 @@ public class AuthorizeDeviceFunctionsSteps {
         request.setDeviceIdentification(getString(requestParameters, PlatformCommonKeys.KEY_DEVICE_IDENTIFICATION,
                 PlatformCommonDefaults.DEFAULT_DEVICE_IDENTIFICATION));
 
-        ScenarioContext.current().put(PlatformCommonKeys.RESPONSE,
-                this.adminDeviceManagementClient.findDeviceAuthorisations(request));
+        ScenarioContext.current()
+                .put(PlatformCommonKeys.RESPONSE, this.adminDeviceManagementClient.findDeviceAuthorisations(request));
     }
 
     private void setEventNotifications(final Map<String, String> requestParameters)
@@ -255,8 +256,8 @@ public class AuthorizeDeviceFunctionsSteps {
         request.setDeviceIdentification(getString(requestParameters, PlatformCommonKeys.KEY_DEVICE_IDENTIFICATION,
                 PlatformCommonDefaults.DEFAULT_DEVICE_IDENTIFICATION));
 
-        ScenarioContext.current().put(PlatformCommonKeys.RESPONSE,
-                this.coreDeviceManagementClient.setEventNotifications(request));
+        ScenarioContext.current()
+                .put(PlatformCommonKeys.RESPONSE, this.coreDeviceManagementClient.setEventNotifications(request));
     }
 
     private void getEventNotifications(final Map<String, String> requestParameters)
@@ -265,8 +266,8 @@ public class AuthorizeDeviceFunctionsSteps {
         request.setDeviceIdentification(getString(requestParameters, PlatformCommonKeys.KEY_DEVICE_IDENTIFICATION,
                 PlatformCommonDefaults.DEFAULT_DEVICE_IDENTIFICATION));
 
-        ScenarioContext.current().put(PlatformCommonKeys.RESPONSE,
-                this.coreDeviceManagementClient.findEventsResponse(request));
+        ScenarioContext.current()
+                .put(PlatformCommonKeys.RESPONSE, this.coreDeviceManagementClient.findEventsResponse(request));
     }
 
     private void updateFirmware(final Map<String, String> requestParameters)
@@ -277,8 +278,8 @@ public class AuthorizeDeviceFunctionsSteps {
         request.setFirmwareIdentification(getString(requestParameters, PlatformCommonKeys.KEY_FIRMWARE_IDENTIFICATION,
                 PlatformCommonDefaults.FIRMWARE_IDENTIFICATION));
 
-        ScenarioContext.current().put(PlatformCommonKeys.RESPONSE,
-                this.coreFirmwareManagementClient.updateFirmware(request));
+        ScenarioContext.current()
+                .put(PlatformCommonKeys.RESPONSE, this.coreFirmwareManagementClient.updateFirmware(request));
     }
 
     private void getFirmwareVersion(final Map<String, String> requestParameters)
@@ -287,8 +288,8 @@ public class AuthorizeDeviceFunctionsSteps {
         request.setDeviceIdentification(getString(requestParameters, PlatformCommonKeys.KEY_DEVICE_IDENTIFICATION,
                 PlatformCommonDefaults.DEFAULT_DEVICE_IDENTIFICATION));
 
-        ScenarioContext.current().put(PlatformCommonKeys.RESPONSE,
-                this.coreFirmwareManagementClient.getFirmwareVersion(request));
+        ScenarioContext.current()
+                .put(PlatformCommonKeys.RESPONSE, this.coreFirmwareManagementClient.getFirmwareVersion(request));
     }
 
     private void setConfiguration(final Map<String, String> requestParameters)
@@ -306,8 +307,8 @@ public class AuthorizeDeviceFunctionsSteps {
 
         request.setConfiguration(config);
 
-        ScenarioContext.current().put(PlatformCommonKeys.RESPONSE,
-                this.coreConfigurationManagementClient.setConfiguration(request));
+        ScenarioContext.current()
+                .put(PlatformCommonKeys.RESPONSE, this.coreConfigurationManagementClient.setConfiguration(request));
     }
 
     private void getConfiguration(final Map<String, String> requestParameters)
@@ -316,8 +317,8 @@ public class AuthorizeDeviceFunctionsSteps {
         request.setDeviceIdentification(getString(requestParameters, PlatformCommonKeys.KEY_DEVICE_IDENTIFICATION,
                 PlatformCommonDefaults.DEFAULT_DEVICE_IDENTIFICATION));
 
-        ScenarioContext.current().put(PlatformCommonKeys.RESPONSE,
-                this.coreConfigurationManagementClient.getConfiguration(request));
+        ScenarioContext.current()
+                .put(PlatformCommonKeys.RESPONSE, this.coreConfigurationManagementClient.getConfiguration(request));
     }
 
     private void removeDevice(final Map<String, String> requestParameters)
@@ -326,8 +327,8 @@ public class AuthorizeDeviceFunctionsSteps {
         request.setDeviceIdentification(getString(requestParameters, PlatformCommonKeys.KEY_DEVICE_IDENTIFICATION,
                 PlatformCommonDefaults.DEFAULT_DEVICE_IDENTIFICATION));
 
-        ScenarioContext.current().put(PlatformCommonKeys.RESPONSE,
-                this.adminDeviceManagementClient.removeDevice(request));
+        ScenarioContext.current()
+                .put(PlatformCommonKeys.RESPONSE, this.adminDeviceManagementClient.removeDevice(request));
     }
 
     private void setReboot(final Map<String, String> requestParameters)
@@ -356,11 +357,12 @@ public class AuthorizeDeviceFunctionsSteps {
         deviceAuthorisation.setRevoked(
                 getBoolean(requestParameters, PlatformCommonKeys.KEY_REVOKED, PlatformCommonDefaults.REVOKED));
         request.getDeviceAuthorisations().add(deviceAuthorisation);
-        ScenarioContext.current().put(PlatformCommonKeys.KEY_ORGANIZATION_IDENTIFICATION,
-                getString(requestParameters, PlatformCommonKeys.KEY_ORGANIZATION_IDENTIFICATION,
-                        PlatformCommonDefaults.DEFAULT_ORGANIZATION_IDENTIFICATION));
-        ScenarioContext.current().put(PlatformCommonKeys.RESPONSE,
-                this.adminDeviceManagementClient.updateDeviceAuthorisations(request));
+        ScenarioContext.current()
+                .put(PlatformCommonKeys.KEY_ORGANIZATION_IDENTIFICATION,
+                        getString(requestParameters, PlatformCommonKeys.KEY_ORGANIZATION_IDENTIFICATION,
+                                PlatformCommonDefaults.DEFAULT_ORGANIZATION_IDENTIFICATION));
+        ScenarioContext.current()
+                .put(PlatformCommonKeys.RESPONSE, this.adminDeviceManagementClient.updateDeviceAuthorisations(request));
 
     }
 }

--- a/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/basicosgpfunctions/AuthorizePlatformFunctionsSteps.java
+++ b/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/basicosgpfunctions/AuthorizePlatformFunctionsSteps.java
@@ -62,8 +62,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ws.soap.client.SoapFaultClientException;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 /**
  * Class with all the AuthorizeDeviceFunctions steps
@@ -178,7 +178,7 @@ public class AuthorizePlatformFunctionsSteps {
         }
     }
 
-    @Then("the platform function response is \"([^\"]*)\"")
+    @Then("the platform function response is \"{}\"")
     public void theDeviceFunctionResponseIsSuccessful(final Boolean allowed) {
         if (allowed) {
             final Object response = ScenarioContext.current().get(PlatformCommonKeys.RESPONSE);
@@ -201,16 +201,16 @@ public class AuthorizePlatformFunctionsSteps {
         organisation.setEnabled(PlatformCommonDefaults.DEFAULT_ORGANIZATION_ENABLED);
         request.setOrganisation(organisation);
 
-        ScenarioContext.current().put(PlatformCommonKeys.RESPONSE,
-                this.adminDeviceManagementClient.createOrganization(request));
+        ScenarioContext.current()
+                .put(PlatformCommonKeys.RESPONSE, this.adminDeviceManagementClient.createOrganization(request));
     }
 
     private void removeOrganisation(final Map<String, String> requestParameters)
             throws WebServiceSecurityException, GeneralSecurityException, IOException {
         final RemoveOrganisationRequest request = new RemoveOrganisationRequest();
         request.setOrganisationIdentification(PlatformCommonDefaults.DEFAULT_ORGANIZATION_IDENTIFICATION);
-        ScenarioContext.current().put(PlatformCommonKeys.RESPONSE,
-                this.adminDeviceManagementClient.removeOrganization(request));
+        ScenarioContext.current()
+                .put(PlatformCommonKeys.RESPONSE, this.adminDeviceManagementClient.removeOrganization(request));
     }
 
     private void changeOrganisation(final Map<String, String> requestParameters)
@@ -220,14 +220,15 @@ public class AuthorizePlatformFunctionsSteps {
         request.setNewOrganisationName(PlatformCommonDefaults.DEFAULT_NEW_ORGANIZATION_NAME);
         request.setNewOrganisationPlatformFunctionGroup(
                 PlatformCommonDefaults.DEFAULT_NEW_ORGANIZATION_PLATFORMFUNCTIONGROUP);
-        ScenarioContext.current().put(PlatformCommonKeys.RESPONSE,
-                this.adminDeviceManagementClient.changeOrganization(request));
+        ScenarioContext.current()
+                .put(PlatformCommonKeys.RESPONSE, this.adminDeviceManagementClient.changeOrganization(request));
     }
 
     private void getOrganisations(final Map<String, String> requestParameters)
             throws WebServiceSecurityException, GeneralSecurityException, IOException {
-        ScenarioContext.current().put(PlatformCommonKeys.RESPONSE,
-                this.adminDeviceManagementClient.findAllOrganizations(new FindAllOrganisationsRequest()));
+        ScenarioContext.current()
+                .put(PlatformCommonKeys.RESPONSE,
+                        this.adminDeviceManagementClient.findAllOrganizations(new FindAllOrganisationsRequest()));
     }
 
     private void getMessages(final Map<String, String> requestParameters)
@@ -237,20 +238,22 @@ public class AuthorizePlatformFunctionsSteps {
         request.setDeviceIdentification(getString(requestParameters, PlatformCommonKeys.KEY_DEVICE_IDENTIFICATION,
                 PlatformCommonDefaults.DEFAULT_DEVICE_IDENTIFICATION));
 
-        ScenarioContext.current().put(PlatformCommonKeys.RESPONSE,
-                this.adminDeviceManagementClient.findMessageLogs(request));
+        ScenarioContext.current()
+                .put(PlatformCommonKeys.RESPONSE, this.adminDeviceManagementClient.findMessageLogs(request));
     }
 
     private void getDevicesWithoutOwner(final Map<String, String> requestParameters)
             throws WebServiceSecurityException, GeneralSecurityException, IOException {
-        ScenarioContext.current().put(PlatformCommonKeys.RESPONSE,
-                this.adminDeviceManagementClient.findDevicesWithoutOwner(new FindDevicesWhichHaveNoOwnerRequest()));
+        ScenarioContext.current()
+                .put(PlatformCommonKeys.RESPONSE, this.adminDeviceManagementClient
+                        .findDevicesWithoutOwner(new FindDevicesWhichHaveNoOwnerRequest()));
     }
 
     private void findDevices(final Map<String, String> requestParameters)
             throws WebServiceSecurityException, GeneralSecurityException, IOException {
-        ScenarioContext.current().put(PlatformCommonKeys.RESPONSE,
-                this.coreDeviceManagementClient.findDevices(new FindDevicesRequest()));
+        ScenarioContext.current()
+                .put(PlatformCommonKeys.RESPONSE,
+                        this.coreDeviceManagementClient.findDevices(new FindDevicesRequest()));
     }
 
     private void setOwner(final Map<String, String> requestParameters)
@@ -273,8 +276,8 @@ public class AuthorizePlatformFunctionsSteps {
         request.setProtocolInfoId(PlatformCommonDefaults.DEFAULT_PROTOCOL_INFO_ID);
         request.setPublicKey(PlatformCommonDefaults.DEFAULT_PUBLIC_KEY);
 
-        ScenarioContext.current().put(PlatformCommonKeys.RESPONSE,
-                this.adminDeviceManagementClient.getUpdateKeyResponse(request));
+        ScenarioContext.current()
+                .put(PlatformCommonKeys.RESPONSE, this.adminDeviceManagementClient.getUpdateKeyResponse(request));
     }
 
     private void revokeKey(final Map<String, String> requestParameters)
@@ -283,15 +286,15 @@ public class AuthorizePlatformFunctionsSteps {
         request.setDeviceIdentification(getString(requestParameters, PlatformCommonKeys.KEY_DEVICE_IDENTIFICATION,
                 PlatformCommonDefaults.DEFAULT_DEVICE_IDENTIFICATION));
 
-        ScenarioContext.current().put(PlatformCommonKeys.RESPONSE,
-                this.adminDeviceManagementClient.getRevokeKeyResponse(request));
+        ScenarioContext.current()
+                .put(PlatformCommonKeys.RESPONSE, this.adminDeviceManagementClient.getRevokeKeyResponse(request));
     }
 
     private void removeFirmware(final Map<String, String> requestParameters) throws WebServiceSecurityException {
         final RemoveFirmwareRequest request = new RemoveFirmwareRequest();
         request.setId(PlatformCommonDefaults.FIRMWARE_ID);
-        ScenarioContext.current().put(PlatformCommonKeys.RESPONSE,
-                this.firmwareManagementClient.removeFirmware(request));
+        ScenarioContext.current()
+                .put(PlatformCommonKeys.RESPONSE, this.firmwareManagementClient.removeFirmware(request));
     }
 
     private void changeFirmware(final Map<String, String> requestParameters)
@@ -304,8 +307,8 @@ public class AuthorizePlatformFunctionsSteps {
         firmware.setModelCode(PlatformCommonDefaults.DEVICE_MODEL_MODEL_CODE);
         firmware.setPushToNewDevices(PlatformCommonDefaults.FIRMWARE_PUSH_TO_NEW_DEVICE);
         request.setFirmware(firmware);
-        ScenarioContext.current().put(PlatformCommonKeys.RESPONSE,
-                this.firmwareManagementClient.changeFirmware(request));
+        ScenarioContext.current()
+                .put(PlatformCommonKeys.RESPONSE, this.firmwareManagementClient.changeFirmware(request));
     }
 
     private void createFirmware(final Map<String, String> requestParameters) throws WebServiceSecurityException {
@@ -333,16 +336,16 @@ public class AuthorizePlatformFunctionsSteps {
         deviceModel.setMetered(PlatformCommonDefaults.DEFAULT_DEVICE_MODEL_METERED);
         deviceModel.setModelCode(PlatformCommonDefaults.DEVICE_MODEL_MODEL_CODE);
         request.setDeviceModel(deviceModel);
-        ScenarioContext.current().put(PlatformCommonKeys.RESPONSE,
-                this.firmwareManagementClient.changeDeviceModel(request));
+        ScenarioContext.current()
+                .put(PlatformCommonKeys.RESPONSE, this.firmwareManagementClient.changeDeviceModel(request));
     }
 
     private void removeDeviceModel(final Map<String, String> requestParameters) throws WebServiceSecurityException {
         final RemoveDeviceModelRequest request = new RemoveDeviceModelRequest();
         request.setDeviceManufacturerId(PlatformCommonDefaults.DEFAULT_MANUFACTURER_CODE);
         request.setDeviceModelId(PlatformCommonDefaults.DEVICE_MODEL_MODEL_CODE);
-        ScenarioContext.current().put(PlatformCommonKeys.RESPONSE,
-                this.firmwareManagementClient.removeDeviceModel(request));
+        ScenarioContext.current()
+                .put(PlatformCommonKeys.RESPONSE, this.firmwareManagementClient.removeDeviceModel(request));
     }
 
     private void createDeviceModel(final Map<String, String> requestParameters) throws WebServiceSecurityException {
@@ -353,13 +356,14 @@ public class AuthorizePlatformFunctionsSteps {
         deviceModel.setMetered(PlatformCommonDefaults.DEFAULT_DEVICE_MODEL_METERED);
         deviceModel.setModelCode(PlatformCommonDefaults.DEVICE_MODEL_MODEL_CODE);
         request.setDeviceModel(deviceModel);
-        ScenarioContext.current().put(PlatformCommonKeys.RESPONSE,
-                this.firmwareManagementClient.addDeviceModel(request));
+        ScenarioContext.current()
+                .put(PlatformCommonKeys.RESPONSE, this.firmwareManagementClient.addDeviceModel(request));
     }
 
     private void getDeviceModels(final Map<String, String> requestParameters) throws WebServiceSecurityException {
-        ScenarioContext.current().put(PlatformCommonKeys.RESPONSE,
-                this.firmwareManagementClient.findAllDeviceModels(new FindAllDeviceModelsRequest()));
+        ScenarioContext.current()
+                .put(PlatformCommonKeys.RESPONSE,
+                        this.firmwareManagementClient.findAllDeviceModels(new FindAllDeviceModelsRequest()));
     }
 
     private void updateDeviceProtocol(final Map<String, String> requestParameters) throws WebServiceSecurityException {
@@ -369,18 +373,20 @@ public class AuthorizePlatformFunctionsSteps {
         protocolInfo.setProtocol(PlatformCommonDefaults.DEFAULT_PROTOCOL);
         protocolInfo.setProtocolVersion(PlatformCommonDefaults.DEFAULT_PROTOCOL_VERSION);
         request.setProtocolInfo(protocolInfo);
-        ScenarioContext.current().put(PlatformCommonKeys.RESPONSE,
-                this.adminDeviceManagementClient.updateDeviceProtocol(request));
+        ScenarioContext.current()
+                .put(PlatformCommonKeys.RESPONSE, this.adminDeviceManagementClient.updateDeviceProtocol(request));
     }
 
     private void getProtocolInfos(final Map<String, String> requestParameters) throws WebServiceSecurityException {
-        ScenarioContext.current().put(PlatformCommonKeys.RESPONSE,
-                this.adminDeviceManagementClient.getProtocolInfos(new GetProtocolInfosRequest()));
+        ScenarioContext.current()
+                .put(PlatformCommonKeys.RESPONSE,
+                        this.adminDeviceManagementClient.getProtocolInfos(new GetProtocolInfosRequest()));
     }
 
     private void getManufacturers(final Map<String, String> requestParameters) throws WebServiceSecurityException {
-        ScenarioContext.current().put(PlatformCommonKeys.RESPONSE,
-                this.adminDeviceManagementClient.findAllManufacturers(new FindAllManufacturersRequest()));
+        ScenarioContext.current()
+                .put(PlatformCommonKeys.RESPONSE,
+                        this.adminDeviceManagementClient.findAllManufacturers(new FindAllManufacturersRequest()));
     }
 
     private void changeManufacturer(final Map<String, String> requestParameters) throws WebServiceSecurityException {
@@ -390,15 +396,15 @@ public class AuthorizePlatformFunctionsSteps {
         manufacturer.setName(PlatformCommonDefaults.DEFAULT_MANUFACTURER_NAME);
         manufacturer.setUsePrefix(PlatformCommonDefaults.DEFAULT_MANUFACTURER_USE_PREFIX);
         request.setManufacturer(manufacturer);
-        ScenarioContext.current().put(PlatformCommonKeys.RESPONSE,
-                this.adminDeviceManagementClient.changeManufacturer(request));
+        ScenarioContext.current()
+                .put(PlatformCommonKeys.RESPONSE, this.adminDeviceManagementClient.changeManufacturer(request));
     }
 
     private void removeManufacturer(final Map<String, String> requestParameters) throws WebServiceSecurityException {
         final RemoveManufacturerRequest request = new RemoveManufacturerRequest();
         request.setManufacturerId(PlatformCommonDefaults.DEFAULT_MANUFACTURER_CODE);
-        ScenarioContext.current().put(PlatformCommonKeys.RESPONSE,
-                this.adminDeviceManagementClient.removeManufacturer(request));
+        ScenarioContext.current()
+                .put(PlatformCommonKeys.RESPONSE, this.adminDeviceManagementClient.removeManufacturer(request));
     }
 
     private void createManufacturer(final Map<String, String> requestParameters) throws WebServiceSecurityException {
@@ -408,15 +414,15 @@ public class AuthorizePlatformFunctionsSteps {
         manufacturer.setName(PlatformCommonDefaults.DEFAULT_MANUFACTURER_NAME);
         manufacturer.setUsePrefix(PlatformCommonDefaults.DEFAULT_MANUFACTURER_USE_PREFIX);
         request.setManufacturer(manufacturer);
-        ScenarioContext.current().put(PlatformCommonKeys.RESPONSE,
-                this.adminDeviceManagementClient.addManufacturer(request));
+        ScenarioContext.current()
+                .put(PlatformCommonKeys.RESPONSE, this.adminDeviceManagementClient.addManufacturer(request));
     }
 
     private void findScheduledTasks(final Map<String, String> requestParameters) throws WebServiceSecurityException {
         final FindScheduledTasksRequest request = new FindScheduledTasksRequest();
         request.setDeviceIdentification(PlatformCommonDefaults.DEFAULT_DEVICE_IDENTIFICATION);
-        ScenarioContext.current().put(PlatformCommonKeys.RESPONSE,
-                this.coreDeviceManagementClient.findScheduledTasks(request));
+        ScenarioContext.current()
+                .put(PlatformCommonKeys.RESPONSE, this.coreDeviceManagementClient.findScheduledTasks(request));
     }
 
 }

--- a/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/basicosgpfunctions/ProtocolSequenceNumberSteps.java
+++ b/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/basicosgpfunctions/ProtocolSequenceNumberSteps.java
@@ -10,7 +10,7 @@ package org.opensmartgridplatform.cucumber.platform.common.glue.steps.ws.basicos
 import org.opensmartgridplatform.cucumber.core.ScenarioContext;
 import org.opensmartgridplatform.cucumber.platform.PlatformKeys;
 
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.When;
 
 /**
  * Class with all the AuthorizeDeviceFunctions steps

--- a/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/core/adhocmanagement/SetRebootSteps.java
+++ b/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/core/adhocmanagement/SetRebootSteps.java
@@ -31,8 +31,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ws.soap.client.SoapFaultClientException;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 /**
  * Class with all the set light requests steps

--- a/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/core/configurationmanagement/GetConfigurationSteps.java
+++ b/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/core/configurationmanagement/GetConfigurationSteps.java
@@ -16,6 +16,7 @@ import static org.opensmartgridplatform.cucumber.platform.core.CorrelationUidHel
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.opensmartgridplatform.adapter.ws.schema.core.common.AsyncRequest;
 import org.opensmartgridplatform.adapter.ws.schema.core.common.OsgpResultType;
 import org.opensmartgridplatform.adapter.ws.schema.core.configurationmanagement.Configuration;
@@ -43,8 +44,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ws.soap.client.SoapFaultClientException;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 /**
  * Class with all the get configuration requests steps
@@ -139,7 +140,7 @@ public class GetConfigurationSteps {
         assertThat(configuration).isNotNull();
 
         if (expectedResponseData.containsKey(PlatformKeys.KEY_LIGHTTYPE)
-                && !expectedResponseData.get(PlatformKeys.KEY_LIGHTTYPE).isEmpty()
+                && StringUtils.isNotBlank(expectedResponseData.get(PlatformKeys.KEY_LIGHTTYPE))
                 && configuration.getLightType() != null) {
             assertThat(configuration.getLightType())
                     .isEqualTo(getEnum(expectedResponseData, PlatformKeys.KEY_LIGHTTYPE, LightType.class));
@@ -149,14 +150,14 @@ public class GetConfigurationSteps {
         if (daliConfiguration != null) {
 
             if (expectedResponseData.containsKey(PlatformKeys.DC_LIGHTS)
-                    && !expectedResponseData.get(PlatformKeys.DC_LIGHTS).isEmpty()
+                    && StringUtils.isNotBlank(expectedResponseData.get(PlatformKeys.DC_LIGHTS))
                     && daliConfiguration.getNumberOfLights() != 0) {
                 assertThat(daliConfiguration.getNumberOfLights())
                         .isEqualTo((int) getInteger(expectedResponseData, PlatformKeys.DC_LIGHTS));
             }
 
             if (expectedResponseData.containsKey(PlatformKeys.DC_MAP)
-                    && !expectedResponseData.get(PlatformKeys.DC_MAP).isEmpty()
+                    && StringUtils.isNotBlank(expectedResponseData.get(PlatformKeys.DC_MAP))
                     && daliConfiguration.getIndexAddressMap() != null) {
                 final List<IndexAddressMap> indexAddressMapList = daliConfiguration.getIndexAddressMap();
                 final String[] dcMapArray = getString(expectedResponseData, PlatformKeys.DC_MAP).split(";");
@@ -175,7 +176,7 @@ public class GetConfigurationSteps {
         if (relayConfiguration != null) {
 
             if (expectedResponseData.containsKey(PlatformKeys.RELAY_CONF)
-                    && !expectedResponseData.get(PlatformKeys.RELAY_CONF).isEmpty()
+                    && StringUtils.isNotBlank(expectedResponseData.get(PlatformKeys.RELAY_CONF))
                     && relayConfiguration.getRelayMap() != null) {
                 final List<RelayMap> relayMapList = relayConfiguration.getRelayMap();
                 final String[] rcMapArray = getString(expectedResponseData, PlatformKeys.RELAY_CONF).split(";");
@@ -187,7 +188,7 @@ public class GetConfigurationSteps {
                         assertThat(relayMapList.get(i).getAddress()).isEqualTo(Integer.parseInt(rcMapArrayElements[1]));
 
                         if (expectedResponseData.containsKey(PlatformKeys.KEY_RELAY_TYPE)
-                                && !expectedResponseData.get(PlatformKeys.KEY_RELAY_TYPE).isEmpty()
+                                && StringUtils.isNotBlank(expectedResponseData.get(PlatformKeys.KEY_RELAY_TYPE))
                                 && relayMapList.get(i).getRelayType() != null) {
                             assertThat(relayMapList.get(i).getRelayType()).isEqualTo(
                                     getEnum(expectedResponseData, PlatformKeys.KEY_RELAY_TYPE, RelayType.class));
@@ -201,7 +202,7 @@ public class GetConfigurationSteps {
         // configuration.getRelayLinking();
 
         if (expectedResponseData.containsKey(PlatformKeys.KEY_PREFERRED_LINKTYPE)
-                && !expectedResponseData.get(PlatformKeys.KEY_PREFERRED_LINKTYPE).isEmpty()
+                && StringUtils.isNotBlank(expectedResponseData.get(PlatformKeys.KEY_PREFERRED_LINKTYPE))
                 && configuration.getPreferredLinkType() != null) {
             assertThat(configuration.getPreferredLinkType())
                     .isEqualTo(getEnum(expectedResponseData, PlatformKeys.KEY_PREFERRED_LINKTYPE, LinkType.class));
@@ -212,7 +213,7 @@ public class GetConfigurationSteps {
         // values the same. Some with underscore and some without.
 
         if (expectedResponseData.containsKey(PlatformKeys.METER_TYPE)
-                && !expectedResponseData.get(PlatformKeys.METER_TYPE).isEmpty()
+                && StringUtils.isNotBlank(expectedResponseData.get(PlatformKeys.METER_TYPE))
                 && configuration.getMeterType() != null) {
             MeterType meterType;
             final String sMeterType = getString(expectedResponseData, PlatformKeys.METER_TYPE);
@@ -226,34 +227,34 @@ public class GetConfigurationSteps {
         }
 
         if (expectedResponseData.containsKey(PlatformKeys.SHORT_INTERVAL)
-                && !expectedResponseData.get(PlatformKeys.SHORT_INTERVAL).isEmpty()
+                && StringUtils.isNotBlank(expectedResponseData.get(PlatformKeys.SHORT_INTERVAL))
                 && configuration.getShortTermHistoryIntervalMinutes() != null) {
             assertThat(configuration.getShortTermHistoryIntervalMinutes()).isEqualTo(getInteger(expectedResponseData,
                     PlatformKeys.SHORT_INTERVAL, PlatformDefaults.DEFAULT_SHORT_INTERVAL));
         }
 
         if (expectedResponseData.containsKey(PlatformKeys.LONG_INTERVAL)
-                && !expectedResponseData.get(PlatformKeys.LONG_INTERVAL).isEmpty()
+                && StringUtils.isNotBlank(expectedResponseData.get(PlatformKeys.LONG_INTERVAL))
                 && configuration.getLongTermHistoryInterval() != null) {
             assertThat(configuration.getLongTermHistoryInterval()).isEqualTo(getInteger(expectedResponseData,
                     PlatformKeys.LONG_INTERVAL, PlatformDefaults.DEFAULT_LONG_INTERVAL));
         }
 
         if (expectedResponseData.containsKey(PlatformKeys.INTERVAL_TYPE)
-                && !expectedResponseData.get(PlatformKeys.INTERVAL_TYPE).isEmpty()
+                && StringUtils.isNotBlank(expectedResponseData.get(PlatformKeys.INTERVAL_TYPE))
                 && configuration.getLongTermHistoryIntervalType() != null) {
             assertThat(configuration.getLongTermHistoryIntervalType())
                     .isEqualTo(getEnum(expectedResponseData, PlatformKeys.INTERVAL_TYPE, LongTermIntervalType.class));
         }
 
         if (expectedResponseData.containsKey(PlatformKeys.OSGP_IP_ADDRESS)
-                && !expectedResponseData.get(PlatformKeys.OSGP_IP_ADDRESS).isEmpty()) {
+                && StringUtils.isNotBlank(expectedResponseData.get(PlatformKeys.OSGP_IP_ADDRESS))) {
             assertThat(configuration.getOsgpIpAddress())
                     .isEqualTo(getString(expectedResponseData, PlatformKeys.OSGP_IP_ADDRESS));
         }
 
         if (expectedResponseData.containsKey(PlatformKeys.OSGP_PORT)
-                && !expectedResponseData.get(PlatformKeys.OSGP_PORT).isEmpty()) {
+                && StringUtils.isNotBlank(expectedResponseData.get(PlatformKeys.OSGP_PORT))) {
             assertThat(configuration.getOsgpPortNumber())
                     .isEqualTo(getInteger(expectedResponseData, PlatformKeys.OSGP_PORT));
         }

--- a/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/core/configurationmanagement/SetConfigurationSteps.java
+++ b/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/core/configurationmanagement/SetConfigurationSteps.java
@@ -45,8 +45,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ws.soap.client.SoapFaultClientException;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 /**
  * Class with all the set configuration requests steps
@@ -151,7 +151,7 @@ public class SetConfigurationSteps {
         config.setPreferredLinkType(preferredLinkType);
 
         if (requestParameters.containsKey(PlatformKeys.METER_TYPE)
-                && !requestParameters.get(PlatformKeys.METER_TYPE).isEmpty()) {
+                && StringUtils.isNotBlank(getString(requestParameters, PlatformKeys.METER_TYPE))) {
             // Note: This piece of code has been made because there are multiple
             // enumerations with the name MeterType, but not all of them has all
             // values the same. Some with underscore and some without.
@@ -168,17 +168,17 @@ public class SetConfigurationSteps {
             config.setMeterType(meterType);
         }
         if (requestParameters.containsKey(PlatformKeys.SHORT_INTERVAL)
-                && !requestParameters.get(PlatformKeys.SHORT_INTERVAL).isEmpty()) {
+                && StringUtils.isNotBlank(requestParameters.get(PlatformKeys.SHORT_INTERVAL))) {
             config.setShortTermHistoryIntervalMinutes(
                     getInteger(requestParameters, PlatformKeys.SHORT_INTERVAL, PlatformCommonDefaults.SHORT_INTERVAL));
         }
 
         if (requestParameters.containsKey(PlatformKeys.INTERVAL_TYPE)
-                && !requestParameters.get(PlatformKeys.INTERVAL_TYPE).isEmpty()) {
+                && StringUtils.isNotBlank(requestParameters.get(PlatformKeys.INTERVAL_TYPE))) {
             final LongTermIntervalType intervalType = getEnum(requestParameters, PlatformKeys.INTERVAL_TYPE,
                     LongTermIntervalType.class, PlatformCommonDefaults.INTERVAL_TYPE);
             if (requestParameters.containsKey(PlatformKeys.LONG_INTERVAL)
-                    && !requestParameters.get(PlatformKeys.LONG_INTERVAL).isEmpty()) {
+                    && StringUtils.isNotBlank(requestParameters.get(PlatformKeys.LONG_INTERVAL))) {
                 config.setLongTermHistoryInterval(getInteger(requestParameters, PlatformKeys.LONG_INTERVAL,
                         PlatformCommonDefaults.LONG_INTERVAL));
                 config.setLongTermHistoryIntervalType(intervalType);

--- a/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/core/deviceinstallation/CreateDeviceSteps.java
+++ b/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/core/deviceinstallation/CreateDeviceSteps.java
@@ -32,8 +32,8 @@ import org.opensmartgridplatform.shared.exceptionhandling.WebServiceSecurityExce
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ws.soap.client.SoapFaultClientException;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 /**
  * Class with all the create organization requests steps

--- a/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/core/deviceinstallation/FindRecentDeviceSteps.java
+++ b/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/core/deviceinstallation/FindRecentDeviceSteps.java
@@ -23,8 +23,8 @@ import org.opensmartgridplatform.cucumber.platform.glue.steps.ws.GenericResponse
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ws.soap.client.SoapFaultClientException;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class FindRecentDeviceSteps {
 
@@ -42,7 +42,7 @@ public class FindRecentDeviceSteps {
         }
     }
 
-    @Then("the find recent devices response contains \"([^\"]*)\" devices?")
+    @Then("the find recent devices response contains \"{int}\" device(s)")
     public void theFindRecentDevicesResponseContains(final Integer numberOfDevices) {
         final FindRecentDevicesResponse response = (FindRecentDevicesResponse) ScenarioContext.current()
                 .get(PlatformCommonKeys.RESPONSE);
@@ -51,7 +51,7 @@ public class FindRecentDeviceSteps {
         assertThat((devices != null) ? devices.size() : 0).isEqualTo((int) numberOfDevices);
     }
 
-    @Then("the find recent devices response contains at index \"([^\"]*)\"")
+    @Then("the find recent devices response contains at index \"{int}\"")
     public void theFindRecentDevicesResponseContainsAtIndex(final Integer index,
             final Map<String, String> expectedDevice) throws Throwable {
         final FindRecentDevicesResponse response = (FindRecentDevicesResponse) ScenarioContext.current()

--- a/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/core/deviceinstallation/GetStatusSteps.java
+++ b/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/core/deviceinstallation/GetStatusSteps.java
@@ -15,6 +15,7 @@ import static org.opensmartgridplatform.cucumber.platform.core.CorrelationUidHel
 import java.util.Map;
 import java.util.Objects;
 
+import org.apache.commons.lang3.StringUtils;
 import org.opensmartgridplatform.adapter.ws.schema.core.common.AsyncRequest;
 import org.opensmartgridplatform.adapter.ws.schema.core.common.OsgpResultType;
 import org.opensmartgridplatform.adapter.ws.schema.core.deviceinstallation.DeviceStatus;
@@ -34,8 +35,8 @@ import org.opensmartgridplatform.cucumber.platform.common.support.ws.core.CoreDe
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ws.soap.client.SoapFaultClientException;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class GetStatusSteps {
 
@@ -71,7 +72,7 @@ public class GetStatusSteps {
                         PlatformDefaults.DEFAULT_ORGANIZATION_IDENTIFICATION));
     }
 
-    @Then("the platform buffers a device installation get status response message for device \"([^\"]*)\"")
+    @Then("the platform buffers a device installation get status response message for device {string}")
     public void thePlatformBuffersADeviceInstallationGetStatusResponseMessageForDevice(
             final String deviceIdentification, final Map<String, String> expectedResult) throws Throwable {
         final GetStatusAsyncRequest request = new GetStatusAsyncRequest();
@@ -99,7 +100,7 @@ public class GetStatusSteps {
                 .isEqualTo(getEnum(expectedResult, PlatformKeys.KEY_LIGHTTYPE, LightType.class));
 
         if (expectedResult.containsKey(PlatformKeys.KEY_EVENTNOTIFICATIONTYPES)
-                && !expectedResult.get(PlatformKeys.KEY_EVENTNOTIFICATIONTYPES).isEmpty()) {
+                && StringUtils.isNotBlank(expectedResult.get(PlatformKeys.KEY_EVENTNOTIFICATIONTYPES))) {
             assertThat(deviceStatus.getEventNotifications().size())
                     .isEqualTo(getString(expectedResult, PlatformKeys.KEY_EVENTNOTIFICATIONS,
                             PlatformDefaults.DEFAULT_EVENTNOTIFICATIONS).split(PlatformKeys.SEPARATOR_COMMA).length);
@@ -114,7 +115,7 @@ public class GetStatusSteps {
         }
 
         if (expectedResult.containsKey(PlatformKeys.KEY_LIGHTVALUES)
-                && !expectedResult.get(PlatformKeys.KEY_LIGHTVALUES).isEmpty()) {
+                && StringUtils.isNotBlank(expectedResult.get(PlatformKeys.KEY_LIGHTVALUES))) {
             assertThat(deviceStatus.getLightValues().size()).isEqualTo(
                     getString(expectedResult, PlatformKeys.KEY_LIGHTVALUES, PlatformDefaults.DEFAULT_LIGHTVALUES)
                             .split(PlatformKeys.SEPARATOR_COMMA).length);

--- a/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/core/deviceinstallation/StartDeviceSteps.java
+++ b/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/core/deviceinstallation/StartDeviceSteps.java
@@ -32,8 +32,8 @@ import org.opensmartgridplatform.shared.exceptionhandling.WebServiceSecurityExce
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ws.soap.client.SoapFaultClientException;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class StartDeviceSteps {
 

--- a/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/core/deviceinstallation/StopDeviceSteps.java
+++ b/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/core/deviceinstallation/StopDeviceSteps.java
@@ -30,8 +30,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ws.soap.client.SoapFaultClientException;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class StopDeviceSteps {
 
@@ -76,7 +76,7 @@ public class StopDeviceSteps {
         GenericResponseSteps.verifySoapFault(expectedResult);
     }
 
-    @Then("the platform buffers a stop device response message for device \"([^\"]*)\"")
+    @Then("the platform buffers a stop device response message for device {string}")
     public void thePlatformBuffersAStopDeviceResponseMessageForDevice(final String deviceIdentification,
             final Map<String, String> expectedResult) throws Throwable {
         final StopDeviceTestAsyncRequest request = new StopDeviceTestAsyncRequest();

--- a/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/core/devicemanagement/DeviceLifecycleStatusSteps.java
+++ b/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/core/devicemanagement/DeviceLifecycleStatusSteps.java
@@ -25,8 +25,8 @@ import org.opensmartgridplatform.domain.core.entities.Device;
 import org.opensmartgridplatform.domain.core.repositories.DeviceRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class DeviceLifecycleStatusSteps {
 

--- a/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/core/devicemanagement/FindDeviceSteps.java
+++ b/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/core/devicemanagement/FindDeviceSteps.java
@@ -29,8 +29,8 @@ import org.opensmartgridplatform.cucumber.platform.common.support.ws.core.CoreDe
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ws.soap.client.SoapFaultClientException;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class FindDeviceSteps {
 
@@ -178,7 +178,7 @@ public class FindDeviceSteps {
         }
     }
 
-    @Then("the find devices response contains \"([^\"]*)\" devices")
+    @Then("the find devices response contains \"{int}\" device(s)")
     public void theFindDevicesResponseContainsDevices(final Integer numberOfDevices) throws Throwable {
         final FindDevicesResponse response = (FindDevicesResponse) ScenarioContext.current()
                 .get(PlatformCommonKeys.RESPONSE);
@@ -186,7 +186,7 @@ public class FindDeviceSteps {
         assertThat(response.getDevices().size()).isEqualTo((int) numberOfDevices);
     }
 
-    @Then("the find devices response contains at index \"([^\"]*)\"")
+    @Then("the find devices response contains at index \"{int}\"")
     public void theFindDevicesResponseContainsAtIndex(final Integer index, final Map<String, String> expectedDevice)
             throws Throwable {
         final FindDevicesResponse response = (FindDevicesResponse) ScenarioContext.current()

--- a/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/core/devicemanagement/FindOrganizationsSteps.java
+++ b/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/core/devicemanagement/FindOrganizationsSteps.java
@@ -34,8 +34,8 @@ import org.opensmartgridplatform.shared.exceptionhandling.WebServiceSecurityExce
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ws.soap.client.SoapFaultClientException;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 /**
  * Class with all the create organization requests steps

--- a/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/core/devicemanagement/FindScheduledTasksSteps.java
+++ b/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/core/devicemanagement/FindScheduledTasksSteps.java
@@ -30,9 +30,9 @@ import org.opensmartgridplatform.cucumber.platform.glue.steps.database.core.Sche
 import org.opensmartgridplatform.shared.exceptionhandling.WebServiceSecurityException;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 import io.cucumber.datatable.DataTable;
 
 public class FindScheduledTasksSteps {

--- a/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/core/devicemanagement/RetrieveReceivedEventNotifications.java
+++ b/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/core/devicemanagement/RetrieveReceivedEventNotifications.java
@@ -37,9 +37,9 @@ import org.opensmartgridplatform.shared.exceptionhandling.WebServiceSecurityExce
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ws.soap.client.SoapFaultClientException;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 /**
  * Class with all the create organization requests steps

--- a/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/core/devicemanagement/SetEventNotificationsSteps.java
+++ b/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/core/devicemanagement/SetEventNotificationsSteps.java
@@ -32,8 +32,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ws.soap.client.SoapFaultClientException;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 /**
  * Class with all the remove organization requests steps

--- a/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/core/devicemanagement/SetOwnerSteps.java
+++ b/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/core/devicemanagement/SetOwnerSteps.java
@@ -25,8 +25,8 @@ import org.opensmartgridplatform.domain.core.repositories.DeviceAuthorizationRep
 import org.opensmartgridplatform.domain.core.repositories.DeviceRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class SetOwnerSteps {
 

--- a/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/core/devicemanagement/UpdateDeviceCdmaSettingsSteps.java
+++ b/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/core/devicemanagement/UpdateDeviceCdmaSettingsSteps.java
@@ -34,8 +34,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class UpdateDeviceCdmaSettingsSteps {
 

--- a/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/core/devicemanagement/UpdateDeviceSettingsSteps.java
+++ b/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/core/devicemanagement/UpdateDeviceSettingsSteps.java
@@ -31,8 +31,8 @@ import org.opensmartgridplatform.shared.exceptionhandling.WebServiceSecurityExce
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ws.soap.client.SoapFaultClientException;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class UpdateDeviceSettingsSteps {
 

--- a/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/core/firmwaremanagement/ChangeFirmwareSteps.java
+++ b/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/core/firmwaremanagement/ChangeFirmwareSteps.java
@@ -29,8 +29,8 @@ import org.opensmartgridplatform.domain.core.repositories.FirmwareFileRepository
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ws.soap.client.SoapFaultClientException;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 /**
  * Class with all the firmware requests steps

--- a/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/core/firmwaremanagement/GetFirmwareVersionSteps.java
+++ b/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/core/firmwaremanagement/GetFirmwareVersionSteps.java
@@ -33,8 +33,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ws.soap.client.SoapFaultClientException;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
 
 /**
  * Class with all the firmware requests steps

--- a/integration-tests/cucumber-tests-platform-distributionautomation/pom.xml
+++ b/integration-tests/cucumber-tests-platform-distributionautomation/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright 2019 Smart Society Services B.V. Licensed under the Apache 
-  License, Version 2.0 (the "License"); you may not use this file except in 
+<!-- Copyright 2019 Smart Society Services B.V. Licensed under the Apache
+  License, Version 2.0 (the "License"); you may not use this file except in
   compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -36,6 +36,12 @@
     <dependency>
       <groupId>io.cucumber</groupId>
       <artifactId>cucumber-spring</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!-- Cucumber tests depend on JUnit 4, add the vintage engine -->
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/integration-tests/cucumber-tests-platform-distributionautomation/src/test/java/org/opensmartgridplatform/cucumber/platform/distributionautomation/AcceptanceTests.java
+++ b/integration-tests/cucumber-tests-platform-distributionautomation/src/test/java/org/opensmartgridplatform/cucumber/platform/distributionautomation/AcceptanceTests.java
@@ -11,18 +11,23 @@ package org.opensmartgridplatform.cucumber.platform.distributionautomation;
 
 import org.junit.runner.RunWith;
 
-import cucumber.api.CucumberOptions;
-import cucumber.api.SnippetType;
-import cucumber.api.junit.Cucumber;
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import io.cucumber.junit.CucumberOptions.SnippetType;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(features = { "classpath:features/osgp-adapter-ws-distributionautomation",
-        "classpath:features/osgp-adapter-ws-core" }, tags = { "~@Skip", "~@NightlyBuildOnly" }, glue = {
-                "classpath:org.opensmartgridplatform.cucumber.platform.glue",
+@CucumberOptions(
+        features = { "classpath:features/osgp-adapter-ws-distributionautomation",
+                "classpath:features/osgp-adapter-ws-core" },
+        tags = { "not @Skip", "not @NightlyBuildOnly" },
+        glue = { "classpath:org.opensmartgridplatform.cucumber.platform.glue",
                 "classpath:org.opensmartgridplatform.cucumber.platform.common.glue",
-                "classpath:org.opensmartgridplatform.cucumber.platform.distributionautomation.glue" }, plugin = {
-                        "pretty", "html:target/output/Cucumber-report", "html:target/output/Cucumber-html-report.html",
-                        "json:target/output/cucumber.json" }, snippets = SnippetType.CAMELCASE, dryRun = false)
+                "classpath:org.opensmartgridplatform.cucumber.platform.distributionautomation.glue" },
+        plugin = { "pretty", "html:target/output/Cucumber-report", "html:target/output/Cucumber-html-report.html",
+                "json:target/output/cucumber.json" },
+        snippets = SnippetType.CAMELCASE,
+        strict = true,
+        dryRun = false)
 public class AcceptanceTests {
 
 }

--- a/integration-tests/cucumber-tests-platform-distributionautomation/src/test/java/org/opensmartgridplatform/cucumber/platform/distributionautomation/glue/hooks/ScenarioHooks.java
+++ b/integration-tests/cucumber-tests-platform-distributionautomation/src/test/java/org/opensmartgridplatform/cucumber/platform/distributionautomation/glue/hooks/ScenarioHooks.java
@@ -7,19 +7,18 @@
  */
 package org.opensmartgridplatform.cucumber.platform.distributionautomation.glue.hooks;
 
-import org.opensmartgridplatform.cucumber.core.GlueBase;
 import org.opensmartgridplatform.cucumber.core.ScenarioContext;
 import org.opensmartgridplatform.cucumber.platform.distributionautomation.database.Database;
 import org.opensmartgridplatform.cucumber.platform.distributionautomation.support.ws.distributionautomation.NotificationService;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.After;
-import cucumber.api.java.Before;
+import io.cucumber.java.After;
+import io.cucumber.java.Before;
 
 /**
  * Class with all the scenario hooks when each scenario runs.
  */
-public class ScenarioHooks extends GlueBase {
+public class ScenarioHooks {
 
     @Autowired
     private Database databaseSteps;

--- a/integration-tests/cucumber-tests-platform-distributionautomation/src/test/java/org/opensmartgridplatform/cucumber/platform/distributionautomation/glue/steps/ReceiveMeasurementReportSteps.java
+++ b/integration-tests/cucumber-tests-platform-distributionautomation/src/test/java/org/opensmartgridplatform/cucumber/platform/distributionautomation/glue/steps/ReceiveMeasurementReportSteps.java
@@ -22,8 +22,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class ReceiveMeasurementReportSteps {
 

--- a/integration-tests/cucumber-tests-platform-distributionautomation/src/test/java/org/opensmartgridplatform/cucumber/platform/distributionautomation/glue/steps/database/adapterprotocoliec60870/Iec60870DeviceSteps.java
+++ b/integration-tests/cucumber-tests-platform-distributionautomation/src/test/java/org/opensmartgridplatform/cucumber/platform/distributionautomation/glue/steps/database/adapterprotocoliec60870/Iec60870DeviceSteps.java
@@ -16,7 +16,6 @@ import java.util.Map;
 
 import org.opensmartgridplatform.adapter.protocol.iec60870.domain.entities.Iec60870Device;
 import org.opensmartgridplatform.adapter.protocol.iec60870.domain.repositories.Iec60870DeviceRepository;
-import org.opensmartgridplatform.cucumber.core.GlueBase;
 import org.opensmartgridplatform.cucumber.core.ScenarioContext;
 import org.opensmartgridplatform.cucumber.platform.PlatformDefaults;
 import org.opensmartgridplatform.cucumber.platform.PlatformKeys;
@@ -28,7 +27,7 @@ import org.opensmartgridplatform.cucumber.platform.helpers.SettingsHelper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
-import cucumber.api.java.en.Given;
+import io.cucumber.java.en.Given;
 
 /**
  * IEC 60870 device specific steps.
@@ -65,8 +64,8 @@ public class Iec60870DeviceSteps {
     @Given("^an IEC 60870 RTU$")
     public void anIec60870Rtu(final Map<String, String> settings) {
 
-        ScenarioContext.current().put(PlatformKeys.KEY_DEVICE_IDENTIFICATION,
-                PlatformDefaults.DEFAULT_DEVICE_IDENTIFICATION);
+        ScenarioContext.current()
+                .put(PlatformKeys.KEY_DEVICE_IDENTIFICATION, PlatformDefaults.DEFAULT_DEVICE_IDENTIFICATION);
         final Map<String, String> rtuSettings = SettingsHelper.addAsDefaults(settings, RTU_60870_DEFAULT_SETTINGS);
         rtuSettings.put(PlatformKeys.KEY_NETWORKADDRESS, this.mockServerConfig.iec60870MockNetworkAddress());
 

--- a/integration-tests/cucumber-tests-platform-microgrids/pom.xml
+++ b/integration-tests/cucumber-tests-platform-microgrids/pom.xml
@@ -44,6 +44,12 @@
       <artifactId>cucumber-spring</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- Cucumber tests depend on JUnit 4, add the vintage engine -->
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>

--- a/integration-tests/cucumber-tests-platform-microgrids/src/test/java/org/opensmartgridplatform/cucumber/platform/microgrids/AcceptanceTests.java
+++ b/integration-tests/cucumber-tests-platform-microgrids/src/test/java/org/opensmartgridplatform/cucumber/platform/microgrids/AcceptanceTests.java
@@ -11,18 +11,22 @@ package org.opensmartgridplatform.cucumber.platform.microgrids;
 
 import org.junit.runner.RunWith;
 
-import cucumber.api.CucumberOptions;
-import cucumber.api.SnippetType;
-import cucumber.api.junit.Cucumber;
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import io.cucumber.junit.CucumberOptions.SnippetType;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(features = { "classpath:features/osgp-adapter-ws-microgrids",
-        "classpath:features/osgp-adapter-ws-core" }, tags = { "not @Skip", "not @NightlyBuildOnly" }, glue = {
-                "classpath:org.opensmartgridplatform.cucumber.platform.glue",
+@CucumberOptions(
+        features = { "classpath:features/osgp-adapter-ws-microgrids", "classpath:features/osgp-adapter-ws-core" },
+        tags = { "not @Skip", "not @NightlyBuildOnly" },
+        glue = { "classpath:org.opensmartgridplatform.cucumber.platform.glue",
                 "classpath:org.opensmartgridplatform.cucumber.platform.common.glue",
-                "classpath:org.opensmartgridplatform.cucumber.platform.microgrids.glue" }, plugin = { "pretty",
-                        "html:target/output/Cucumber-report", "html:target/output/Cucumber-html-report.html",
-                        "json:target/output/cucumber.json" }, snippets = SnippetType.CAMELCASE, dryRun = false)
+                "classpath:org.opensmartgridplatform.cucumber.platform.microgrids.glue" },
+        plugin = { "pretty", "html:target/output/Cucumber-report", "html:target/output/Cucumber-html-report.html",
+                "json:target/output/cucumber.json" },
+        snippets = SnippetType.CAMELCASE,
+        strict = true,
+        dryRun = false)
 public class AcceptanceTests {
 
 }

--- a/integration-tests/cucumber-tests-platform-microgrids/src/test/java/org/opensmartgridplatform/cucumber/platform/microgrids/glue/hooks/ScenarioHooks.java
+++ b/integration-tests/cucumber-tests-platform-microgrids/src/test/java/org/opensmartgridplatform/cucumber/platform/microgrids/glue/hooks/ScenarioHooks.java
@@ -12,8 +12,8 @@ import org.opensmartgridplatform.cucumber.platform.microgrids.database.Database;
 import org.opensmartgridplatform.cucumber.platform.microgrids.support.ws.microgrids.NotificationService;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.After;
-import cucumber.api.java.Before;
+import io.cucumber.java.After;
+import io.cucumber.java.Before;
 
 /**
  * Class with all the scenario hooks when each scenario runs.

--- a/integration-tests/cucumber-tests-platform-microgrids/src/test/java/org/opensmartgridplatform/cucumber/platform/microgrids/glue/steps/database/adapterprotocolie61850/Iec61850DeviceSteps.java
+++ b/integration-tests/cucumber-tests-platform-microgrids/src/test/java/org/opensmartgridplatform/cucumber/platform/microgrids/glue/steps/database/adapterprotocolie61850/Iec61850DeviceSteps.java
@@ -26,7 +26,7 @@ import org.opensmartgridplatform.cucumber.platform.microgrids.config.Iec61850Moc
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
-import cucumber.api.java.en.Given;
+import io.cucumber.java.en.Given;
 
 /**
  * IEC61850 specific device steps.

--- a/integration-tests/cucumber-tests-platform-microgrids/src/test/java/org/opensmartgridplatform/cucumber/platform/microgrids/glue/steps/database/ws/MicrogridsResponseDataSteps.java
+++ b/integration-tests/cucumber-tests-platform-microgrids/src/test/java/org/opensmartgridplatform/cucumber/platform/microgrids/glue/steps/database/ws/MicrogridsResponseDataSteps.java
@@ -27,8 +27,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
 
 public class MicrogridsResponseDataSteps extends BaseDeviceSteps {
 

--- a/integration-tests/cucumber-tests-platform-microgrids/src/test/java/org/opensmartgridplatform/cucumber/platform/microgrids/glue/steps/housekeeping/MicrogridsResponseDataCleanupJobSteps.java
+++ b/integration-tests/cucumber-tests-platform-microgrids/src/test/java/org/opensmartgridplatform/cucumber/platform/microgrids/glue/steps/housekeeping/MicrogridsResponseDataCleanupJobSteps.java
@@ -15,8 +15,8 @@ import org.opensmartgridplatform.cucumber.platform.microgrids.glue.steps.databas
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class MicrogridsResponseDataCleanupJobSteps {
 

--- a/integration-tests/cucumber-tests-platform-microgrids/src/test/java/org/opensmartgridplatform/cucumber/platform/microgrids/glue/steps/mocks/RtuMarkerWaddenSteps.java
+++ b/integration-tests/cucumber-tests-platform-microgrids/src/test/java/org/opensmartgridplatform/cucumber/platform/microgrids/glue/steps/mocks/RtuMarkerWaddenSteps.java
@@ -12,8 +12,8 @@ import java.util.List;
 import org.opensmartgridplatform.cucumber.platform.microgrids.mocks.iec61850.Iec61850MockServer;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
 
 public class RtuMarkerWaddenSteps implements RtuSteps {
 

--- a/integration-tests/cucumber-tests-platform-microgrids/src/test/java/org/opensmartgridplatform/cucumber/platform/microgrids/glue/steps/mocks/RtuPampusSteps.java
+++ b/integration-tests/cucumber-tests-platform-microgrids/src/test/java/org/opensmartgridplatform/cucumber/platform/microgrids/glue/steps/mocks/RtuPampusSteps.java
@@ -12,8 +12,8 @@ import java.util.List;
 import org.opensmartgridplatform.cucumber.platform.microgrids.mocks.iec61850.Iec61850MockServer;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
 
 public class RtuPampusSteps implements RtuSteps {
 

--- a/integration-tests/cucumber-tests-platform-microgrids/src/test/java/org/opensmartgridplatform/cucumber/platform/microgrids/glue/steps/mocks/RtuSchoteroogSteps.java
+++ b/integration-tests/cucumber-tests-platform-microgrids/src/test/java/org/opensmartgridplatform/cucumber/platform/microgrids/glue/steps/mocks/RtuSchoteroogSteps.java
@@ -12,8 +12,8 @@ import java.util.List;
 import org.opensmartgridplatform.cucumber.platform.microgrids.mocks.iec61850.Iec61850MockServer;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
 
 public class RtuSchoteroogSteps implements RtuSteps {
 

--- a/integration-tests/cucumber-tests-platform-microgrids/src/test/java/org/opensmartgridplatform/cucumber/platform/microgrids/glue/steps/mocks/RtuWagoSteps.java
+++ b/integration-tests/cucumber-tests-platform-microgrids/src/test/java/org/opensmartgridplatform/cucumber/platform/microgrids/glue/steps/mocks/RtuWagoSteps.java
@@ -12,8 +12,8 @@ import java.util.List;
 import org.opensmartgridplatform.cucumber.platform.microgrids.mocks.iec61850.Iec61850MockServer;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
 
 public class RtuWagoSteps implements RtuSteps {
 

--- a/integration-tests/cucumber-tests-platform-microgrids/src/test/java/org/opensmartgridplatform/cucumber/platform/microgrids/glue/steps/reporting/ReportingSteps.java
+++ b/integration-tests/cucumber-tests-platform-microgrids/src/test/java/org/opensmartgridplatform/cucumber/platform/microgrids/glue/steps/reporting/ReportingSteps.java
@@ -14,9 +14,9 @@ import org.opensmartgridplatform.cucumber.platform.microgrids.support.ws.microgr
 import org.opensmartgridplatform.simulator.protocol.iec61850.server.QualityType;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class ReportingSteps {
 

--- a/integration-tests/cucumber-tests-platform-microgrids/src/test/java/org/opensmartgridplatform/cucumber/platform/microgrids/glue/steps/ws/microgrids/adhocmanagement/FaultSteps.java
+++ b/integration-tests/cucumber-tests-platform-microgrids/src/test/java/org/opensmartgridplatform/cucumber/platform/microgrids/glue/steps/ws/microgrids/adhocmanagement/FaultSteps.java
@@ -21,7 +21,7 @@ import org.opensmartgridplatform.cucumber.platform.microgrids.support.ws.microgr
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ws.soap.client.SoapFaultClientException;
 
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Then;
 
 public class FaultSteps {
 

--- a/integration-tests/cucumber-tests-platform-microgrids/src/test/java/org/opensmartgridplatform/cucumber/platform/microgrids/glue/steps/ws/microgrids/adhocmanagement/GetDataSteps.java
+++ b/integration-tests/cucumber-tests-platform-microgrids/src/test/java/org/opensmartgridplatform/cucumber/platform/microgrids/glue/steps/ws/microgrids/adhocmanagement/GetDataSteps.java
@@ -33,9 +33,9 @@ import org.opensmartgridplatform.cucumber.platform.microgrids.support.ws.microgr
 import org.opensmartgridplatform.cucumber.platform.microgrids.support.ws.microgrids.adhocmanagement.GetDataRequestBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.PendingException;
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.PendingException;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class GetDataSteps {
 

--- a/integration-tests/cucumber-tests-platform-microgrids/src/test/java/org/opensmartgridplatform/cucumber/platform/microgrids/glue/steps/ws/microgrids/adhocmanagement/SetDataSteps.java
+++ b/integration-tests/cucumber-tests-platform-microgrids/src/test/java/org/opensmartgridplatform/cucumber/platform/microgrids/glue/steps/ws/microgrids/adhocmanagement/SetDataSteps.java
@@ -25,8 +25,8 @@ import org.opensmartgridplatform.cucumber.platform.microgrids.support.ws.microgr
 import org.opensmartgridplatform.cucumber.platform.microgrids.support.ws.microgrids.adhocmanagement.SetDataRequestBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class SetDataSteps {
 

--- a/integration-tests/cucumber-tests-platform-microgrids/src/test/java/org/opensmartgridplatform/cucumber/platform/microgrids/glue/steps/ws/microgrids/notification/MicrogridsNotificationSteps.java
+++ b/integration-tests/cucumber-tests-platform-microgrids/src/test/java/org/opensmartgridplatform/cucumber/platform/microgrids/glue/steps/ws/microgrids/notification/MicrogridsNotificationSteps.java
@@ -20,8 +20,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class MicrogridsNotificationSteps {
 

--- a/integration-tests/cucumber-tests-platform-microgrids/src/test/java/org/opensmartgridplatform/cucumber/platform/microgrids/glue/steps/ws/microgrids/notifications/ResendNotificationJobSteps.java
+++ b/integration-tests/cucumber-tests-platform-microgrids/src/test/java/org/opensmartgridplatform/cucumber/platform/microgrids/glue/steps/ws/microgrids/notifications/ResendNotificationJobSteps.java
@@ -7,7 +7,7 @@
  */
 package org.opensmartgridplatform.cucumber.platform.microgrids.glue.steps.ws.microgrids.notifications;
 
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.When;
 
 public class ResendNotificationJobSteps {
 

--- a/integration-tests/cucumber-tests-platform-publiclighting/pom.xml
+++ b/integration-tests/cucumber-tests-platform-publiclighting/pom.xml
@@ -56,6 +56,12 @@
       <artifactId>cucumber-spring</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- Cucumber tests depend on JUnit 4, add the vintage engine -->
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>

--- a/integration-tests/cucumber-tests-platform-publiclighting/src/test/java/org/opensmartgridplatform/cucumber/platform/publiclighting/AcceptanceTests.java
+++ b/integration-tests/cucumber-tests-platform-publiclighting/src/test/java/org/opensmartgridplatform/cucumber/platform/publiclighting/AcceptanceTests.java
@@ -11,17 +11,21 @@ package org.opensmartgridplatform.cucumber.platform.publiclighting;
 
 import org.junit.runner.RunWith;
 
-import cucumber.api.CucumberOptions;
-import cucumber.api.SnippetType;
-import cucumber.api.junit.Cucumber;
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import io.cucumber.junit.CucumberOptions.SnippetType;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(features = { "classpath:features/publiclighting" }, tags = { "not @Skip",
-        "not @NightlyBuildOnly" }, glue = { "classpath:org.opensmartgridplatform.cucumber.platform.glue",
+@CucumberOptions(features = { "classpath:features/publiclighting" },
+        tags = { "not @Skip", "not @NightlyBuildOnly" },
+        glue = { "classpath:org.opensmartgridplatform.cucumber.platform.glue",
                 "classpath:org.opensmartgridplatform.cucumber.platform.common.glue",
-                "classpath:org.opensmartgridplatform.cucumber.platform.publiclighting.glue" }, plugin = { "pretty",
-                        "html:target/output/Cucumber-report", "html:target/output/Cucumber-html-report.html",
-                        "json:target/output/cucumber.json" }, snippets = SnippetType.CAMELCASE, dryRun = false)
+                "classpath:org.opensmartgridplatform.cucumber.platform.publiclighting.glue" },
+        plugin = { "pretty", "html:target/output/Cucumber-report", "html:target/output/Cucumber-html-report.html",
+                "json:target/output/cucumber.json" },
+        snippets = SnippetType.CAMELCASE,
+        strict = true,
+        dryRun = false)
 public class AcceptanceTests {
 
 }

--- a/integration-tests/cucumber-tests-platform-publiclighting/src/test/java/org/opensmartgridplatform/cucumber/platform/publiclighting/glue/hooks/OslpMockServerHooks.java
+++ b/integration-tests/cucumber-tests-platform-publiclighting/src/test/java/org/opensmartgridplatform/cucumber/platform/publiclighting/glue/hooks/OslpMockServerHooks.java
@@ -10,7 +10,7 @@ package org.opensmartgridplatform.cucumber.platform.publiclighting.glue.hooks;
 import org.opensmartgridplatform.cucumber.platform.publiclighting.mocks.oslpdevice.MockOslpServer;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.Before;
+import io.cucumber.java.Before;
 
 public class OslpMockServerHooks {
 

--- a/integration-tests/cucumber-tests-platform-publiclighting/src/test/java/org/opensmartgridplatform/cucumber/platform/publiclighting/glue/hooks/ScenarioHooks.java
+++ b/integration-tests/cucumber-tests-platform-publiclighting/src/test/java/org/opensmartgridplatform/cucumber/platform/publiclighting/glue/hooks/ScenarioHooks.java
@@ -14,8 +14,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.After;
-import cucumber.api.java.Before;
+import io.cucumber.java.After;
+import io.cucumber.java.Before;
 
 /**
  * Class with all the scenario hooks when each scenario runs.

--- a/integration-tests/cucumber-tests-platform-publiclighting/src/test/java/org/opensmartgridplatform/cucumber/platform/publiclighting/glue/steps/database/adapterprotocoloslp/OslpDeviceSteps.java
+++ b/integration-tests/cucumber-tests-platform-publiclighting/src/test/java/org/opensmartgridplatform/cucumber/platform/publiclighting/glue/steps/database/adapterprotocoloslp/OslpDeviceSteps.java
@@ -23,8 +23,8 @@ import org.opensmartgridplatform.cucumber.platform.PlatformKeys;
 import org.opensmartgridplatform.cucumber.platform.glue.steps.database.core.SsldDeviceSteps;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
 
 /**
  * OSLP device specific steps.

--- a/integration-tests/cucumber-tests-platform-publiclighting/src/test/java/org/opensmartgridplatform/cucumber/platform/publiclighting/glue/steps/database/ws/PublicLightingResponseDataSteps.java
+++ b/integration-tests/cucumber-tests-platform-publiclighting/src/test/java/org/opensmartgridplatform/cucumber/platform/publiclighting/glue/steps/database/ws/PublicLightingResponseDataSteps.java
@@ -26,8 +26,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
 
 public class PublicLightingResponseDataSteps {
 

--- a/integration-tests/cucumber-tests-platform-publiclighting/src/test/java/org/opensmartgridplatform/cucumber/platform/publiclighting/glue/steps/mocks/OslpDeviceSteps.java
+++ b/integration-tests/cucumber-tests-platform-publiclighting/src/test/java/org/opensmartgridplatform/cucumber/platform/publiclighting/glue/steps/mocks/OslpDeviceSteps.java
@@ -78,9 +78,9 @@ import org.springframework.util.CollectionUtils;
 
 import com.google.protobuf.ByteString;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 /**
  * Class which holds all the OSLP device mock steps in order to let the device
@@ -251,13 +251,13 @@ public class OslpDeviceSteps {
                 final DaliConfiguration receivedDaliConfiguration = receivedConfiguration.getDaliConfiguration();
                 if (receivedDaliConfiguration != null) {
                     if (expectedResponseData.containsKey(PlatformKeys.DC_LIGHTS)
-                            && !expectedResponseData.get(PlatformKeys.DC_LIGHTS).isEmpty()) {
+                            && StringUtils.isNotBlank(expectedResponseData.get(PlatformKeys.DC_LIGHTS))) {
                         assertThat(OslpUtils.byteStringToInteger(receivedDaliConfiguration.getNumberOfLights()))
                                 .isEqualTo(getInteger(expectedResponseData, PlatformKeys.DC_LIGHTS));
                     }
 
                     if (expectedResponseData.containsKey(PlatformKeys.DC_MAP)
-                            && !expectedResponseData.get(PlatformKeys.DC_MAP).isEmpty()) {
+                            && StringUtils.isNotBlank(expectedResponseData.get(PlatformKeys.DC_MAP))) {
                         assertThat(receivedDaliConfiguration.getAddressMapList()).isNotNull();
                         final String[] expectedDcMapArray = getString(expectedResponseData, PlatformKeys.DC_MAP)
                                 .split(";");
@@ -741,8 +741,12 @@ public class OslpDeviceSteps {
         final Map<String, String[]> requestMap = new HashMap<>();
 
         for (final String key : requestParameters.keySet()) {
-            final String[] values = requestParameters.get(key)
-                    .split(PlatformPubliclightingKeys.SEPARATOR_SPACE_COLON_SPACE);
+            final String[] values;
+            if (requestParameters.get(key) == null) {
+                values = new String[] { "" };
+            } else {
+                values = requestParameters.get(key).split(PlatformPubliclightingKeys.SEPARATOR_SPACE_COLON_SPACE);
+            }
             requestMap.put(key, values);
         }
 

--- a/integration-tests/cucumber-tests-platform-publiclighting/src/test/java/org/opensmartgridplatform/cucumber/platform/publiclighting/glue/steps/mocks/OslpDeviceSteps.java
+++ b/integration-tests/cucumber-tests-platform-publiclighting/src/test/java/org/opensmartgridplatform/cucumber/platform/publiclighting/glue/steps/mocks/OslpDeviceSteps.java
@@ -724,8 +724,10 @@ public class OslpDeviceSteps {
                         PlatformPubliclightingDefaults.SHORT_INTERVAL),
                 getInteger(requestParameters, PlatformPubliclightingKeys.LONG_INTERVAL,
                         PlatformPubliclightingDefaults.LONG_INTERVAL),
-                getEnum(requestParameters, PlatformPubliclightingKeys.INTERVAL_TYPE, LongTermIntervalType.class,
-                        PlatformPubliclightingDefaults.DEFAULT_INTERVAL_TYPE),
+                requestParameters.containsKey(PlatformPubliclightingKeys.INTERVAL_TYPE)
+                        ? getEnum(requestParameters, PlatformPubliclightingKeys.INTERVAL_TYPE,
+                                LongTermIntervalType.class)
+                        : PlatformPubliclightingDefaults.DEFAULT_INTERVAL_TYPE,
                 osgpIpAddressMock, getInteger(requestParameters, PlatformPubliclightingKeys.OSGP_PORT,
                         PlatformPubliclightingDefaults.DEFAULT_OSLP_PORT));
     }

--- a/integration-tests/cucumber-tests-platform-publiclighting/src/test/java/org/opensmartgridplatform/cucumber/platform/publiclighting/glue/steps/ws/basicosgpfunctions/AuthorizeDeviceFunctionsSteps.java
+++ b/integration-tests/cucumber-tests-platform-publiclighting/src/test/java/org/opensmartgridplatform/cucumber/platform/publiclighting/glue/steps/ws/basicosgpfunctions/AuthorizeDeviceFunctionsSteps.java
@@ -53,8 +53,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ws.soap.client.SoapFaultClientException;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 /**
  * Class with all the AuthorizeDeviceFunctions steps
@@ -122,7 +122,7 @@ public class AuthorizeDeviceFunctionsSteps {
         }
     }
 
-    @Then("the publiclighting device function response is \"([^\"]*)\"")
+    @Then("the publiclighting device function response is \"{}\"")
     public void thePublicLightingDeviceFunctionResponseIsSuccessful(final Boolean allowed) {
         if (allowed) {
             Wait.until(() -> {
@@ -155,8 +155,8 @@ public class AuthorizeDeviceFunctionsSteps {
         lightValue.setDimValue(100);
         lightValue.setOn(true);
         request.getLightValue().add(lightValue);
-        ScenarioContext.current().put(PlatformPubliclightingKeys.RESPONSE,
-                this.publicLightingAdHocManagementClient.setLight(request));
+        ScenarioContext.current()
+                .put(PlatformPubliclightingKeys.RESPONSE, this.publicLightingAdHocManagementClient.setLight(request));
     }
 
     private void setLightSchedule(final Map<String, String> requestParameters)
@@ -183,8 +183,9 @@ public class AuthorizeDeviceFunctionsSteps {
         windowType.setMinutesBefore(0);
         schedule.setTriggerWindow(windowType);
         request.getSchedules().add(schedule);
-        ScenarioContext.current().put(PlatformPubliclightingKeys.RESPONSE,
-                this.publicLightingScheduleManagementClient.setSchedule(request));
+        ScenarioContext.current()
+                .put(PlatformPubliclightingKeys.RESPONSE,
+                        this.publicLightingScheduleManagementClient.setSchedule(request));
     }
 
     private void setTariffSchedule(final Map<String, String> requestParameters)
@@ -206,8 +207,9 @@ public class AuthorizeDeviceFunctionsSteps {
         schedule.setIsEnabled(true);
         schedule.setMinimumLightsOn(10);
         request.getSchedules().add(schedule);
-        ScenarioContext.current().put(PlatformPubliclightingKeys.RESPONSE,
-                this.tariffSwitchingScheduleManagementClient.setSchedule(request));
+        ScenarioContext.current()
+                .put(PlatformPubliclightingKeys.RESPONSE,
+                        this.tariffSwitchingScheduleManagementClient.setSchedule(request));
     }
 
     private void getPowerUsageHistory(final Map<String, String> requestParameters)
@@ -224,8 +226,9 @@ public class AuthorizeDeviceFunctionsSteps {
         request.setTimePeriod(timePeriod);
         request.setHistoryTermType(HistoryTermType.LONG);
 
-        ScenarioContext.current().put(PlatformPubliclightingKeys.RESPONSE,
-                this.publicLightingDeviceMonitoringClient.getPowerUsageHistory(request));
+        ScenarioContext.current()
+                .put(PlatformPubliclightingKeys.RESPONSE,
+                        this.publicLightingDeviceMonitoringClient.getPowerUsageHistory(request));
     }
 
     private void resumeSchedule(final Map<String, String> requestParameters)
@@ -235,8 +238,9 @@ public class AuthorizeDeviceFunctionsSteps {
                 getString(requestParameters, PlatformPubliclightingKeys.KEY_DEVICE_IDENTIFICATION,
                         PlatformPubliclightingDefaults.DEFAULT_DEVICE_IDENTIFICATION));
 
-        ScenarioContext.current().put(PlatformPubliclightingKeys.RESPONSE,
-                this.publicLightingAdHocManagementClient.resumeSchedule(request));
+        ScenarioContext.current()
+                .put(PlatformPubliclightingKeys.RESPONSE,
+                        this.publicLightingAdHocManagementClient.resumeSchedule(request));
     }
 
     private void setTransition(final Map<String, String> requestParameters)
@@ -247,8 +251,9 @@ public class AuthorizeDeviceFunctionsSteps {
                         PlatformPubliclightingDefaults.DEFAULT_DEVICE_IDENTIFICATION));
         request.setTransitionType(TransitionType.DAY_NIGHT);
 
-        ScenarioContext.current().put(PlatformPubliclightingKeys.RESPONSE,
-                this.publicLightingAdHocManagementClient.setTransition(request));
+        ScenarioContext.current()
+                .put(PlatformPubliclightingKeys.RESPONSE,
+                        this.publicLightingAdHocManagementClient.setTransition(request));
     }
 
     private void getTariffStatus(final Map<String, String> requestParameters) throws WebServiceSecurityException {
@@ -256,8 +261,8 @@ public class AuthorizeDeviceFunctionsSteps {
         request.setDeviceIdentification(
                 getString(requestParameters, PlatformPubliclightingKeys.KEY_DEVICE_IDENTIFICATION,
                         PlatformPubliclightingDefaults.DEFAULT_DEVICE_IDENTIFICATION));
-        ScenarioContext.current().put(PlatformPubliclightingKeys.RESPONSE,
-                this.tariffSwitchingAdHocManagementClient.getStatus(request));
+        ScenarioContext.current()
+                .put(PlatformPubliclightingKeys.RESPONSE, this.tariffSwitchingAdHocManagementClient.getStatus(request));
     }
 
     private void getLightStatus(final Map<String, String> requestParameters)
@@ -266,7 +271,7 @@ public class AuthorizeDeviceFunctionsSteps {
         request.setDeviceIdentification(
                 getString(requestParameters, PlatformPubliclightingKeys.KEY_DEVICE_IDENTIFICATION,
                         PlatformPubliclightingDefaults.DEFAULT_DEVICE_IDENTIFICATION));
-        ScenarioContext.current().put(PlatformPubliclightingKeys.RESPONSE,
-                this.publicLightingAdHocManagementClient.getStatus(request));
+        ScenarioContext.current()
+                .put(PlatformPubliclightingKeys.RESPONSE, this.publicLightingAdHocManagementClient.getStatus(request));
     }
 }

--- a/integration-tests/cucumber-tests-platform-publiclighting/src/test/java/org/opensmartgridplatform/cucumber/platform/publiclighting/glue/steps/ws/publiclighting/adhocmanagement/GetStatusSteps.java
+++ b/integration-tests/cucumber-tests-platform-publiclighting/src/test/java/org/opensmartgridplatform/cucumber/platform/publiclighting/glue/steps/ws/publiclighting/adhocmanagement/GetStatusSteps.java
@@ -41,8 +41,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ws.soap.client.SoapFaultClientException;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 /**
  * Class with all the set light requests steps

--- a/integration-tests/cucumber-tests-platform-publiclighting/src/test/java/org/opensmartgridplatform/cucumber/platform/publiclighting/glue/steps/ws/publiclighting/adhocmanagement/ResumeScheduleSteps.java
+++ b/integration-tests/cucumber-tests-platform-publiclighting/src/test/java/org/opensmartgridplatform/cucumber/platform/publiclighting/glue/steps/ws/publiclighting/adhocmanagement/ResumeScheduleSteps.java
@@ -34,8 +34,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ws.soap.client.SoapFaultClientException;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 /**
  * Class with all the set light requests steps

--- a/integration-tests/cucumber-tests-platform-publiclighting/src/test/java/org/opensmartgridplatform/cucumber/platform/publiclighting/glue/steps/ws/publiclighting/adhocmanagement/SetLightSteps.java
+++ b/integration-tests/cucumber-tests-platform-publiclighting/src/test/java/org/opensmartgridplatform/cucumber/platform/publiclighting/glue/steps/ws/publiclighting/adhocmanagement/SetLightSteps.java
@@ -36,8 +36,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ws.soap.client.SoapFaultClientException;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 /**
  * Class with all the set light requests steps

--- a/integration-tests/cucumber-tests-platform-publiclighting/src/test/java/org/opensmartgridplatform/cucumber/platform/publiclighting/glue/steps/ws/publiclighting/adhocmanagement/SetTransitionSteps.java
+++ b/integration-tests/cucumber-tests-platform-publiclighting/src/test/java/org/opensmartgridplatform/cucumber/platform/publiclighting/glue/steps/ws/publiclighting/adhocmanagement/SetTransitionSteps.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
 
+import org.apache.commons.lang3.StringUtils;
 import org.opensmartgridplatform.adapter.ws.schema.publiclighting.adhocmanagement.SetTransitionAsyncRequest;
 import org.opensmartgridplatform.adapter.ws.schema.publiclighting.adhocmanagement.SetTransitionAsyncResponse;
 import org.opensmartgridplatform.adapter.ws.schema.publiclighting.adhocmanagement.SetTransitionRequest;
@@ -38,8 +39,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ws.soap.client.SoapFaultClientException;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 /**
  * Class with all the set light requests steps
@@ -67,13 +68,13 @@ public class SetTransitionSteps {
                         PlatformPubliclightingDefaults.DEFAULT_DEVICE_IDENTIFICATION));
 
         if (requestParameters.containsKey(PlatformPubliclightingKeys.KEY_TRANSITION_TYPE)
-                && !requestParameters.get(PlatformPubliclightingKeys.KEY_TRANSITION_TYPE).isEmpty()) {
+                && StringUtils.isNotBlank(requestParameters.get(PlatformPubliclightingKeys.KEY_TRANSITION_TYPE))) {
             request.setTransitionType(getEnum(requestParameters, PlatformPubliclightingKeys.KEY_TRANSITION_TYPE,
                     TransitionType.class, PlatformPubliclightingDefaults.DEFAULT_TRANSITION_TYPE));
         }
 
         if (requestParameters.containsKey(PlatformPubliclightingKeys.KEY_TIME)
-                && !requestParameters.get(PlatformPubliclightingKeys.KEY_TIME).isEmpty()) {
+                && StringUtils.isNotBlank(requestParameters.get(PlatformPubliclightingKeys.KEY_TIME))) {
             final GregorianCalendar gcal = new GregorianCalendar();
             gcal.add(Calendar.HOUR,
                     Integer.parseInt(requestParameters.get(PlatformPubliclightingKeys.KEY_TIME).substring(0, 2)));
@@ -96,8 +97,8 @@ public class SetTransitionSteps {
     public void receivingASetTransitionRequestByAnUnknownOrganization(final Map<String, String> requestParameters)
             throws Throwable {
         // Force the request being send to the platform as a given organization.
-        ScenarioContext.current().put(PlatformPubliclightingKeys.KEY_ORGANIZATION_IDENTIFICATION,
-                "unknown-organization");
+        ScenarioContext.current()
+                .put(PlatformPubliclightingKeys.KEY_ORGANIZATION_IDENTIFICATION, "unknown-organization");
 
         this.receivingASetTransitionRequest(requestParameters);
     }

--- a/integration-tests/cucumber-tests-platform-publiclighting/src/test/java/org/opensmartgridplatform/cucumber/platform/publiclighting/glue/steps/ws/publiclighting/devicemonitoring/GetPowerUsageHistorySteps.java
+++ b/integration-tests/cucumber-tests-platform-publiclighting/src/test/java/org/opensmartgridplatform/cucumber/platform/publiclighting/glue/steps/ws/publiclighting/devicemonitoring/GetPowerUsageHistorySteps.java
@@ -45,8 +45,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ws.soap.client.SoapFaultClientException;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 /**
  * Class with all the get power usage history requests steps

--- a/integration-tests/cucumber-tests-platform-publiclighting/src/test/java/org/opensmartgridplatform/cucumber/platform/publiclighting/glue/steps/ws/publiclighting/firmwaremanagement/UpdateFirmwareSteps.java
+++ b/integration-tests/cucumber-tests-platform-publiclighting/src/test/java/org/opensmartgridplatform/cucumber/platform/publiclighting/glue/steps/ws/publiclighting/firmwaremanagement/UpdateFirmwareSteps.java
@@ -39,8 +39,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ws.soap.client.SoapFaultClientException;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 /**
  * Class with all the firmware requests steps

--- a/integration-tests/cucumber-tests-platform-publiclighting/src/test/java/org/opensmartgridplatform/cucumber/platform/publiclighting/glue/steps/ws/publiclighting/housekeeping/PublicLightingResponseDataCleanupJobSteps.java
+++ b/integration-tests/cucumber-tests-platform-publiclighting/src/test/java/org/opensmartgridplatform/cucumber/platform/publiclighting/glue/steps/ws/publiclighting/housekeeping/PublicLightingResponseDataCleanupJobSteps.java
@@ -18,8 +18,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.transaction.annotation.Transactional;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class PublicLightingResponseDataCleanupJobSteps {
 

--- a/integration-tests/cucumber-tests-platform-publiclighting/src/test/java/org/opensmartgridplatform/cucumber/platform/publiclighting/glue/steps/ws/publiclighting/notification/PublicLightingNotificationSteps.java
+++ b/integration-tests/cucumber-tests-platform-publiclighting/src/test/java/org/opensmartgridplatform/cucumber/platform/publiclighting/glue/steps/ws/publiclighting/notification/PublicLightingNotificationSteps.java
@@ -20,7 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Then;
 
 public class PublicLightingNotificationSteps {
 

--- a/integration-tests/cucumber-tests-platform-publiclighting/src/test/java/org/opensmartgridplatform/cucumber/platform/publiclighting/glue/steps/ws/publiclighting/schedulemanagement/SetLightScheduleSteps.java
+++ b/integration-tests/cucumber-tests-platform-publiclighting/src/test/java/org/opensmartgridplatform/cucumber/platform/publiclighting/glue/steps/ws/publiclighting/schedulemanagement/SetLightScheduleSteps.java
@@ -48,8 +48,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ws.soap.client.SoapFaultClientException;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 /**
  * Class with all the set light requests steps

--- a/integration-tests/cucumber-tests-platform-publiclighting/src/test/java/org/opensmartgridplatform/cucumber/platform/publiclighting/glue/steps/ws/tariffswitching/schedulemanagement/SetReverseTariffScheduleSteps.java
+++ b/integration-tests/cucumber-tests-platform-publiclighting/src/test/java/org/opensmartgridplatform/cucumber/platform/publiclighting/glue/steps/ws/tariffswitching/schedulemanagement/SetReverseTariffScheduleSteps.java
@@ -13,8 +13,8 @@ import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 /**
  * Class with all the set requests steps

--- a/integration-tests/cucumber-tests-platform-publiclighting/src/test/java/org/opensmartgridplatform/cucumber/platform/publiclighting/glue/steps/ws/tariffswitching/schedulemanagement/SetTariffScheduleSteps.java
+++ b/integration-tests/cucumber-tests-platform-publiclighting/src/test/java/org/opensmartgridplatform/cucumber/platform/publiclighting/glue/steps/ws/tariffswitching/schedulemanagement/SetTariffScheduleSteps.java
@@ -45,8 +45,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ws.soap.client.SoapFaultClientException;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 /**
  * Class with all the set requests steps

--- a/integration-tests/cucumber-tests-platform-publiclighting/src/test/resources/features/publiclighting/osgp-adapter-ws-tariffswitching/housekeeping/TariffSwitchingResponseDataCleanupJob.feature
+++ b/integration-tests/cucumber-tests-platform-publiclighting/src/test/resources/features/publiclighting/osgp-adapter-ws-tariffswitching/housekeeping/TariffSwitchingResponseDataCleanupJob.feature
@@ -1,8 +1,8 @@
-#@TariffSwitching @Platform @NightlyBuildOnly @Housekeeping
-#Feature: TariffSwitching Housekeeping - Response Data Cleanup Job
-  #As open smart grid platform
-  #I want to clean up the response data
-  #So that obsolete data is removed
+@Skip @TariffSwitching @Platform @NightlyBuildOnly @Housekeeping
+Feature: TariffSwitching Housekeeping - Response Data Cleanup Job
+  As open smart grid platform
+  I want to clean up the response data
+  So that obsolete data is removed
 #
   #Scenario: Clean obsolete response data
     #Given a tariff switching response data record

--- a/integration-tests/cucumber-tests-platform-smartmetering/pom.xml
+++ b/integration-tests/cucumber-tests-platform-smartmetering/pom.xml
@@ -74,6 +74,12 @@
       <artifactId>cucumber-spring</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- Cucumber tests depend on JUnit 4, add the vintage engine -->
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/AcceptanceTests.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/AcceptanceTests.java
@@ -9,18 +9,23 @@ package org.opensmartgridplatform.cucumber.platform.smartmetering;
 
 import org.junit.runner.RunWith;
 
-import cucumber.api.CucumberOptions;
-import cucumber.api.SnippetType;
-import cucumber.api.junit.Cucumber;
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import io.cucumber.junit.CucumberOptions.SnippetType;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(features = { "classpath:features/functional-exceptions", "classpath:features/osgp-adapter-ws-core",
-        "classpath:features/osgp-adapter-ws-smartmetering" }, tags = { "not @Skip", "not @NightlyBuildOnly" }, glue = {
-                "classpath:org.opensmartgridplatform.cucumber.platform.glue",
+@CucumberOptions(
+        features = { "classpath:features/functional-exceptions", "classpath:features/osgp-adapter-ws-core",
+                "classpath:features/osgp-adapter-ws-smartmetering" },
+        tags = { "not @Skip", "not @NightlyBuildOnly" },
+        glue = { "classpath:org.opensmartgridplatform.cucumber.platform.glue",
                 "classpath:org.opensmartgridplatform.cucumber.platform.common.glue",
-                "classpath:org.opensmartgridplatform.cucumber.platform.smartmetering.glue" }, plugin = { "pretty",
-                        "html:target/output/Cucumber-report", "html:target/output/Cucumber-html-report.html",
-                        "json:target/output/cucumber.json" }, snippets = SnippetType.CAMELCASE, dryRun = false)
+                "classpath:org.opensmartgridplatform.cucumber.platform.smartmetering.glue" },
+        plugin = { "pretty", "html:target/output/Cucumber-report", "html:target/output/Cucumber-html-report.html",
+                "json:target/output/cucumber.json" },
+        snippets = SnippetType.CAMELCASE,
+        strict = true,
+        dryRun = false)
 public class AcceptanceTests {
 
 }

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/hooks/ScenarioHooks.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/hooks/ScenarioHooks.java
@@ -21,8 +21,8 @@ import org.opensmartgridplatform.cucumber.platform.smartmetering.support.Service
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 
-import cucumber.api.java.After;
-import cucumber.api.java.Before;
+import io.cucumber.java.After;
+import io.cucumber.java.Before;
 
 /**
  * Class with all the scenario hooks when each scenario runs.

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/database/core/SmartMeterSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/database/core/SmartMeterSteps.java
@@ -49,7 +49,7 @@ import org.opensmartgridplatform.domain.core.valueobjects.GpsCoordinates;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
-import cucumber.api.java.en.Given;
+import io.cucumber.java.en.Given;
 
 public class SmartMeterSteps extends BaseDeviceSteps {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/database/device/DlmsDeviceSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/database/device/DlmsDeviceSteps.java
@@ -50,8 +50,8 @@ import org.opensmartgridplatform.domain.core.valueobjects.DeviceFunctionGroup;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
 
 /**
  * DLMS device specific steps.

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/database/ws/ResponseUrlDataSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/database/ws/ResponseUrlDataSteps.java
@@ -21,8 +21,8 @@ import org.opensmartgridplatform.cucumber.core.ScenarioContext;
 import org.opensmartgridplatform.cucumber.platform.PlatformKeys;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
 
 public class ResponseUrlDataSteps {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/database/ws/SmartMeteringResponseDataSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/database/ws/SmartMeteringResponseDataSteps.java
@@ -27,8 +27,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
 
 public class SmartMeteringResponseDataSteps extends BaseDeviceSteps {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/functional/exceptions/FunctionalExceptionsSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/functional/exceptions/FunctionalExceptionsSteps.java
@@ -42,10 +42,10 @@ import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smar
 import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smartmetering.monitoring.SmartMeteringMonitoringRequestClient;
 import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smartmetering.monitoring.SmartMeteringMonitoringResponseClient;
 
-import cucumber.api.Scenario;
-import cucumber.api.java.Before;
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.Scenario;
+import io.cucumber.java.Before;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class FunctionalExceptionsSteps {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/simulator/DefinableLoadProfileSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/simulator/DefinableLoadProfileSteps.java
@@ -12,7 +12,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Then;
 
 public class DefinableLoadProfileSteps {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/simulator/DeviceSimulatorSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/simulator/DeviceSimulatorSteps.java
@@ -26,8 +26,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
 
 public class DeviceSimulatorSteps {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/simulator/SimulatedAlarmObjectSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/simulator/SimulatedAlarmObjectSteps.java
@@ -14,7 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
-import cucumber.api.java.en.Given;
+import io.cucumber.java.en.Given;
 
 public class SimulatedAlarmObjectSteps {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/simulator/SimulatedConfigurationObjectSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/simulator/SimulatedConfigurationObjectSteps.java
@@ -43,7 +43,7 @@ public class SimulatedConfigurationObjectSteps {
     @Autowired
     private JsonObjectCreator jsonObjectCreator;
 
-    @Given("device simulation of \"([^\"]*)\" with configuration object")
+    @Given("device simulation of {string} with configuration object")
     public void deviceSimulationOfConfigurationObject(final String deviceIdentification,
             final Map<String, String> settings) {
 
@@ -56,7 +56,7 @@ public class SimulatedConfigurationObjectSteps {
                 OBJECT_DESCRIPTION);
     }
 
-    @Then("device simulation of \"([^\"]*)\" should be with configuration object")
+    @Then("device simulation of {string} should be with configuration object")
     public void deviceSimulationOfShouldBeWithConfigurationObject(final String deviceIdentification,
             final Map<String, String> settings) {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/simulator/SimulatedConfigurationObjectSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/simulator/SimulatedConfigurationObjectSteps.java
@@ -27,8 +27,8 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
 
 public class SimulatedConfigurationObjectSteps {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/core/audittrail/AuditTrail.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/core/audittrail/AuditTrail.java
@@ -27,7 +27,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Then;
 
 public class AuditTrail {
     private static final String PATTERN_RETRY_OPERATION = "retry count= .*, correlationuid= .*";

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/housekeeping/ResponseUrlDataCleanupJobSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/housekeeping/ResponseUrlDataCleanupJobSteps.java
@@ -15,8 +15,8 @@ import org.opensmartgridplatform.cucumber.platform.smartmetering.glue.steps.data
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class ResponseUrlDataCleanupJobSteps {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/housekeeping/SmartMeteringResponseDataCleanupJobSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/housekeeping/SmartMeteringResponseDataCleanupJobSteps.java
@@ -15,8 +15,8 @@ import org.opensmartgridplatform.cucumber.platform.smartmetering.glue.steps.data
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class SmartMeteringResponseDataCleanupJobSteps {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/notification/SmartMeteringNotificationSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/notification/SmartMeteringNotificationSteps.java
@@ -19,7 +19,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Then;
 
 public class SmartMeteringNotificationSteps {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/notifications/ResendNotificationJobSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/notifications/ResendNotificationJobSteps.java
@@ -7,7 +7,7 @@
  */
 package org.opensmartgridplatform.cucumber.platform.smartmetering.glue.steps.ws.smartmetering.notifications;
 
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.When;
 
 public class ResendNotificationJobSteps {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringadhoc/AllAttributeValues.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringadhoc/AllAttributeValues.java
@@ -24,8 +24,8 @@ import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smar
 import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smartmetering.adhoc.SmartMeteringAdHocResponseClient;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class AllAttributeValues {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringadhoc/AssociationLnObjects.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringadhoc/AssociationLnObjects.java
@@ -24,8 +24,8 @@ import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smar
 import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smartmetering.adhoc.SmartMeteringAdHocResponseClient;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class AssociationLnObjects {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringadhoc/ScanMbusChannelsSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringadhoc/ScanMbusChannelsSteps.java
@@ -29,8 +29,8 @@ import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smar
 import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smartmetering.adhoc.SmartMeteringAdHocResponseClient;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class ScanMbusChannelsSteps {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringadhoc/SpecificAttributeValue.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringadhoc/SpecificAttributeValue.java
@@ -24,8 +24,8 @@ import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smar
 import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smartmetering.adhoc.SpecificAttributeValueRequestFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class SpecificAttributeValue {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringadhoc/SynchronizeTime.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringadhoc/SynchronizeTime.java
@@ -23,8 +23,8 @@ import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smar
 import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smartmetering.adhoc.SynchronizeTimeRequestFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class SynchronizeTime {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringbundle/BundleSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringbundle/BundleSteps.java
@@ -56,9 +56,9 @@ import org.opensmartgridplatform.cucumber.platform.smartmetering.ScenarioContext
 import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smartmetering.bundle.SmartMeteringBundleClient;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class BundleSteps extends BaseBundleSteps {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringbundle/BundledFindEventsSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringbundle/BundledFindEventsSteps.java
@@ -16,8 +16,8 @@ import org.opensmartgridplatform.adapter.ws.schema.smartmetering.bundle.FindEven
 import org.opensmartgridplatform.adapter.ws.schema.smartmetering.common.Response;
 import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smartmetering.bundle.FindEventsRequestBuilder;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
 
 public class BundledFindEventsSteps extends BaseBundleSteps {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringbundle/BundledGetActualMeterReadsSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringbundle/BundledGetActualMeterReadsSteps.java
@@ -13,8 +13,8 @@ import org.opensmartgridplatform.adapter.ws.schema.smartmetering.bundle.ActualMe
 import org.opensmartgridplatform.adapter.ws.schema.smartmetering.bundle.GetActualMeterReadsRequest;
 import org.opensmartgridplatform.adapter.ws.schema.smartmetering.common.Response;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
 
 public class BundledGetActualMeterReadsSteps extends BaseBundleSteps {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringbundle/BundledGetAdministrativeStatusSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringbundle/BundledGetAdministrativeStatusSteps.java
@@ -13,8 +13,8 @@ import org.opensmartgridplatform.adapter.ws.schema.smartmetering.bundle.Administ
 import org.opensmartgridplatform.adapter.ws.schema.smartmetering.bundle.GetAdministrativeStatusRequest;
 import org.opensmartgridplatform.adapter.ws.schema.smartmetering.common.Response;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
 
 public class BundledGetAdministrativeStatusSteps extends BaseBundleSteps {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringbundle/BundledGetAllAttributeValuesSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringbundle/BundledGetAllAttributeValuesSteps.java
@@ -17,8 +17,8 @@ import org.opensmartgridplatform.adapter.ws.schema.smartmetering.bundle.GetAllAt
 import org.opensmartgridplatform.adapter.ws.schema.smartmetering.common.Response;
 import org.opensmartgridplatform.cucumber.platform.smartmetering.PlatformSmartmeteringKeys;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
 
 public class BundledGetAllAttributeValuesSteps extends BaseBundleSteps {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringbundle/BundledGetAssociationLnObjectListSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringbundle/BundledGetAssociationLnObjectListSteps.java
@@ -17,8 +17,8 @@ import org.opensmartgridplatform.adapter.ws.schema.smartmetering.bundle.GetAssoc
 import org.opensmartgridplatform.adapter.ws.schema.smartmetering.common.Response;
 import org.opensmartgridplatform.cucumber.platform.smartmetering.PlatformSmartmeteringKeys;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
 
 public class BundledGetAssociationLnObjectListSteps extends BaseBundleSteps {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringbundle/BundledGetConfigurationObjectSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringbundle/BundledGetConfigurationObjectSteps.java
@@ -18,8 +18,8 @@ import org.opensmartgridplatform.adapter.ws.schema.smartmetering.common.Response
 import org.opensmartgridplatform.adapter.ws.schema.smartmetering.configuration.ConfigurationFlag;
 import org.opensmartgridplatform.adapter.ws.schema.smartmetering.configuration.ConfigurationObject;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
 
 public class BundledGetConfigurationObjectSteps extends BaseBundleSteps {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringbundle/BundledGetFirmwareVersionSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringbundle/BundledGetFirmwareVersionSteps.java
@@ -19,8 +19,8 @@ import org.opensmartgridplatform.adapter.ws.schema.smartmetering.configuration.F
 import org.opensmartgridplatform.cucumber.platform.smartmetering.glue.steps.ws.smartmetering.smartmeteringconfiguration.GetFirmwareVersion;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
 
 public class BundledGetFirmwareVersionSteps extends BaseBundleSteps {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringbundle/BundledGetMbusEncryptionKeyStatusSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringbundle/BundledGetMbusEncryptionKeyStatusSteps.java
@@ -16,8 +16,8 @@ import org.opensmartgridplatform.adapter.ws.schema.smartmetering.bundle.GetMbusE
 import org.opensmartgridplatform.adapter.ws.schema.smartmetering.common.Response;
 import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smartmetering.bundle.GetMbusEncryptionKeyStatusRequestBuilder;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
 
 public class BundledGetMbusEncryptionKeyStatusSteps extends BaseBundleSteps {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringbundle/BundledGetProfileGenericDataSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringbundle/BundledGetProfileGenericDataSteps.java
@@ -22,8 +22,8 @@ import org.opensmartgridplatform.adapter.ws.schema.smartmetering.monitoring.Prof
 import org.opensmartgridplatform.cucumber.platform.helpers.SettingsHelper;
 import org.opensmartgridplatform.cucumber.platform.smartmetering.builders.GetProfileGenericDataRequestBuilder;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
 
 public class BundledGetProfileGenericDataSteps extends BaseBundleSteps {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringbundle/BundledGetSpecificAttributeValueSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringbundle/BundledGetSpecificAttributeValueSteps.java
@@ -18,8 +18,8 @@ import org.opensmartgridplatform.adapter.ws.schema.smartmetering.common.Response
 import org.opensmartgridplatform.cucumber.platform.smartmetering.PlatformSmartmeteringKeys;
 import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smartmetering.bundle.GetSpecificAttributeValueRequestBuilder;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
 
 public class BundledGetSpecificAttributeValueSteps extends BaseBundleSteps {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringbundle/BundledReadAlarmRegisterSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringbundle/BundledReadAlarmRegisterSteps.java
@@ -13,8 +13,8 @@ import org.opensmartgridplatform.adapter.ws.schema.smartmetering.bundle.ReadAlar
 import org.opensmartgridplatform.adapter.ws.schema.smartmetering.bundle.ReadAlarmRegisterResponse;
 import org.opensmartgridplatform.adapter.ws.schema.smartmetering.common.Response;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
 
 public class BundledReadAlarmRegisterSteps extends BaseBundleSteps {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringbundle/BundledScanMbusChannelsSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringbundle/BundledScanMbusChannelsSteps.java
@@ -19,8 +19,8 @@ import org.opensmartgridplatform.adapter.ws.schema.smartmetering.common.Response
 import org.opensmartgridplatform.cucumber.platform.smartmetering.glue.steps.ws.smartmetering.smartmeteringadhoc.ScanMbusChannelsSteps;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
 
 public class BundledScanMbusChannelsSteps extends BaseBundleSteps {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringbundle/BundledSetActivityCalendarSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringbundle/BundledSetActivityCalendarSteps.java
@@ -26,8 +26,8 @@ import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smar
 import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smartmetering.bundle.activitycalendar.SeasonProfile;
 import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smartmetering.bundle.activitycalendar.WeekProfile;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
 
 public class BundledSetActivityCalendarSteps extends BaseBundleSteps {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringbundle/BundledSetAdministrativeStatusSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringbundle/BundledSetAdministrativeStatusSteps.java
@@ -17,8 +17,8 @@ import org.opensmartgridplatform.adapter.ws.schema.smartmetering.common.Response
 import org.opensmartgridplatform.cucumber.platform.smartmetering.PlatformSmartmeteringKeys;
 import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smartmetering.bundle.SetAdministrativeStatusRequestBuilder;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
 
 public class BundledSetAdministrativeStatusSteps extends BaseBundleSteps {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringbundle/BundledSetAlarmNotificationsSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringbundle/BundledSetAlarmNotificationsSteps.java
@@ -17,8 +17,8 @@ import org.opensmartgridplatform.adapter.ws.schema.smartmetering.common.Response
 import org.opensmartgridplatform.cucumber.platform.smartmetering.PlatformSmartmeteringKeys;
 import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smartmetering.bundle.SetAlarmNotificationsRequestBuilder;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
 
 public class BundledSetAlarmNotificationsSteps extends BaseBundleSteps {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringbundle/BundledSetClockConfigurationSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringbundle/BundledSetClockConfigurationSteps.java
@@ -18,8 +18,8 @@ import org.opensmartgridplatform.adapter.ws.schema.smartmetering.common.Response
 import org.opensmartgridplatform.cucumber.platform.smartmetering.PlatformSmartmeteringKeys;
 import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smartmetering.configuration.SetClockConfigurationRequestDataFactory;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
 
 public class BundledSetClockConfigurationSteps extends BaseBundleSteps {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringbundle/BundledSetConfigurationObjectSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringbundle/BundledSetConfigurationObjectSteps.java
@@ -17,8 +17,8 @@ import org.opensmartgridplatform.adapter.ws.schema.smartmetering.common.Response
 import org.opensmartgridplatform.cucumber.platform.smartmetering.PlatformSmartmeteringKeys;
 import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smartmetering.bundle.SetConfigurationObjectRequestBuilder;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
 
 public class BundledSetConfigurationObjectSteps extends BaseBundleSteps {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringbundle/BundledSetPushSetupAlarmSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringbundle/BundledSetPushSetupAlarmSteps.java
@@ -17,8 +17,8 @@ import org.opensmartgridplatform.adapter.ws.schema.smartmetering.common.Response
 import org.opensmartgridplatform.cucumber.platform.smartmetering.PlatformSmartmeteringKeys;
 import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smartmetering.bundle.SetPushSetupAlarmRequestBuilder;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
 
 public class BundledSetPushSetupAlarmSteps extends BaseBundleSteps {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringbundle/BundledSetSpecialDaysSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringbundle/BundledSetSpecialDaysSteps.java
@@ -17,8 +17,8 @@ import org.opensmartgridplatform.adapter.ws.schema.smartmetering.common.Response
 import org.opensmartgridplatform.cucumber.platform.smartmetering.PlatformSmartmeteringKeys;
 import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smartmetering.bundle.SetSpecialDaysRequestBuilder;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
 
 public class BundledSetSpecialDaysSteps extends BaseBundleSteps {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringbundle/BundledSynchronizeTimeSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringbundle/BundledSynchronizeTimeSteps.java
@@ -21,8 +21,8 @@ import org.opensmartgridplatform.adapter.ws.schema.smartmetering.common.Response
 import org.opensmartgridplatform.cucumber.platform.smartmetering.PlatformSmartmeteringKeys;
 import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smartmetering.configuration.SynchronizeTimeRequestDataFactory;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
 
 public class BundledSynchronizeTimeSteps extends BaseBundleSteps {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/ConfigureDefinableLoadProfileSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/ConfigureDefinableLoadProfileSteps.java
@@ -21,8 +21,8 @@ import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smar
 import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smartmetering.configuration.SmartMeteringConfigurationClient;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class ConfigureDefinableLoadProfileSteps {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/GetAdministrativeStatus.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/GetAdministrativeStatus.java
@@ -23,8 +23,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class GetAdministrativeStatus {
     protected static final Logger LOGGER = LoggerFactory.getLogger(GetAdministrativeStatus.class);

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/GetFirmwareVersion.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/GetFirmwareVersion.java
@@ -30,8 +30,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class GetFirmwareVersion {
     protected static final Logger LOGGER = LoggerFactory.getLogger(GetFirmwareVersion.class);

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/GetMbusEncryptionKeyStatusByChannelSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/GetMbusEncryptionKeyStatusByChannelSteps.java
@@ -31,8 +31,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ws.soap.client.SoapFaultClientException;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class GetMbusEncryptionKeyStatusByChannelSteps {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/GetMbusEncryptionKeyStatusSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/GetMbusEncryptionKeyStatusSteps.java
@@ -30,8 +30,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ws.soap.client.SoapFaultClientException;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class GetMbusEncryptionKeyStatusSteps {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/PushNotificationAlarm.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/PushNotificationAlarm.java
@@ -20,7 +20,7 @@ import org.opensmartgridplatform.cucumber.platform.PlatformKeys;
 import org.opensmartgridplatform.cucumber.platform.smartmetering.hooks.SimulatePushedAlarmsHooks;
 import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ServiceEndpoint;
 
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.When;
 
 public class PushNotificationAlarm {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/ReceivedAlarmNotificationsSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/ReceivedAlarmNotificationsSteps.java
@@ -31,8 +31,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class ReceivedAlarmNotificationsSteps {
     private static final Logger LOGGER = LoggerFactory.getLogger(ReceivedAlarmNotificationsSteps.class);

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/ReplaceKeysSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/ReplaceKeysSteps.java
@@ -28,8 +28,8 @@ import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smar
 import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smartmetering.configuration.SmartMeteringConfigurationClient;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class ReplaceKeysSteps extends AbstractSmartMeteringSteps {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/SetActivityCalendar.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/SetActivityCalendar.java
@@ -24,8 +24,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class SetActivityCalendar {
     protected static final Logger LOGGER = LoggerFactory.getLogger(SetActivityCalendar.class);

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/SetAdministrativeStatus.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/SetAdministrativeStatus.java
@@ -25,8 +25,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class SetAdministrativeStatus {
     protected static final Logger LOGGER = LoggerFactory.getLogger(SetAdministrativeStatus.class);

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/SetAlarmNotifications.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/SetAlarmNotifications.java
@@ -24,8 +24,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class SetAlarmNotifications {
     protected static final Logger LOGGER = LoggerFactory.getLogger(SetAlarmNotifications.class);

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/SetClockConfiguration.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/SetClockConfiguration.java
@@ -21,8 +21,8 @@ import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smar
 import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smartmetering.configuration.SmartMeteringConfigurationClient;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class SetClockConfiguration {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/SetConfigurationObject.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/SetConfigurationObject.java
@@ -24,8 +24,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class SetConfigurationObject {
     protected static final Logger LOGGER = LoggerFactory.getLogger(SetConfigurationObject.class);

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/SetEncryptionKeyExchangeOnGMeterSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/SetEncryptionKeyExchangeOnGMeterSteps.java
@@ -29,8 +29,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class SetEncryptionKeyExchangeOnGMeterSteps {
     protected static final Logger LOGGER = LoggerFactory.getLogger(SetEncryptionKeyExchangeOnGMeterSteps.class);

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/SetPushSetupSms.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/SetPushSetupSms.java
@@ -37,8 +37,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class SetPushSetupSms {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/SetSpecialDays.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/SetSpecialDays.java
@@ -24,8 +24,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class SetSpecialDays {
     protected static final Logger LOGGER = LoggerFactory.getLogger(SetSpecialDays.class);

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/UpdateFirmware.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/UpdateFirmware.java
@@ -36,8 +36,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.ws.soap.client.SoapFaultClientException;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 @Transactional(value = "txMgrCore")
 public class UpdateFirmware {

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringinstallation/AddDeviceSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringinstallation/AddDeviceSteps.java
@@ -37,8 +37,8 @@ import org.opensmartgridplatform.shared.exceptionhandling.WebServiceSecurityExce
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ws.soap.client.SoapFaultClientException;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class AddDeviceSteps extends AbstractSmartMeteringSteps {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringinstallation/CoupleDeviceSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringinstallation/CoupleDeviceSteps.java
@@ -31,8 +31,8 @@ import org.opensmartgridplatform.shared.exceptionhandling.WebServiceSecurityExce
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ws.soap.client.SoapFaultClientException;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class CoupleDeviceSteps extends AbstractSmartMeteringSteps {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringinstallation/DeCoupleDeviceSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringinstallation/DeCoupleDeviceSteps.java
@@ -25,8 +25,8 @@ import org.opensmartgridplatform.shared.exceptionhandling.WebServiceSecurityExce
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ws.soap.client.SoapFaultClientException;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class DeCoupleDeviceSteps extends AbstractSmartMeteringSteps {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringmanagement/EnableAndDisableDebugging.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringmanagement/EnableAndDisableDebugging.java
@@ -30,8 +30,8 @@ import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smar
 import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smartmetering.management.SmartMeteringManagementResponseClient;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class EnableAndDisableDebugging {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringmanagement/FindCommunicationEventsReads.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringmanagement/FindCommunicationEventsReads.java
@@ -15,8 +15,8 @@ import java.util.Map;
 import org.opensmartgridplatform.adapter.ws.schema.smartmetering.management.EventLogCategory;
 import org.opensmartgridplatform.adapter.ws.schema.smartmetering.management.EventType;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class FindCommunicationEventsReads extends AbstractFindEventsReads {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringmanagement/FindFraudEventsReads.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringmanagement/FindFraudEventsReads.java
@@ -15,8 +15,8 @@ import java.util.Map;
 import org.opensmartgridplatform.adapter.ws.schema.smartmetering.management.EventLogCategory;
 import org.opensmartgridplatform.adapter.ws.schema.smartmetering.management.EventType;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class FindFraudEventsReads extends AbstractFindEventsReads {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringmanagement/FindMbusEventsReads.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringmanagement/FindMbusEventsReads.java
@@ -18,8 +18,8 @@ import org.opensmartgridplatform.adapter.ws.schema.smartmetering.management.Even
 import org.opensmartgridplatform.adapter.ws.schema.smartmetering.management.EventType;
 import org.opensmartgridplatform.cucumber.platform.PlatformKeys;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class FindMbusEventsReads extends AbstractFindEventsReads {
     private static final List<EventType> allowed = Collections.unmodifiableList(Arrays.asList(

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringmanagement/FindStandardEventsReads.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringmanagement/FindStandardEventsReads.java
@@ -15,8 +15,8 @@ import java.util.Map;
 import org.opensmartgridplatform.adapter.ws.schema.smartmetering.management.EventLogCategory;
 import org.opensmartgridplatform.adapter.ws.schema.smartmetering.management.EventType;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class FindStandardEventsReads extends AbstractFindEventsReads {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringmanagement/GetDebugInformation.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringmanagement/GetDebugInformation.java
@@ -26,9 +26,9 @@ import org.opensmartgridplatform.logging.domain.entities.DeviceLogItem;
 import org.opensmartgridplatform.logging.domain.repositories.DeviceLogItemPagingRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class GetDebugInformation {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringmanagement/SetDeviceCommunicationSettingsSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringmanagement/SetDeviceCommunicationSettingsSteps.java
@@ -27,8 +27,8 @@ import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smar
 import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smartmetering.management.SmartMeteringManagementResponseClient;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class SetDeviceCommunicationSettingsSteps {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringmanagement/SetDeviceLifecycleStatusByChannel.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringmanagement/SetDeviceLifecycleStatusByChannel.java
@@ -30,8 +30,8 @@ import org.opensmartgridplatform.domain.core.valueobjects.DeviceLifecycleStatus;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ws.soap.client.SoapFaultClientException;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class SetDeviceLifecycleStatusByChannel {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringmonitoring/ActualMeterReadsGasSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringmonitoring/ActualMeterReadsGasSteps.java
@@ -22,8 +22,8 @@ import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smar
 import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smartmetering.monitoring.SmartMeteringMonitoringResponseClient;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class ActualMeterReadsGasSteps {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringmonitoring/ActualMeterReadsSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringmonitoring/ActualMeterReadsSteps.java
@@ -22,8 +22,8 @@ import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smar
 import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smartmetering.monitoring.SmartMeteringMonitoringResponseClient;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class ActualMeterReadsSteps {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringmonitoring/ClearAlarmRegisterSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringmonitoring/ClearAlarmRegisterSteps.java
@@ -23,8 +23,8 @@ import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smar
 import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smartmetering.monitoring.SmartMeteringMonitoringResponseClient;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class ClearAlarmRegisterSteps {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringmonitoring/PeriodicMeterReadsGasSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringmonitoring/PeriodicMeterReadsGasSteps.java
@@ -26,8 +26,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class PeriodicMeterReadsGasSteps {
     protected static final Logger LOGGER = LoggerFactory.getLogger(AbstractFindEventsReads.class);

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringmonitoring/PeriodicMeterReadsSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringmonitoring/PeriodicMeterReadsSteps.java
@@ -23,8 +23,8 @@ import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smar
 import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smartmetering.monitoring.SmartMeteringMonitoringResponseClient;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class PeriodicMeterReadsSteps {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringmonitoring/ProfileGenericDataSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringmonitoring/ProfileGenericDataSteps.java
@@ -28,8 +28,8 @@ import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smar
 import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smartmetering.monitoring.SmartMeteringMonitoringResponseClient;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class ProfileGenericDataSteps {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringmonitoring/ReadAlarmRegisterSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringmonitoring/ReadAlarmRegisterSteps.java
@@ -22,8 +22,8 @@ import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smar
 import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smartmetering.monitoring.SmartMeteringMonitoringResponseClient;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 
 public class ReadAlarmRegisterSteps {
 

--- a/integration-tests/cucumber-tests-platform/pom.xml
+++ b/integration-tests/cucumber-tests-platform/pom.xml
@@ -41,6 +41,12 @@
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- Cucumber tests depend on JUnit 4, add the vintage engine -->
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
@@ -76,10 +82,6 @@
       <groupId>io.cucumber</groupId>
       <artifactId>cucumber-junit</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.cucumber</groupId>
-      <artifactId>cucumber-core</artifactId>
     </dependency>
     <dependency>
       <groupId>io.cucumber</groupId>

--- a/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/hooks/Configurer.java
+++ b/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/hooks/Configurer.java
@@ -8,49 +8,23 @@
 package org.opensmartgridplatform.cucumber.platform.glue.hooks;
 
 import java.lang.reflect.Type;
-import java.util.Locale;
-import java.util.Map;
 
-import cucumber.api.TypeRegistry;
-import cucumber.api.TypeRegistryConfigurer;
-import io.cucumber.cucumberexpressions.ParameterByTypeTransformer;
-import io.cucumber.datatable.TableCellByTypeTransformer;
-import io.cucumber.datatable.TableEntryByTypeTransformer;
-import io.cucumber.datatable.dependency.com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
-public class Configurer implements TypeRegistryConfigurer {
-    @Override
-    public void configureTypeRegistry(final TypeRegistry registry) {
+import io.cucumber.java.DefaultDataTableCellTransformer;
+import io.cucumber.java.DefaultDataTableEntryTransformer;
+import io.cucumber.java.DefaultParameterTransformer;
 
-        final JacksonTableTransformer jacksonTableTransformer = new JacksonTableTransformer();
-        registry.setDefaultParameterTransformer(jacksonTableTransformer);
-        registry.setDefaultDataTableEntryTransformer(jacksonTableTransformer);
-        registry.setDefaultDataTableCellTransformer(jacksonTableTransformer);
-    }
+public class Configurer {
 
-    @Override
-    public Locale locale() {
-        return Locale.ENGLISH;
-    }
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
-    private static final class JacksonTableTransformer
-            implements ParameterByTypeTransformer, TableEntryByTypeTransformer, TableCellByTypeTransformer {
-        private final ObjectMapper objectMapper = new ObjectMapper();
-
-        @Override
-        public <T> T transform(final Map<String, String> entry, final Class<T> type,
-                final TableCellByTypeTransformer cellTransformer) {
-            return this.objectMapper.convertValue(entry, type);
-        }
-
-        @Override
-        public <T> T transform(final String value, final Class<T> cellType) {
-            return this.objectMapper.convertValue(value, cellType);
-        }
-
-        @Override
-        public Object transform(final String value, final Type type) throws Throwable {
-            return this.objectMapper.convertValue(value, this.objectMapper.constructType(type));
-        }
+    @DefaultParameterTransformer
+    @DefaultDataTableEntryTransformer
+    @DefaultDataTableCellTransformer
+    public Object defaultTransformer(final Object fromValue, final Type toValueType) {
+        final JavaType javaType = this.objectMapper.constructType(toValueType);
+        return this.objectMapper.convertValue(fromValue, javaType);
     }
 }

--- a/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/hooks/ScenarioHooks.java
+++ b/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/hooks/ScenarioHooks.java
@@ -13,8 +13,8 @@ import org.opensmartgridplatform.cucumber.core.GlueBase;
 import org.opensmartgridplatform.cucumber.core.ScenarioContext;
 import org.opensmartgridplatform.cucumber.platform.database.CoreDatabase;
 
-import cucumber.api.java.After;
-import cucumber.api.java.Before;
+import io.cucumber.java.After;
+import io.cucumber.java.Before;
 
 /**
  * Class with all the scenario hooks when each scenario runs.

--- a/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/common/TimeoutSteps.java
+++ b/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/common/TimeoutSteps.java
@@ -10,7 +10,7 @@ package org.opensmartgridplatform.cucumber.platform.glue.steps.common;
 import org.opensmartgridplatform.cucumber.core.ScenarioContext;
 import org.opensmartgridplatform.cucumber.platform.PlatformKeys;
 
-import cucumber.api.java.en.Given;
+import io.cucumber.java.en.Given;
 
 public class TimeoutSteps {
 

--- a/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/database/core/BaseDeviceSteps.java
+++ b/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/database/core/BaseDeviceSteps.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import org.apache.commons.lang3.StringUtils;
 import org.opensmartgridplatform.cucumber.core.ScenarioContext;
 import org.opensmartgridplatform.cucumber.platform.PlatformDefaults;
 import org.opensmartgridplatform.cucumber.platform.PlatformKeys;
@@ -80,7 +81,7 @@ public abstract class BaseDeviceSteps {
 
         // Now set the optional stuff
         if (settings.containsKey(PlatformKeys.KEY_TECHNICAL_INSTALLATION_DATE)
-                && !settings.get(PlatformKeys.KEY_TECHNICAL_INSTALLATION_DATE).isEmpty()) {
+                && StringUtils.isNotBlank(settings.get(PlatformKeys.KEY_TECHNICAL_INSTALLATION_DATE))) {
             device.setTechnicalInstallationDate(
                     getDate(settings, PlatformKeys.KEY_TECHNICAL_INSTALLATION_DATE).toDate());
         }
@@ -139,12 +140,12 @@ public abstract class BaseDeviceSteps {
                 getString(settings, PlatformKeys.KEY_MUNICIPALITY, PlatformDefaults.DEFAULT_CONTAINER_MUNICIPALITY)),
                 new GpsCoordinates(
                         (settings.containsKey(PlatformKeys.KEY_LATITUDE)
-                                && !settings.get(PlatformKeys.KEY_LATITUDE).isEmpty())
+                                && StringUtils.isNotBlank(settings.get(PlatformKeys.KEY_LATITUDE)))
                                         ? getFloat(settings, PlatformKeys.KEY_LATITUDE,
                                                 PlatformDefaults.DEFAULT_LATITUDE)
                                         : null,
                         (settings.containsKey(PlatformKeys.KEY_LONGITUDE)
-                                && !settings.get(PlatformKeys.KEY_LONGITUDE).isEmpty())
+                                && StringUtils.isNotBlank(settings.get(PlatformKeys.KEY_LONGITUDE)))
                                         ? getFloat(settings, PlatformKeys.KEY_LONGITUDE,
                                                 PlatformDefaults.DEFAULT_LONGITUDE)
                                         : null));

--- a/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/database/core/DeviceAuthorizationSteps.java
+++ b/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/database/core/DeviceAuthorizationSteps.java
@@ -28,8 +28,8 @@ import org.opensmartgridplatform.domain.core.valueobjects.DeviceFunctionGroup;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
 
 public class DeviceAuthorizationSteps {
 

--- a/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/database/core/DeviceConfigurationSteps.java
+++ b/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/database/core/DeviceConfigurationSteps.java
@@ -23,7 +23,7 @@ import org.opensmartgridplatform.domain.core.repositories.SsldRepository;
 import org.opensmartgridplatform.domain.core.valueobjects.RelayType;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Given;
+import io.cucumber.java.en.Given;
 
 public class DeviceConfigurationSteps {
 

--- a/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/database/core/DeviceFirmwareFileSteps.java
+++ b/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/database/core/DeviceFirmwareFileSteps.java
@@ -27,8 +27,8 @@ import org.opensmartgridplatform.domain.core.repositories.DeviceRepository;
 import org.opensmartgridplatform.domain.core.repositories.FirmwareFileRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
 
 public class DeviceFirmwareFileSteps {
 

--- a/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/database/core/DeviceFirmwareModuleSteps.java
+++ b/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/database/core/DeviceFirmwareModuleSteps.java
@@ -23,7 +23,7 @@ import org.opensmartgridplatform.domain.core.repositories.FirmwareModuleReposito
 import org.opensmartgridplatform.domain.core.valueobjects.FirmwareModuleData;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Then;
 
 public class DeviceFirmwareModuleSteps {
 

--- a/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/database/core/DeviceModelSteps.java
+++ b/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/database/core/DeviceModelSteps.java
@@ -24,8 +24,8 @@ import org.opensmartgridplatform.domain.core.repositories.DeviceModelRepository;
 import org.opensmartgridplatform.domain.core.repositories.ManufacturerRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
 
 public class DeviceModelSteps {
 

--- a/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/database/core/DeviceOutputSettingsSteps.java
+++ b/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/database/core/DeviceOutputSettingsSteps.java
@@ -26,7 +26,7 @@ import org.opensmartgridplatform.domain.core.repositories.SsldRepository;
 import org.opensmartgridplatform.domain.core.valueobjects.RelayType;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Given;
+import io.cucumber.java.en.Given;
 
 public class DeviceOutputSettingsSteps {
 

--- a/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/database/core/DeviceSteps.java
+++ b/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/database/core/DeviceSteps.java
@@ -8,6 +8,9 @@
 package org.opensmartgridplatform.cucumber.platform.glue.steps.database.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.opensmartgridplatform.cucumber.core.ReadSettingsHelper.getBoolean;
+import static org.opensmartgridplatform.cucumber.core.ReadSettingsHelper.getEnum;
+import static org.opensmartgridplatform.cucumber.core.ReadSettingsHelper.getFloat;
 import static org.opensmartgridplatform.cucumber.core.ReadSettingsHelper.getString;
 
 import java.util.List;
@@ -26,7 +29,7 @@ import org.opensmartgridplatform.domain.core.repositories.SsldRepository;
 import org.opensmartgridplatform.domain.core.valueobjects.DeviceLifecycleStatus;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Then;
 
 public class DeviceSteps extends BaseDeviceSteps {
 
@@ -68,61 +71,63 @@ public class DeviceSteps extends BaseDeviceSteps {
         });
 
         if (settings.containsKey(PlatformKeys.ALIAS)) {
-            assertThat(device.getAlias()).isEqualTo(settings.get(PlatformKeys.ALIAS));
+            assertThat(device.getAlias()).isEqualTo(getString(settings, PlatformKeys.ALIAS));
         }
         if (settings.containsKey(PlatformKeys.KEY_ORGANIZATION_IDENTIFICATION)) {
             assertThat(device.getOwner().getOrganisationIdentification())
-                    .isEqualTo(settings.get(PlatformKeys.KEY_ORGANIZATION_IDENTIFICATION));
+                    .isEqualTo(getString(settings, PlatformKeys.KEY_ORGANIZATION_IDENTIFICATION));
         }
         if (settings.containsKey(PlatformKeys.CONTAINER_POSTALCODE)) {
             assertThat(device.getContainerAddress().getPostalCode())
-                    .isEqualTo(settings.get(PlatformKeys.CONTAINER_POSTALCODE));
+                    .isEqualTo(getString(settings, PlatformKeys.CONTAINER_POSTALCODE));
         }
         if (settings.containsKey(PlatformKeys.CONTAINER_CITY)) {
-            assertThat(device.getContainerAddress().getCity()).isEqualTo(settings.get(PlatformKeys.CONTAINER_CITY));
+            assertThat(device.getContainerAddress().getCity())
+                    .isEqualTo(getString(settings, PlatformKeys.CONTAINER_CITY));
         }
         if (settings.containsKey(PlatformKeys.CONTAINER_STREET)) {
-            assertThat(device.getContainerAddress().getStreet()).isEqualTo(settings.get(PlatformKeys.CONTAINER_STREET));
+            assertThat(device.getContainerAddress().getStreet())
+                    .isEqualTo(getString(settings, PlatformKeys.CONTAINER_STREET));
         }
         if (settings.containsKey(PlatformKeys.CONTAINER_NUMBER)) {
-            assertThat(device.getContainerAddress().getNumber()).isEqualTo(settings.get(PlatformKeys.CONTAINER_NUMBER));
+            assertThat(device.getContainerAddress().getNumber())
+                    .isEqualTo(getString(settings, PlatformKeys.CONTAINER_NUMBER));
         }
         if (settings.containsKey(PlatformKeys.CONTAINER_MUNICIPALITY)) {
             assertThat(device.getContainerAddress().getMunicipality())
-                    .isEqualTo(settings.get(PlatformKeys.CONTAINER_MUNICIPALITY));
+                    .isEqualTo(getString(settings, PlatformKeys.CONTAINER_MUNICIPALITY));
         }
         if (settings.containsKey(PlatformKeys.KEY_LATITUDE)) {
-            assertThat(Float.parseFloat(settings.get(PlatformKeys.KEY_LATITUDE)) == device.getGpsCoordinates()
-                    .getLatitude()).isTrue();
+            assertThat(device.getGpsCoordinates().getLatitude())
+                    .isEqualTo(getFloat(settings, PlatformKeys.KEY_LATITUDE));
         }
         if (settings.containsKey(PlatformKeys.KEY_LONGITUDE)) {
-            assertThat(Float.parseFloat(settings.get(PlatformKeys.KEY_LONGITUDE)) == device.getGpsCoordinates()
-                    .getLongitude()).isTrue();
+            assertThat(device.getGpsCoordinates().getLongitude())
+                    .isEqualTo(getFloat(settings, PlatformKeys.KEY_LONGITUDE));
         }
         if (settings.containsKey(PlatformKeys.KEY_ACTIVATED)) {
-            assertThat(Boolean.parseBoolean(settings.get(PlatformKeys.KEY_ACTIVATED)) == device.isActivated()).isTrue();
+            assertThat(device.isActivated()).isEqualTo(getBoolean(settings, PlatformKeys.KEY_ACTIVATED));
         }
         if (settings.containsKey(PlatformKeys.KEY_DEVICE_LIFECYCLE_STATUS)) {
-            assertThat(DeviceLifecycleStatus.valueOf(settings.get(PlatformKeys.KEY_DEVICE_LIFECYCLE_STATUS)) == device
-                    .getDeviceLifecycleStatus()).isTrue();
+            assertThat(device.getDeviceLifecycleStatus()).isEqualTo(
+                    getEnum(settings, PlatformKeys.KEY_DEVICE_LIFECYCLE_STATUS, DeviceLifecycleStatus.class));
         }
         if (settings.containsKey(PlatformKeys.KEY_HAS_SCHEDULE)
                 || settings.containsKey(PlatformKeys.KEY_PUBLICKEYPRESENT)) {
             final Ssld ssld = this.ssldRepository
-                    .findByDeviceIdentification(settings.get(PlatformKeys.KEY_DEVICE_IDENTIFICATION));
+                    .findByDeviceIdentification(getString(settings, PlatformKeys.KEY_DEVICE_IDENTIFICATION));
 
             if (settings.containsKey(PlatformKeys.KEY_HAS_SCHEDULE)) {
-                assertThat(Boolean.parseBoolean(settings.get(PlatformKeys.KEY_HAS_SCHEDULE)) == ssld.getHasSchedule())
-                        .isTrue();
+                assertThat(ssld.getHasSchedule()).isEqualTo(getBoolean(settings, PlatformKeys.KEY_HAS_SCHEDULE));
             }
             if (settings.containsKey(PlatformKeys.KEY_PUBLICKEYPRESENT)) {
-                assertThat(Boolean.parseBoolean(settings.get(PlatformKeys.KEY_PUBLICKEYPRESENT)) == ssld
-                        .isPublicKeyPresent()).isTrue();
+                assertThat(ssld.isPublicKeyPresent())
+                        .isEqualTo(getBoolean(settings, PlatformKeys.KEY_PUBLICKEYPRESENT));
             }
         }
         if (settings.containsKey(PlatformKeys.KEY_DEVICE_MODEL_MODELCODE)) {
             assertThat(device.getDeviceModel().getModelCode())
-                    .isEqualTo(settings.get(PlatformKeys.KEY_DEVICE_MODEL_MODELCODE));
+                    .isEqualTo(getString(settings, PlatformKeys.KEY_DEVICE_MODEL_MODELCODE));
         }
     }
 

--- a/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/database/core/EventSteps.java
+++ b/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/database/core/EventSteps.java
@@ -32,8 +32,8 @@ import org.opensmartgridplatform.domain.core.repositories.SsldRepository;
 import org.opensmartgridplatform.domain.core.valueobjects.EventType;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
 
 public class EventSteps {
 

--- a/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/database/core/FirmwareFileSteps.java
+++ b/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/database/core/FirmwareFileSteps.java
@@ -43,8 +43,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.google.common.io.Files;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
 
 /**
  * The firmware file related steps.

--- a/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/database/core/LightMeasurementDeviceSteps.java
+++ b/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/database/core/LightMeasurementDeviceSteps.java
@@ -21,7 +21,7 @@ import org.opensmartgridplatform.domain.core.repositories.LightMeasurementDevice
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
-import cucumber.api.java.en.Given;
+import io.cucumber.java.en.Given;
 
 public class LightMeasurementDeviceSteps extends BaseDeviceSteps {
 

--- a/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/database/core/ManufacturerSteps.java
+++ b/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/database/core/ManufacturerSteps.java
@@ -20,8 +20,8 @@ import org.opensmartgridplatform.domain.core.entities.Manufacturer;
 import org.opensmartgridplatform.domain.core.repositories.ManufacturerRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
 
 /**
  * The manufacturer related steps.

--- a/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/database/core/OrganizationSteps.java
+++ b/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/database/core/OrganizationSteps.java
@@ -26,8 +26,8 @@ import org.opensmartgridplatform.domain.core.valueobjects.PlatformDomain;
 import org.opensmartgridplatform.domain.core.valueobjects.PlatformFunctionGroup;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
 
 /**
  * Class with all the organization steps

--- a/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/database/core/RelayStatusSteps.java
+++ b/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/database/core/RelayStatusSteps.java
@@ -20,8 +20,8 @@ import org.opensmartgridplatform.domain.core.entities.RelayStatus;
 import org.opensmartgridplatform.domain.core.entities.Ssld;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
 
 public class RelayStatusSteps extends BaseDeviceSteps {
 

--- a/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/database/core/RtuDeviceSteps.java
+++ b/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/database/core/RtuDeviceSteps.java
@@ -23,7 +23,7 @@ import org.opensmartgridplatform.domain.core.repositories.RtuDeviceRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
-import cucumber.api.java.en.Given;
+import io.cucumber.java.en.Given;
 
 /**
  * RTU device specific steps.

--- a/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/database/core/ScheduledTaskSteps.java
+++ b/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/database/core/ScheduledTaskSteps.java
@@ -44,7 +44,7 @@ public class ScheduledTaskSteps extends BaseDeviceSteps {
     @Autowired
     private ScheduledTaskRepository scheduledTaskRepository;
 
-    @Given("a scheduled \"([^\"]*)\" task")
+    @Given("a scheduled {string} task")
     public void givenAScheduledTask(final String messageType, final Map<String, String> settings) {
         final ScheduledTask scheduledTask = SCHEDULED_TASK_CREATOR_MAP.get(messageType).apply(settings);
         this.scheduledTaskRepository.save(scheduledTask);

--- a/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/database/core/ScheduledTaskSteps.java
+++ b/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/database/core/ScheduledTaskSteps.java
@@ -32,7 +32,7 @@ import org.opensmartgridplatform.shared.infra.jms.DeviceMessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import cucumber.api.java.en.Given;
+import io.cucumber.java.en.Given;
 
 public class ScheduledTaskSteps extends BaseDeviceSteps {
 

--- a/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/database/core/SsldDeviceSteps.java
+++ b/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/database/core/SsldDeviceSteps.java
@@ -32,8 +32,8 @@ import org.opensmartgridplatform.domain.core.valueobjects.RelayType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
 
 public class SsldDeviceSteps extends BaseDeviceSteps {
 

--- a/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/database/logging/DeviceLogItemSteps.java
+++ b/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/database/logging/DeviceLogItemSteps.java
@@ -22,8 +22,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
 
 public class DeviceLogItemSteps {
 

--- a/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/ws/FaultSteps.java
+++ b/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/ws/FaultSteps.java
@@ -9,7 +9,7 @@ package org.opensmartgridplatform.cucumber.platform.glue.steps.ws;
 
 import java.util.Map;
 
-import cucumber.api.java.en.Then;
+import io.cucumber.java.en.Then;
 
 public class FaultSteps {
 

--- a/integration-tests/parent-integration-tests/pom.xml
+++ b/integration-tests/parent-integration-tests/pom.xml
@@ -32,14 +32,14 @@
   </distributionManagement>
 
   <properties>
-    <!-- Default always skip integration tests, to ensure all developer data 
+    <!-- Default always skip integration tests, to ensure all developer data
       is retained -->
     <skipITs>true</skipITs>
 
-    <!-- Skip code coverage gathering with Jacoco on IT tests from Tomcat. 
+    <!-- Skip code coverage gathering with Jacoco on IT tests from Tomcat.
       Requires jacoco-agent to be setup on remote Tomcat -->
     <skipITCoverage>true</skipITCoverage>
-    
+
     <!-- Default always skip creating a test jar with dependencies tests -->
     <skipTestJarWithDependenciesAssembly>true</skipTestJarWithDependenciesAssembly>
 
@@ -49,17 +49,6 @@
 
   <dependencyManagement>
     <dependencies>
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-api</artifactId>
-        <version>${junit.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-engine</artifactId>
-        <version>${junit.version}</version>
-        <scope>test</scope>
-      </dependency>
       <dependency>
         <groupId>org.opensmartgridplatform</groupId>
         <artifactId>osgp-adapter-ws-admin</artifactId>
@@ -279,7 +268,7 @@
           <artifactId>jacoco-maven-plugin</artifactId>
           <version>${jacoco.version}</version>
           <executions>
-            <!-- Prepares the property pointing to the JaCoCo runtime agent 
+            <!-- Prepares the property pointing to the JaCoCo runtime agent
               which is passed as VM argument when Maven the Surefire plugin is executed. -->
             <execution>
               <id>pre-unit-test</id>
@@ -287,10 +276,10 @@
                 <goal>prepare-agent</goal>
               </goals>
               <configuration>
-                <!-- Sets the path to the file which contains the execution 
+                <!-- Sets the path to the file which contains the execution
                   data. -->
                 <destFile>${project.build.directory}/coverage-reports/jacoco-ut.exec</destFile>
-                <!-- Sets the name of the property containing the settings 
+                <!-- Sets the name of the property containing the settings
                   for JaCoCo runtime agent. -->
                 <propertyName>surefireArgLine</propertyName>
                 <skipTests>${skipTests}</skipTests>
@@ -303,7 +292,7 @@
                 <goal>report</goal>
               </goals>
               <configuration>
-                <!-- Sets the path to the file which contains the execution 
+                <!-- Sets the path to the file which contains the execution
                   data. -->
                 <dataFile>${project.build.directory}/coverage-reports/jacoco-ut.exec</dataFile>
                 <!-- Sets the output directory for the code coverage report. -->
@@ -311,7 +300,7 @@
                 <skipTests>${skipTests}</skipTests>
               </configuration>
             </execution>
-            <!-- Ensures that the code coverage report for unit tests is 
+            <!-- Ensures that the code coverage report for unit tests is
               created after unit tests have been run. -->
             <execution>
               <id>post-unit-test</id>
@@ -320,7 +309,7 @@
                 <goal>report</goal>
               </goals>
               <configuration>
-                <!-- Sets the path to the file which contains the execution 
+                <!-- Sets the path to the file which contains the execution
                   data. -->
                 <dataFile>${project.build.directory}/coverage-reports/jacoco-ut.exec</dataFile>
                 <!-- Sets the output directory for the code coverage report. -->
@@ -328,7 +317,7 @@
                 <skipTests>${skipTests}</skipTests>
               </configuration>
             </execution>
-            <!-- Reset the code coverage before the integration tests are 
+            <!-- Reset the code coverage before the integration tests are
               started. Ensures Tomcat startup code execution is ignored in report -->
             <execution>
               <id>pre-integration-test</id>

--- a/jenkins/pipeline/osgp-pr-build.groovy
+++ b/jenkins/pipeline/osgp-pr-build.groovy
@@ -142,7 +142,7 @@ pipeline {
 # - Replace ~@ with not @ surrounded with parentheses
 # - Output to cucumber-tags.txt, which is imported as environment variables
 
-EXTRACTED_TAGS=`echo $ghprbPullLongDescription | grep -o \'\\[@.*\\]\' | sed \'s/\\[/ /g\' | sed \'s/\\]//g\' | sed \':a;N;$!ba;s/\\n/ /g\' | sed \'s/ / and /g\' | sed \'s/\\([^[:blank:]]\\+,[^[:blank:]]\\+\)/\\(\\1\\)/g\' | sed \'s/,/ or /g\' | sed \'s/~\\(@[^[:blank:]]\\+\\)/\\(not \\1\\)/g\'`
+EXTRACTED_TAGS=`echo $ghprbPullLongDescription | grep -o \'\\[@.*\\]\' | sed \'s/\\[/ /g\' | sed \'s/\\]//g\' | sed \':a;N;$!ba;s/\\n/ /g\' | sed \'s/ / and /g\' | sed \'s/\\([^[:blank:]]\\+,[^[:blank:]]\\+\\)/\\(\\1\\)/g\' | sed \'s/,/ or /g\' | sed \'s/~\\(@[^[:blank:]]\\+\\)/\\(not \\1\\)/g\'`
 
 echo "$EXTRACTED_TAGS and not @NightlyBuildOnly" > "${WORKSPACE}/cucumber-tags"
 

--- a/jenkins/pipeline/osgp-pr-build.groovy
+++ b/jenkins/pipeline/osgp-pr-build.groovy
@@ -36,7 +36,7 @@ pipeline {
                       contextSource: [$class: 'ManuallyEnteredCommitContextSource']])
             }
         }
-        
+
         stage ('Maven Build') {
             steps {
                 withMaven(
@@ -124,7 +124,7 @@ pipeline {
                         string(name: 'BRANCH', value: branchReleaseRepo)]
             }
         }
-       
+
         stage('Run Tests') {
             steps {
                 sh '''echo Searching for specific Cucumber tags in git commit.
@@ -138,12 +138,13 @@ pipeline {
 # - Search for [<tags>]
 # - Remove brackets []
 # - Replace new-lines with spaces
-# - Replace spaces with --tags
+# - Replace spaces with and, commas with or surrounded with parentheses
+# - Replace ~@ with not @ surrounded with parentheses
 # - Output to cucumber-tags.txt, which is imported as environment variables
 
-EXTRACTED_TAGS=`echo $ghprbPullLongDescription | grep -o \'\\[@.*\\]\' | sed \'s/\\[/ /g\' | sed \'s/\\]//g\' | sed \':a;N;$!ba;s/\\n/ /g\' | sed \'s/ / --tags /g\'`
+EXTRACTED_TAGS=`echo $ghprbPullLongDescription | grep -o \'\\[@.*\\]\' | sed \'s/\\[/ /g\' | sed \'s/\\]//g\' | sed \':a;N;$!ba;s/\\n/ /g\' | sed \'s/ / and /g\' | sed \'s/\\([^[:blank:]]\\+,[^[:blank:]]\\+\)/\\(\\1\\)/g\' | sed \'s/,/ or /g\' | sed \'s/~\\(@[^[:blank:]]\\+\\)/\\(not \\1\\)/g\'`
 
-echo "$EXTRACTED_TAGS --tags 'not @NightlyBuildOnly'" > "${WORKSPACE}/cucumber-tags"
+echo "$EXTRACTED_TAGS and not @NightlyBuildOnly" > "${WORKSPACE}/cucumber-tags"
 
 echo Found cucumber tags: [$EXTRACTED_TAGS]'''
                 sh "ssh-keygen -f \"$HOME/.ssh/known_hosts\" -R ${servername}-instance.dev.osgp.cloud"

--- a/runTestsAtRemoteServer.sh
+++ b/runTestsAtRemoteServer.sh
@@ -45,7 +45,7 @@ echo "  [${CMD}]"
 ${CMD}
 
 echo "- Executing cucumber project ${PROJECT} remote on ${SERVER} ..."
-CMD="sudo ${XVFB} java -javaagent:/usr/share/tomcat/lib/jacocoagent.jar=destfile=target/code-coverage/jacoco-it.exec ${ADDITIONAL_PARAMETERS} -Dcucumber.options=\"--tags 'not @Skip' --strict ${ADDITIONAL_CUCUMBER_OPTIONS}\" -DskipITs=false -Dtimeout=30 -DskipITCoverage=false -jar cucumber-*-test-jar-with-dependencies.jar -report target/output; sudo chown -R ${USER}:${USER} /data/software/${PROJECT}/*"
+CMD="sudo ${XVFB} java -javaagent:/usr/share/tomcat/lib/jacocoagent.jar=destfile=target/code-coverage/jacoco-it.exec ${ADDITIONAL_PARAMETERS} -Dcucumber.execution.strict=true -Dcucumber.filter.tags=\"not @Skip ${ADDITIONAL_CUCUMBER_OPTIONS}\" -DskipITs=false -Dtimeout=30 -DskipITCoverage=false -jar cucumber-*-test-jar-with-dependencies.jar -report target/output; sudo chown -R ${USER}:${USER} /data/software/${PROJECT}/*"
 echo "  [${CMD}]"
 CMD="ssh -oStrictHostKeyChecking=no -oTCPKeepAlive=yes -oServerAliveInterval=50 ${SSH_KEY_FILE} ${USER}@${SERVER} \"\"cd /data/software/${PROJECT} && ${CMD}\"\""
 ${CMD}

--- a/super/pom.xml
+++ b/super/pom.xml
@@ -118,7 +118,7 @@
     <SunriseSunsetCalculator.version>1.2</SunriseSunsetCalculator.version>
     <ant.junit.version>1.10.5</ant.junit.version>
     <args4j.version>2.33</args4j.version>
-    <cucumber.version>5.0.0</cucumber.version>
+    <cucumber.version>5.1.2</cucumber.version>
     <sun.httpserver.version>20070405</sun.httpserver.version>
     <postgresql.version>42.2.9</postgresql.version>
   </properties>

--- a/super/pom.xml
+++ b/super/pom.xml
@@ -17,7 +17,7 @@
   <version>5.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>super-osgp</name>
-  <!-- Description, Organization, Licences, URL and Distribution Management 
+  <!-- Description, Organization, Licences, URL and Distribution Management
     elements are needed for the maven-jxr-plugin to generate a maven site -->
   <description>Super pom for OSGP components.</description>
   <organization>
@@ -118,7 +118,7 @@
     <SunriseSunsetCalculator.version>1.2</SunriseSunsetCalculator.version>
     <ant.junit.version>1.10.5</ant.junit.version>
     <args4j.version>2.33</args4j.version>
-    <cucumber.version>4.2.6</cucumber.version>
+    <cucumber.version>5.0.0</cucumber.version>
     <sun.httpserver.version>20070405</sun.httpserver.version>
     <postgresql.version>42.2.9</postgresql.version>
   </properties>
@@ -710,6 +710,13 @@
         <version>${junit.version}</version>
         <scope>test</scope>
       </dependency>
+      <!-- Cucumber tests depend on JUnit 4, add the vintage engine -->
+      <dependency>
+        <groupId>org.junit.vintage</groupId>
+        <artifactId>junit-vintage-engine</artifactId>
+        <version>${junit.version}</version>
+        <scope>test</scope>
+      </dependency>
       <dependency>
         <groupId>org.junit.platform</groupId>
         <artifactId>junit-platform-launcher</artifactId>
@@ -783,11 +790,6 @@
       <dependency>
         <groupId>io.cucumber</groupId>
         <artifactId>cucumber-java</artifactId>
-        <version>${cucumber.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.cucumber</groupId>
-        <artifactId>cucumber-core</artifactId>
         <version>${cucumber.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
Refactors packages of Cucumber classes to the newer API. The core part
is considered internal and to be used through the java and junit
projects.

Add strict equals true to the AcceptanceTests classes as the non-strict
mode is deprecated, and will be removed in a future version. This
prevents warnings in the output logs.

Updates settings handling in the steps, to get rid of issues because of
empty cells defaulting to null instead of the empty string as before.

Updates step method annotations where the step definition text with the
step methods is not wrapped between "^" and "$" and the step has
parameters. These are now considered Cucumber expressions instead of
regular expressions. For Cucumber expressions a different syntax is
needed to match the arguments.

Updates the Configurer to no longer implement TypeRegistryConfigurer.
The configurers registers some default step data transformers without
implementing an interface of which only one implementation is allowed on
the glue path. This should offer flexibility in adding custom
transformer functionality with other step classes as needed, without
having to configure this in a single class.

Adds the junit-vintage-engine to the POMs of projects with Cucumber
tests. The current setup of Cucumber depends on JUnit 4.

Uncommented and at-skipped a feature in
TariffSwitchingResponseDataCleanupJob.feature in
cucumber-tests-platform-publiclighting. A feature file without any
contents leads to errors when running the Cucumber tests.