### PR TITLE
FLEX-5274 ~ Fix issues in Cucumber set up IEC 60870

### DIFF
--- a/integration-tests/cucumber-tests-platform-distributionautomation/pom.xml
+++ b/integration-tests/cucumber-tests-platform-distributionautomation/pom.xml
@@ -167,7 +167,7 @@
               </descriptors>
               <archive>
                 <manifest>
-                  <mainClass>org.opensmartgridplatform.cucumber.platform.microgrids.App</mainClass>
+                  <mainClass>org.opensmartgridplatform.cucumber.platform.distributionautomation.App</mainClass>
                 </manifest>
               </archive>
             </configuration>

--- a/integration-tests/cucumber-tests-platform-distributionautomation/src/test/java/org/opensmartgridplatform/cucumber/platform/distributionautomation/AcceptanceTests.java
+++ b/integration-tests/cucumber-tests-platform-distributionautomation/src/test/java/org/opensmartgridplatform/cucumber/platform/distributionautomation/AcceptanceTests.java
@@ -16,9 +16,7 @@ import io.cucumber.junit.CucumberOptions;
 import io.cucumber.junit.CucumberOptions.SnippetType;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(
-        features = { "classpath:features/osgp-adapter-ws-distributionautomation",
-                "classpath:features/osgp-adapter-ws-core" },
+@CucumberOptions(features = { "classpath:features/osgp-adapter-ws-distributionautomation" },
         tags = { "not @Skip", "not @NightlyBuildOnly" },
         glue = { "classpath:org.opensmartgridplatform.cucumber.platform.glue",
                 "classpath:org.opensmartgridplatform.cucumber.platform.common.glue",

--- a/integration-tests/cucumber-tests-platform-distributionautomation/src/test/resources/features/osgp-adapter-ws-distributionautomation/ReceiveMeasurementReports.feature
+++ b/integration-tests/cucumber-tests-platform-distributionautomation/src/test/resources/features/osgp-adapter-ws-distributionautomation/ReceiveMeasurementReports.feature
@@ -1,5 +1,5 @@
 @DistributionAutomation @Platform @MeasurementReports
-Feature: Receive measurement reports
+Feature: DistributionAutomation Receive measurement reports
   As a grid operator
   I want to receive measurement reports from an IEC 60870 device
   So I get updates about the current state of the device

--- a/jenkins/pipeline/osgp-nightly-build.groovy
+++ b/jenkins/pipeline/osgp-nightly-build.groovy
@@ -56,6 +56,7 @@ pipeline {
                 sh "./runPubliclightingTestsAtRemoteServer.sh ${servername}-instance.dev.osgp.cloud integration-tests cucumber-tests-platform-publiclighting centos \"OSGP Development.pem\""
                 sh "./runMicrogridsTestsAtRemoteServer.sh ${servername}-instance.dev.osgp.cloud integration-tests cucumber-tests-platform-microgrids centos \"OSGP Development.pem\""
                 sh "./runSmartMeteringTestsAtRemoteServer.sh ${servername}-instance.dev.osgp.cloud integration-tests cucumber-tests-platform-smartmetering centos \"OSGP Development.pem\""
+                sh "./runDistributionAutomationTestsAtRemoteServer.sh ${servername}-instance.dev.osgp.cloud integration-tests cucumber-tests-platform-distributionautomation centos \"OSGP Development.pem\""
             }
         }
 

--- a/jenkins/pipeline/osgp-pr-build.groovy
+++ b/jenkins/pipeline/osgp-pr-build.groovy
@@ -5,7 +5,7 @@ def servername = stream + '-at-pr-' + env.BUILD_NUMBER
 def playbook = stream + '-at.yml'
 
 // Choose the branch to use for SmartSocietyServices/release repository. Default value is 'master'.
-def branchReleaseRepo = 'master'
+def branchReleaseRepo = 'bug/FLEX-5274-issues-running-cucumber-tests-platform-da'
 
 pipeline {
     agent {

--- a/jenkins/pipeline/osgp-pr-build.groovy
+++ b/jenkins/pipeline/osgp-pr-build.groovy
@@ -75,11 +75,7 @@ pipeline {
                 sh "cd release && plays/download-artifacts.yml -e artifactstodownload='{{ configuration_artifacts }}' -e deployment_type=snapshot -e osgp_version=${POMVERSION} -e tmp_artifacts_directory=../../target/artifacts"
                 sh "cd release && plays/download-artifacts.yml -e artifactstodownload='{{ dlms_simulator_artifacts }}' -e deployment_type=snapshot -e osgp_version=${POMVERSION} -e tmp_artifacts_directory=../../target/artifacts"
                 // Make sure a standalone version of the dlms device simulator is present
-// Ruud, temporarily modify the version number by copying the DLMS simulator files
                 sh "cp -p target/artifacts/dlms-device-simulator-${POMVERSION}.jar target/artifacts/dlms-device-simulator-${POMVERSION}-standalone.jar"
-                
-                // I think this step is superfluous now. The build fails with error: cp: ‘target/artifacts/osgp-simulator-dlms-triggered-5.0.0-SNAPSHOT.war’ and ‘target/artifacts/osgp-simulator-dlms-triggered-5.0.0-SNAPSHOT.war’ are the same file
-                //sh "cp -p target/artifacts/osgp-simulator-dlms-triggered-${POMVERSION}.war target/artifacts/osgp-simulator-dlms-triggered-${POMVERSION}.war"
 
                 // Now create a new single instance (not stream specific) and put all the artifacts in /data/software/artifacts
                 sh "cd release && plays/deploy-files-to-system.yml -e osgp_version=${POMVERSION} -e deployment_name=${servername} -e directory_to_deploy=../../target/artifacts -e tomcat_restart=false -e ec2_instance_type=m4.xlarge -e ami_name=CentOS6SingleInstance -e ami_owner=self"
@@ -157,6 +153,7 @@ echo Found cucumber tags: [$EXTRACTED_TAGS]'''
                 sh "./runPubliclightingTestsAtRemoteServer.sh ${servername}-instance.dev.osgp.cloud integration-tests cucumber-tests-platform-publiclighting centos \"OSGP Development.pem\" \"\" \"\" \"`cat \"${WORKSPACE}/cucumber-tags\"`\""
                 sh "./runMicrogridsTestsAtRemoteServer.sh ${servername}-instance.dev.osgp.cloud integration-tests cucumber-tests-platform-microgrids centos \"OSGP Development.pem\" \"\" \"\" \"`cat \"${WORKSPACE}/cucumber-tags\"`\""
                 sh "./runSmartMeteringTestsAtRemoteServer.sh ${servername}-instance.dev.osgp.cloud integration-tests cucumber-tests-platform-smartmetering centos \"OSGP Development.pem\" \"\" \"\" \"`cat \"${WORKSPACE}/cucumber-tags\"`\""
+                sh "./runDistributionAutomationTestsAtRemoteServer.sh ${servername}-instance.dev.osgp.cloud integration-tests cucumber-tests-platform-distributionautomation centos \"OSGP Development.pem\" \"\" \"\" \"`cat \"${WORKSPACE}/cucumber-tags\"`\""
             }
         } // stage
 

--- a/osgp/protocol-adapter-iec60870/osgp-protocol-adapter-iec60870/pom.xml
+++ b/osgp/protocol-adapter-iec60870/osgp-protocol-adapter-iec60870/pom.xml
@@ -265,12 +265,12 @@
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
     </dependency>
-      <!-- Cucumber tests depend on JUnit 4, add the vintage engine -->
-      <dependency>
-        <groupId>org.junit.vintage</groupId>
-        <artifactId>junit-vintage-engine</artifactId>
-        <scope>test</scope>
-      </dependency>
+    <!-- Cucumber tests depend on JUnit 4, add the vintage engine -->
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>

--- a/osgp/protocol-adapter-iec60870/osgp-protocol-adapter-iec60870/pom.xml
+++ b/osgp/protocol-adapter-iec60870/osgp-protocol-adapter-iec60870/pom.xml
@@ -17,7 +17,7 @@
   <artifactId>osgp-protocol-adapter-iec60870</artifactId>
   <name>osgp-protocol-adapter-iec60870</name>
   <packaging>war</packaging>
-  <!-- Description, Organization, Licenses, URL and Distribution Management elements 
+  <!-- Description, Organization, Licenses, URL and Distribution Management elements
     are needed for the maven-jxr-plugin to generate a maven site -->
   <description>Protocol adapter for IEC60870-5-104 Protocol.</description>
 
@@ -30,8 +30,6 @@
 
   <properties>
     <display.version>${project.version}-${BUILD_TAG}</display.version>
-    <cucumber.version>4.8.0</cucumber.version>
-    <spring.test.version>4.3.23.RELEASE</spring.test.version>
     <skip.integration.tests>false</skip.integration.tests>
     <skip.unit.tests>false</skip.unit.tests>
 
@@ -267,6 +265,12 @@
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
     </dependency>
+      <!-- Cucumber tests depend on JUnit 4, add the vintage engine -->
+      <dependency>
+        <groupId>org.junit.vintage</groupId>
+        <artifactId>junit-vintage-engine</artifactId>
+        <scope>test</scope>
+      </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>

--- a/runDistributionAutomationTestsAtRemoteServer.sh
+++ b/runDistributionAutomationTestsAtRemoteServer.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+./runTestsAtRemoteServer.sh $1 $2 $3 $4 "$5" "-Ddevice.networkaddress=127.0.0.1 -Diec60870.mock.networkaddress=127.0.0.1 -Diec60870.mock.port=62404 -Diec60870.mock.connection.timeout=5000 $6"  "$7" "$8"


### PR DESCRIPTION
Removes version properties for Cucumber and Spring Test from the
protocol adapter IEC60870 POM to align with versions from the super POM.
Adds a dependency to the JUnit vintage engine so the TestRunnerIT will
be executed to trigger the Cucumber component tests.

Fixes copy paste mistakes in the Cucumber tests for platform
distribution automation. Removes reference to features not present in
this project from the CucumberOptions in AcceptanceTests.
Changes the mainClass in the POM for the jar with dependencies to the
App that belongs with the distribution automation project and which is
present in the resulting jar, so that the jar can be executed.

Adapts the Jenkins pipelines to include Distribution Automation tests.