### PR TITLE
OC-526 ~ Adds dependency analysis reporting

### DIFF
--- a/integration-tests/parent-integration-tests/pom.xml
+++ b/integration-tests/parent-integration-tests/pom.xml
@@ -139,21 +139,6 @@
   <build>
     <pluginManagement>
       <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-checkstyle-plugin</artifactId>
-          <version>${checkstyle.version}</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-pmd-plugin</artifactId>
-          <version>${pmd.version}</version>
-        </plugin>
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>findbugs-maven-plugin</artifactId>
-          <version>${findbug.version}</version>
-        </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/jenkins/pipeline/osgp-dependency-check-build.groovy
+++ b/jenkins/pipeline/osgp-dependency-check-build.groovy
@@ -19,7 +19,13 @@ pipeline {
                         maven: 'Apache Maven 3.6.2',
                         mavenLocalRepo: '.repository',
                         publisherStrategy: 'EXPLICIT') {
-                    sh "mvn -V -B clean install site -Dmaven.test.skip=true -DskipTests=true -DskipITs=true -Dmaven.site.distributionManagement.site.url="
+                    sh "mvn -V -B -T 1C clean install -Dmaven.test.skip=true -DskipTests=true -DskipITs=true -Dmaven.site.distributionManagement.site.url="
+                }
+                withMaven(
+                        maven: 'Apache Maven 3.6.2',
+                        mavenLocalRepo: '.repository',
+                        publisherStrategy: 'EXPLICIT') {
+                    sh "mvn -V -B site -Dmaven.site.distributionManagement.site.url="
                 }
                 publishHTML(target: [
                         allowMissing: false,

--- a/jenkins/pipeline/osgp-dependency-check-build.groovy
+++ b/jenkins/pipeline/osgp-dependency-check-build.groovy
@@ -19,7 +19,7 @@ pipeline {
                         maven: 'Apache Maven 3.6.2',
                         mavenLocalRepo: '.repository',
                         publisherStrategy: 'EXPLICIT') {
-                    sh "mvn -V -B -T 1C clean install site -DskipTests=true -DskipITs=true -Dmaven.site.distributionManagement.site.url="
+                    sh "mvn -V -B -T 1C clean install site -DskipTests=true -DskipITs=true -Dmaven.version.rules=file://$(pwd)/super/versions-plugin-rules.xml -Dmaven.site.distributionManagement.site.url="
                 }
                 publishHTML(target: [
                         allowMissing: false,

--- a/jenkins/pipeline/osgp-dependency-check-build.groovy
+++ b/jenkins/pipeline/osgp-dependency-check-build.groovy
@@ -18,10 +18,7 @@ pipeline {
                 withMaven(
                         maven: 'Apache Maven 3.6.2',
                         mavenLocalRepo: '.repository',
-                        publisherStrategy: 'EXPLICIT',
-                        options: [
-                                sitePublisher(disabled: false)
-                        ]) {
+                        publisherStrategy: 'EXPLICIT') {
                     sh "mvn -V -B clean site -Dmaven.site.distributionManagement.site.url="
                 }
                 publishHTML(target: [

--- a/jenkins/pipeline/osgp-dependency-check-build.groovy
+++ b/jenkins/pipeline/osgp-dependency-check-build.groovy
@@ -19,13 +19,7 @@ pipeline {
                         maven: 'Apache Maven 3.6.2',
                         mavenLocalRepo: '.repository',
                         publisherStrategy: 'EXPLICIT') {
-                    sh "mvn -V -B -T 1C clean install -Dmaven.test.skip=true -DskipTests=true -DskipITs=true -Dmaven.site.distributionManagement.site.url="
-                }
-                withMaven(
-                        maven: 'Apache Maven 3.6.2',
-                        mavenLocalRepo: '.repository',
-                        publisherStrategy: 'EXPLICIT') {
-                    sh "mvn -V -B site -Dmaven.site.distributionManagement.site.url="
+                    sh "mvn -V -B -T 1C clean install site -DskipTests=true -DskipITs=true -Dmaven.site.distributionManagement.site.url="
                 }
                 publishHTML(target: [
                         allowMissing: false,

--- a/jenkins/pipeline/osgp-dependency-check-build.groovy
+++ b/jenkins/pipeline/osgp-dependency-check-build.groovy
@@ -19,7 +19,7 @@ pipeline {
                         maven: 'Apache Maven 3.6.2',
                         mavenLocalRepo: '.repository',
                         publisherStrategy: 'EXPLICIT') {
-                    sh "mvn -V -B clean site -Dmaven.site.distributionManagement.site.url="
+                    sh "mvn -V -B clean install site -Dmaven.test.skip=true -DskipTests=true -DskipITs=true -Dmaven.site.distributionManagement.site.url="
                 }
                 publishHTML(target: [
                         allowMissing: false,

--- a/jenkins/pipeline/osgp-dependency-check-build.groovy
+++ b/jenkins/pipeline/osgp-dependency-check-build.groovy
@@ -19,7 +19,7 @@ pipeline {
                         maven: 'Apache Maven 3.6.2',
                         mavenLocalRepo: '.repository',
                         publisherStrategy: 'EXPLICIT') {
-                    sh "mvn -V -B -T 1C clean install site -DskipTests=true -DskipITs=true -Dmaven.version.rules=file://$(pwd)/super/versions-plugin-rules.xml -Dmaven.site.distributionManagement.site.url="
+                    sh "mvn -V -B -T 1C clean install site -DskipTests=true -DskipITs=true -Dmaven.version.rules=file://${pwd()}/super/versions-plugin-rules.xml -Dmaven.site.distributionManagement.site.url="
                 }
                 publishHTML(target: [
                         allowMissing: false,

--- a/jenkins/pipeline/osgp-dependency-check-build.groovy
+++ b/jenkins/pipeline/osgp-dependency-check-build.groovy
@@ -1,0 +1,57 @@
+// Pipeline script for the OSGP Dependency Check Build job in Jenkins
+
+pipeline {
+    agent any
+
+    options {
+        ansiColor('xterm')
+        timestamps()
+        timeout(240)
+        // Only keep the 10 most recent builds
+        buildDiscarder(logRotator(numToKeepStr:'10'))
+    }
+
+    stages {
+
+        stage('Maven Build') {
+            steps {
+                withMaven(
+                        maven: 'Apache Maven 3.6.2',
+                        mavenLocalRepo: '.repository',
+                        publisherStrategy: 'EXPLICIT',
+                        options: [
+                                sitePublisher(disabled: false)
+                        ]) {
+                    sh "mvn -V -B clean site -Dmaven.site.distributionManagement.site.url="
+                }
+                publishHTML(target: [
+                        allowMissing: false,
+                        alwaysLinkToLastBuild: true,
+                        keepAll: false,
+                        reportDir: 'super/target/site',
+                        reportFiles: '*.html',
+                        reportName: 'Maven Site Reports'
+                    ])
+            }
+        }
+
+    }
+
+    post {
+        always {
+            echo "End of pipeline"
+        }
+        failure {
+            emailext (
+                subject: '${DEFAULT_SUBJECT}',
+                body: '${DEFAULT_CONTENT}',
+                recipientProviders: [[$class: 'DevelopersRecipientProvider'], [$class: 'RequesterRecipientProvider']],
+                to: '${DEFAULT_RECIPIENTS}',
+                from: '${DEFAULT_REPLYTO}')
+        }
+        cleanup {
+            // Delete workspace folder.
+            cleanWs()
+        }
+    }
+}

--- a/osgp/protocol-adapter-iec60870/parent-pa-iec60870/pom.xml
+++ b/osgp/protocol-adapter-iec60870/parent-pa-iec60870/pom.xml
@@ -75,12 +75,7 @@
           <artifactId>maven-site-plugin</artifactId>
           <version>${maven.site.plugin}</version>
         </plugin>
-        
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-pmd-plugin</artifactId>
-          <version>${pmd.version}</version>
-        </plugin>
+
         <plugin>
           <groupId>com.mycila</groupId>
           <artifactId>license-maven-plugin</artifactId>

--- a/osgp/protocol-adapter-iec61850/parent-pa-iec61850/pom.xml
+++ b/osgp/protocol-adapter-iec61850/parent-pa-iec61850/pom.xml
@@ -75,12 +75,7 @@
           <artifactId>maven-site-plugin</artifactId>
           <version>${maven.site.plugin}</version>
         </plugin>
-        
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-pmd-plugin</artifactId>
-          <version>${pmd.version}</version>
-        </plugin>
+
         <plugin>
           <groupId>com.mycila</groupId>
           <artifactId>license-maven-plugin</artifactId>

--- a/super/pom.xml
+++ b/super/pom.xml
@@ -82,7 +82,7 @@
     <orika.version>1.5.4</orika.version>
     <jxr.version>3.0.0</jxr.version>
     <maven.project.info.reports.plugin.version>3.0.0</maven.project.info.reports.plugin.version>
-    <maven.site.plugin>3.8.2</maven.site.plugin>
+    <maven.site.plugin>3.9.0</maven.site.plugin>
     <maven.javadoc.version>3.1.1</maven.javadoc.version>
     <maven.jar.plugin.version>3.2.0</maven.jar.plugin.version>
     <maven.war.plugin.version>3.2.3</maven.war.plugin.version>
@@ -1036,6 +1036,9 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>versions-maven-plugin</artifactId>
         <version>${versions.maven.plugin.version}</version>
+        <configuration>
+          <rulesUri>file://${maven.multiModuleProjectDirectory}/super/versions-plugin-rules.xml</rulesUri>
+        </configuration>
         <reportSets>
           <reportSet>
             <reports>

--- a/super/pom.xml
+++ b/super/pom.xml
@@ -92,6 +92,11 @@
     <maven.eclipse.plugin.version>2.10</maven.eclipse.plugin.version>
     <maven.exec.plugin.version>1.6.0</maven.exec.plugin.version>
     <jaxb2.maven.plugin.version>2.5.0</jaxb2.maven.plugin.version>
+    <spotbugs.maven.plugin.version>3.1.12.2</spotbugs.maven.plugin.version>
+    <pmd.maven.plugin.version>3.13.0</pmd.maven.plugin.version>
+    <checkstyle.maven.plugin.version>3.1.1</checkstyle.maven.plugin.version>
+    <dependency-check.maven.plugin.version>5.3.0</dependency-check.maven.plugin.version>
+    <versions.maven.plugin.version>2.7</versions.maven.plugin.version>
     <apache.activemq.version>5.15.11</apache.activemq.version>
     <logback.version>1.2.3</logback.version>
     <logback.ext.version>0.1.5</logback.ext.version>
@@ -112,8 +117,7 @@
     <protobuf.version>2.4.1</protobuf.version>
     <protobuf.maven.plugin>0.6.5</protobuf.maven.plugin>
     <guava.version>28.2-jre</guava.version>
-    <pmd.version>4.3</pmd.version>
-    <checkstyle.version>8.18</checkstyle.version>
+    <spotbugs.version>4.0.0</spotbugs.version>
     <jacoco.version>0.8.5</jacoco.version>
     <selenium.java.version>3.141.59</selenium.java.version>
     <SunriseSunsetCalculator.version>1.2</SunriseSunsetCalculator.version>
@@ -866,6 +870,20 @@
     </dependencies>
   </dependencyManagement>
 
+  <dependencies>
+    <!-- Dependency to tools jar added to prevent dependency-check errors:
+      Error generating dependency-check-maven:5.3.0:aggregate report: One or more
+      exceptions occurred during dependency-check analysis: One or more exceptions
+      occurred during analysis: Unable to resolve system scoped dependency: com.sun:tools:jar:1.8.0:system -->
+    <dependency>
+      <groupId>com.sun</groupId>
+      <artifactId>tools</artifactId>
+      <version>1.8.0</version>
+      <scope>system</scope>
+      <systemPath>${tools-jar}</systemPath>
+    </dependency>
+  </dependencies>
+
   <build>
     <pluginManagement>
       <plugins>
@@ -910,6 +928,40 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-site-plugin</artifactId>
           <version>${maven.site.plugin}</version>
+        </plugin>
+
+        <plugin>
+          <groupId>com.github.spotbugs</groupId>
+          <artifactId>spotbugs-maven-plugin</artifactId>
+          <version>${spotbugs.maven.plugin.version}</version>
+          <dependencies>
+            <dependency>
+              <groupId>com.github.spotbugs</groupId>
+              <artifactId>spotbugs</artifactId>
+              <version>${spotbugs.version}</version>
+            </dependency>
+          </dependencies>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-checkstyle-plugin</artifactId>
+          <version>${checkstyle.maven.plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-pmd-plugin</artifactId>
+          <version>${pmd.maven.plugin.version}</version>
+        </plugin>
+
+        <plugin>
+          <groupId>org.owasp</groupId>
+          <artifactId>dependency-check-maven</artifactId>
+          <version>${dependency-check.maven.plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>versions-maven-plugin</artifactId>
+          <version>${versions.maven.plugin.version}</version>
         </plugin>
 
         <plugin>
@@ -968,6 +1020,60 @@
         <artifactId>maven-jxr-plugin</artifactId>
         <version>${jxr.version}</version>
       </plugin>
+      <plugin>
+        <groupId>org.owasp</groupId>
+        <artifactId>dependency-check-maven</artifactId>
+        <version>${dependency-check.maven.plugin.version}</version>
+        <reportSets>
+          <reportSet>
+            <reports>
+              <report>aggregate</report>
+            </reports>
+          </reportSet>
+        </reportSets>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>versions-maven-plugin</artifactId>
+        <version>${versions.maven.plugin.version}</version>
+        <reportSets>
+          <reportSet>
+            <reports>
+              <report>dependency-updates-report</report>
+              <report>plugin-updates-report</report>
+              <report>property-updates-report</report>
+            </reports>
+          </reportSet>
+        </reportSets>
+      </plugin>
     </plugins>
   </reporting>
+
+  <profiles>
+    <profile>
+      <id>default-tools-profile</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+        <file>
+          <exists>${java.home}/../lib/tools.jar</exists>
+        </file>
+      </activation>
+      <properties>
+        <tools-jar>${java.home}/../lib/tools.jar</tools-jar>
+      </properties>
+    </profile>
+    <profile>
+      <id>mac-tools-profile</id>
+      <activation>
+        <file>
+          <missing>${java.home}/../lib/tools.jar</missing>
+          <exists>${java.home}/../Classes/classes.jar</exists>
+        </file>
+      </activation>
+      <properties>
+        <tools-jar>${java.home}/../Classes/classes.jar</tools-jar>
+      </properties>
+    </profile>
+  </profiles>
+
 </project>

--- a/super/pom.xml
+++ b/super/pom.xml
@@ -95,7 +95,7 @@
     <spotbugs.maven.plugin.version>3.1.12.2</spotbugs.maven.plugin.version>
     <pmd.maven.plugin.version>3.13.0</pmd.maven.plugin.version>
     <checkstyle.maven.plugin.version>3.1.1</checkstyle.maven.plugin.version>
-    <dependency-check.maven.plugin.version>5.3.0</dependency-check.maven.plugin.version>
+    <dependency-check.maven.plugin.version>5.3.1</dependency-check.maven.plugin.version>
     <versions.maven.plugin.version>2.7</versions.maven.plugin.version>
     <apache.activemq.version>5.15.11</apache.activemq.version>
     <logback.version>1.2.3</logback.version>

--- a/super/pom.xml
+++ b/super/pom.xml
@@ -1036,9 +1036,6 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>versions-maven-plugin</artifactId>
         <version>${versions.maven.plugin.version}</version>
-        <configuration>
-          <rulesUri>file://${maven.multiModuleProjectDirectory}/super/versions-plugin-rules.xml</rulesUri>
-        </configuration>
         <reportSets>
           <reportSet>
             <reports>

--- a/super/versions-plugin-rules.xml
+++ b/super/versions-plugin-rules.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset
+  xmlns="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  comparisonMethod="maven"
+  xsi:schemaLocation="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0 https://mojo.codehaus.org/versions-maven-plugin/xsd/rule-2.0.0.xsd">
+  <ignoreVersions>
+    <ignoreVersion type="regex">(?i).*[-\._](alpha|beta|m|rc)[-\._]?[0-9]*</ignoreVersion>
+  </ignoreVersions>
+</ruleset>

--- a/super/versions-plugin-rules.xml
+++ b/super/versions-plugin-rules.xml
@@ -10,7 +10,7 @@
   <rules>
     <rule groupId="org.postgresql" artifactId="postgresql">
       <ignoreVersions>
-        <ignoreVersion type="regex">(?i).*\.jre6</ignoreVersion>
+        <ignoreVersion type="regex">(?i).*\.jre[67]</ignoreVersion>
       </ignoreVersions>
     </rule>
   </rules>

--- a/super/versions-plugin-rules.xml
+++ b/super/versions-plugin-rules.xml
@@ -7,4 +7,11 @@
   <ignoreVersions>
     <ignoreVersion type="regex">(?i).*[-\._](alpha|beta|m|rc)[-\._]?[0-9]*</ignoreVersion>
   </ignoreVersions>
+  <rules>
+    <rule groupId="org.postgresql" artifactId="postgresql">
+      <ignoreVersions>
+        <ignoreVersion type="regex">(?i).*\.jre6</ignoreVersion>
+      </ignoreVersions>
+    </rule>
+  </rules>
 </ruleset>


### PR DESCRIPTION
Configures the aggregate report of the OWASP dependency-check-maven
plugin to analyze dependencies with potential security vulnerabilities.

Configures reports about dependency and plugin updates by the
versions-maven-plugin to get insight into dependencies and plugins with
newer versions than used.

Configures a system dependency for tools.jar (com.sun:tools:1.8.0) that
caused errors when missing during the dependency analysis. Takes into
account that this jar may not be present for some Java installations on
Mac OS and uses a suggested alternative (not tested).

Replaces the FindBugs plugin, which is no longer maintained, by its
successor the SpotBugs plugin. Sets the version in the POM (which was
missing for the FindBugs plugin causing errors during dependency
analysis in the build).

Replaces PMD and Checkstyle versions by the versions of the respective
maven plugins (the version of the plugin is different from the version
of the tool, which caused errors during dependency analysis since the
plugins did not exist for the versions of the tools in the POMs).

Cleans up plugin management configuration of the PMD, Checkstyle and
SpotBugs plugins.