### PR TITLE
FLEX-5325 ~ Provides access to hard coded european time zone

### DIFF
--- a/integration-tests/cucumber-tests-core/src/test/java/org/opensmartgridplatform/cucumber/core/DateTimeHelper.java
+++ b/integration-tests/cucumber-tests-core/src/test/java/org/opensmartgridplatform/cucumber/core/DateTimeHelper.java
@@ -29,6 +29,13 @@ public class DateTimeHelper {
     private static final String CET_TIMEZONE = "Europe/Paris";
 
     /**
+     * @return CET/CEST time zone based on ID {@value #CET_TIMEZONE}
+     */
+    public static DateTimeZone getCentralEuropeanTimeZone() {
+        return DateTimeZone.forID(CET_TIMEZONE);
+    }
+
+    /**
      * This is a generic method which will translate the given string to a
      * datetime. Supported:
      * <p>


### PR DESCRIPTION
Provides a public method giving access to the time zone used in the
DateTimeHelper for central European time (CET/CEST).