### PR TITLE
FLEX-5289 Configure javax.annotation-api in super POM

### DIFF
--- a/super/pom.xml
+++ b/super/pom.xml
@@ -107,6 +107,7 @@
     <beanit.openiec61850.version>1.8.0</beanit.openiec61850.version>
     <openmuc.j60870.version>1.3.1</openmuc.j60870.version>
     <javax.inject.version>1</javax.inject.version>
+    <javax.annotation.version>1.3.2</javax.annotation.version>
     <license.maven.plugin>3.0</license.maven.plugin>
     <jackson.version>2.10.3</jackson.version>
     <jackson-databind.version>2.10.3</jackson-databind.version>
@@ -455,6 +456,12 @@
         <groupId>javax.inject</groupId>
         <artifactId>javax.inject</artifactId>
         <version>${javax.inject.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>javax.annotation</groupId>
+        <artifactId>javax.annotation-api</artifactId>
+        <version>${javax.annotation.version}</version>
       </dependency>
 
       <!-- ws support -->


### PR DESCRIPTION
Adds the dependency to javax.annotation-api in the dependency
management section of the super POM.
In many projects the dependency is transitively present, and
mostly used in for example the javax.annotation.PostConstruct
annotation.
If it is used and not declared, maven dependency analysis will
warn about a used undeclared dependency. Having the dependency
configured in the super POM simplifies fixing the maven warning
without duplication of version metadata.