### PR TITLE
OC-557 ~ Prevents long running database transaction.

### DIFF
--- a/osgp/protocol-adapter-oslp/web-device-simulator/src/main/java/org/opensmartgridplatform/webdevicesimulator/application/services/OslpLogService.java
+++ b/osgp/protocol-adapter-oslp/web-device-simulator/src/main/java/org/opensmartgridplatform/webdevicesimulator/application/services/OslpLogService.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2020 Smart Society Services B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.opensmartgridplatform.webdevicesimulator.application.services;
+
+import org.opensmartgridplatform.oslp.OslpEnvelope;
+import org.opensmartgridplatform.webdevicesimulator.domain.entities.Device;
+import org.opensmartgridplatform.webdevicesimulator.domain.entities.OslpLogItem;
+import org.opensmartgridplatform.webdevicesimulator.domain.repositories.OslpLogItemRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class OslpLogService {
+
+    @Autowired
+    private OslpLogItemRepository oslpLogItemRepository;
+
+    @Transactional
+    public OslpLogItem writeOslpLogItem(final OslpEnvelope oslpEnvelope, final Device device, final boolean incoming) {
+        final OslpLogItem logItem = new OslpLogItem(oslpEnvelope.getDeviceId(), device.getDeviceIdentification(),
+                incoming, oslpEnvelope.getPayloadMessage());
+        return this.oslpLogItemRepository.save(logItem);
+    }
+}


### PR DESCRIPTION
The function `sendEventNotificationCommand()` was annotated with
`@Transactional`. This made sure the `OslpLogItem` could be saved. But
this function also creates a TCP connection to actually send an event
from the simulator to the protocol adapter. In case this TCP connection
hangs/errors/times-out the database transaction will be blocked during
that time.

The new class `OslpLogService` makes sure that the database transaction
required for saving an `OslpLogItem` is small and fast.