### PR TITLE
OC-526 Skip system scoped dependencies in OWASP dependency check

### DIFF
--- a/super/pom.xml
+++ b/super/pom.xml
@@ -870,20 +870,6 @@
     </dependencies>
   </dependencyManagement>
 
-  <dependencies>
-    <!-- Dependency to tools jar added to prevent dependency-check errors:
-      Error generating dependency-check-maven:5.3.0:aggregate report: One or more
-      exceptions occurred during dependency-check analysis: One or more exceptions
-      occurred during analysis: Unable to resolve system scoped dependency: com.sun:tools:jar:1.8.0:system -->
-    <dependency>
-      <groupId>com.sun</groupId>
-      <artifactId>tools</artifactId>
-      <version>1.8.0</version>
-      <scope>system</scope>
-      <systemPath>${tools-jar}</systemPath>
-    </dependency>
-  </dependencies>
-
   <build>
     <pluginManagement>
       <plugins>
@@ -957,6 +943,16 @@
           <groupId>org.owasp</groupId>
           <artifactId>dependency-check-maven</artifactId>
           <version>${dependency-check.maven.plugin.version}</version>
+          <configuration>
+            <!-- Skip system scoped dependencies to prevent dependency-check errors:
+              Error generating dependency-check-maven:5.3.1:aggregate report: One or more
+              exceptions occurred during dependency-check analysis: One or more exceptions
+              occurred during analysis: Unable to resolve system scoped dependency: com.sun:tools:jar:1.8.0:system
+              An alternative would be to add com.sun:tools:jar:1.8.0:system as a system
+              scoped dependencies, but this would add tools.jar to all projects' build
+              dependencies. -->
+            <skipSystemScope>true</skipSystemScope>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
@@ -1048,32 +1044,5 @@
       </plugin>
     </plugins>
   </reporting>
-
-  <profiles>
-    <profile>
-      <id>default-tools-profile</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-        <file>
-          <exists>${java.home}/../lib/tools.jar</exists>
-        </file>
-      </activation>
-      <properties>
-        <tools-jar>${java.home}/../lib/tools.jar</tools-jar>
-      </properties>
-    </profile>
-    <profile>
-      <id>mac-tools-profile</id>
-      <activation>
-        <file>
-          <missing>${java.home}/../lib/tools.jar</missing>
-          <exists>${java.home}/../Classes/classes.jar</exists>
-        </file>
-      </activation>
-      <properties>
-        <tools-jar>${java.home}/../Classes/classes.jar</tools-jar>
-      </properties>
-    </profile>
-  </profiles>
 
 </project>


### PR DESCRIPTION
To resolve errors executing the aggregate report for the OWASP
dependency check plugin a system scoped dependency to tools.jar was
added. This lead however to this dependency being added to all projects
deriving from the super POM.
As an alternative system scoped dependencies can be skipped.