### PR TITLE
OC-533 Makes build fail on error running tests

### DIFF
--- a/jenkins/pipeline/osgp-nightly-build.groovy
+++ b/jenkins/pipeline/osgp-nightly-build.groovy
@@ -80,7 +80,7 @@ pipeline {
                 archiveArtifacts '**/target/*.tgz'
 
                 // Check the console log for failed tests
-                step([$class: 'LogParserPublisher', projectRulePath: 'console-test-result-rules', unstableOnWarning: true, useProjectRule: true])
+                step([$class: 'LogParserPublisher', projectRulePath: 'console-test-result-rules', unstableOnWarning: true, failBuildOnError: true, useProjectRule: true])
             }
         }
     }
@@ -88,7 +88,7 @@ pipeline {
     post {
         always {
             echo "End of pipeline"
-            build job: 'Destroy an AWS System', parameters: [string(name: 'SERVERNAME', value: servername), string(name: 'PLAYBOOK', value: playbook)]            
+            build job: 'Destroy an AWS System', parameters: [string(name: 'SERVERNAME', value: servername), string(name: 'PLAYBOOK', value: playbook)]
         }
         failure {
             emailext (

--- a/jenkins/pipeline/osgp-pr-build.groovy
+++ b/jenkins/pipeline/osgp-pr-build.groovy
@@ -176,7 +176,7 @@ echo Found cucumber tags: [$EXTRACTED_TAGS]'''
                 archiveArtifacts '**/target/*.tgz'
 
                 // Check the console log for failed tests
-                step([$class: 'LogParserPublisher', projectRulePath: 'console-test-result-rules', unstableOnWarning: true, useProjectRule: true])
+                step([$class: 'LogParserPublisher', projectRulePath: 'console-test-result-rules', unstableOnWarning: true, failBuildOnError: true, useProjectRule: true])
             }
         }
     } // stages


### PR DESCRIPTION
When an error is introduced in the Spring or glue context of Cucumber
tests an error is thrown preventing further tests to be executed.
This happens because the Cucumber feature runner makes the JUnit runner
abort the tests throwing a StoppedByUserException.
In such cases the Jenkins console log contains the text "End. Retval =
1", but does not contain any information on failed scenarios.
The LogParserPublisher Jenkins plugin which is activated in order to
check the log for issues with the build has configuration in a file
named console-test-rules marking this situation as an error.
By adding parameter failBuildOnError with value true, the build will be
failed when the LogParserPublisher determines an error has occurred.