### PR TITLE
FLEX-5278 ~ Explicitly deals with optional value from DB not present

### DIFF
--- a/osgp/platform/osgp-adapter-domain-core/src/main/java/org/opensmartgridplatform/adapter/domain/core/application/services/AbstractService.java
+++ b/osgp/platform/osgp-adapter-domain-core/src/main/java/org/opensmartgridplatform/adapter/domain/core/application/services/AbstractService.java
@@ -7,6 +7,8 @@
  */
 package org.opensmartgridplatform.adapter.domain.core.application.services;
 
+import javax.persistence.EntityNotFoundException;
+
 import org.opensmartgridplatform.adapter.domain.core.application.mapping.DomainCoreMapper;
 import org.opensmartgridplatform.adapter.domain.core.infra.jms.core.OsgpCoreRequestMessageSender;
 import org.opensmartgridplatform.adapter.domain.core.infra.jms.ws.WebServiceResponseMessageSender;
@@ -60,6 +62,7 @@ public class AbstractService {
     }
 
     protected Ssld findSsldForDevice(final Device device) {
-        return this.ssldRepository.findById(device.getId()).get();
+        return this.ssldRepository.findById(device.getId())
+                .orElseThrow(() -> new EntityNotFoundException("SSLD with id: " + device.getId() + " not found."));
     }
 }


### PR DESCRIPTION
If an entity was not found an explicit exception is thrown indicating
the type and ID, instead of the no such element exception of optional
when get is called without checking isPresent first.