### PR TITLE
FLEX-5239 ~ Fix Cucumber 5 related nightly build issues

### DIFF
--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/builders/entities/BaseDeviceBuilder.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/builders/entities/BaseDeviceBuilder.java
@@ -12,6 +12,7 @@ import java.net.UnknownHostException;
 import java.util.Date;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.opensmartgridplatform.cucumber.platform.PlatformDefaults;
 import org.opensmartgridplatform.cucumber.platform.inputparsers.DateInputParser;
 import org.opensmartgridplatform.cucumber.platform.smartmetering.PlatformSmartmeteringDefaults;
@@ -201,14 +202,12 @@ public abstract class BaseDeviceBuilder<T extends BaseDeviceBuilder<T>> {
         }
 
         if (inputSettings.containsKey(PlatformSmartmeteringKeys.NETWORK_ADDRESS)) {
-            if (inputSettings.get(PlatformSmartmeteringKeys.NETWORK_ADDRESS).isEmpty()) {
+            if (StringUtils.isBlank(inputSettings.get(PlatformSmartmeteringKeys.NETWORK_ADDRESS))) {
                 this.setNetworkAddress(null);
             } else {
                 try {
-                    if (inputSettings.containsKey(PlatformSmartmeteringKeys.NETWORK_ADDRESS)) {
-                        this.setNetworkAddress(
-                                InetAddress.getByName(inputSettings.get(PlatformSmartmeteringKeys.NETWORK_ADDRESS)));
-                    }
+                    this.setNetworkAddress(
+                            InetAddress.getByName(inputSettings.get(PlatformSmartmeteringKeys.NETWORK_ADDRESS)));
                 } catch (final UnknownHostException e) {
                     LOGGER.error("Exception occured while setting InetAddress for device.", e);
                 }

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/builders/entities/SecurityKeyBuilder.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/builders/entities/SecurityKeyBuilder.java
@@ -7,6 +7,8 @@
  */
 package org.opensmartgridplatform.cucumber.platform.smartmetering.builders.entities;
 
+import static org.opensmartgridplatform.cucumber.core.ReadSettingsHelper.getString;
+
 import java.util.Date;
 import java.util.Map;
 
@@ -76,32 +78,32 @@ public class SecurityKeyBuilder implements CucumberBuilder<SecurityKey> {
 
         if (SecurityKeyType.E_METER_AUTHENTICATION == this.securityKeyType
                 && inputSettings.containsKey(PlatformSmartmeteringKeys.SECURITY_KEY_A)) {
-            this.setKey(inputSettings.get(PlatformSmartmeteringKeys.SECURITY_KEY_A));
+            this.setKey(getString(inputSettings, PlatformSmartmeteringKeys.SECURITY_KEY_A));
         }
 
         if (SecurityKeyType.E_METER_MASTER == this.securityKeyType
                 && inputSettings.containsKey(PlatformSmartmeteringKeys.SECURITY_KEY_M)) {
-            this.setKey(inputSettings.get(PlatformSmartmeteringKeys.SECURITY_KEY_M));
+            this.setKey(getString(inputSettings, PlatformSmartmeteringKeys.SECURITY_KEY_M));
         }
 
         if (SecurityKeyType.E_METER_ENCRYPTION == this.securityKeyType
                 && inputSettings.containsKey(PlatformSmartmeteringKeys.SECURITY_KEY_E)) {
-            this.setKey(inputSettings.get(PlatformSmartmeteringKeys.SECURITY_KEY_E));
+            this.setKey(getString(inputSettings, PlatformSmartmeteringKeys.SECURITY_KEY_E));
         }
 
         if (SecurityKeyType.G_METER_MASTER == this.securityKeyType
                 && inputSettings.containsKey(PlatformSmartmeteringKeys.MBUS_DEFAULT_KEY)) {
-            this.setKey(inputSettings.get(PlatformSmartmeteringKeys.MBUS_DEFAULT_KEY));
+            this.setKey(getString(inputSettings, PlatformSmartmeteringKeys.MBUS_DEFAULT_KEY));
         }
 
         if (SecurityKeyType.G_METER_ENCRYPTION == this.securityKeyType
                 && inputSettings.containsKey(PlatformSmartmeteringKeys.MBUS_USER_KEY)) {
-            this.setKey(inputSettings.get(PlatformSmartmeteringKeys.MBUS_USER_KEY));
+            this.setKey(getString(inputSettings, PlatformSmartmeteringKeys.MBUS_USER_KEY));
         }
 
         if (SecurityKeyType.PASSWORD == this.securityKeyType
                 && inputSettings.containsKey(PlatformSmartmeteringKeys.PASSWORD)) {
-            this.setKey(inputSettings.get(PlatformSmartmeteringKeys.PASSWORD));
+            this.setKey(getString(inputSettings, PlatformSmartmeteringKeys.PASSWORD));
         }
 
         return this;


### PR DESCRIPTION
FLEX-5239 ~Fixes Cucumber 5 related nightly build issues smart metering

Fixes Cucumber step code that was broken due to the different handling
of empty data table cells with Cucumber 5 (null instead of empty
string).