### PR TITLE
FLEX-5325 Use central European time parsing flexible step dates

### DIFF
--- a/integration-tests/cucumber-tests-core/src/test/java/org/opensmartgridplatform/cucumber/core/DateTimeHelper.java
+++ b/integration-tests/cucumber-tests-core/src/test/java/org/opensmartgridplatform/cucumber/core/DateTimeHelper.java
@@ -37,7 +37,7 @@ public class DateTimeHelper {
 
     /**
      * This is a generic method which will translate the given string to a
-     * datetime. Supported:
+     * datetime using central European time (CET/CEST). Supported:
      * <p>
      * <ul>
      * <li>now + 3 months
@@ -57,7 +57,7 @@ public class DateTimeHelper {
             return null;
         }
 
-        DateTime retval = DateTime.now(getCentralEuropeanTimeZone()).withTimeAtStartOfDay();
+        DateTime retval = DateTime.now(getCentralEuropeanTimeZone());
 
         final String pattern = "([a-z ]*)[ ]*([+-]?)[ ]*([0-9]*)[ ]*([a-z]*)";
         final Pattern r = Pattern.compile(pattern);
@@ -97,6 +97,10 @@ public class DateTimeHelper {
                     + "], expected the string to begin with tomorrow, yesterday or now or today");
         }
 
+        // Normalize the seconds and milliseconds to zero
+        retval = retval.withSecondOfMinute(0);
+        retval = retval.withMillisOfSecond(0);
+
         if (whenMatcher.groupCount() > 1 && whenMatcher.group(2).equals("at")) {
 
             switch (whenMatcher.group(3)) {
@@ -111,6 +115,8 @@ public class DateTimeHelper {
                 throw new IllegalArgumentException(
                         "Invalid dateString [" + dateString + "], expected \"midday\", \"noon\" or \"midnight\"");
             }
+            retval = retval.withMinuteOfHour(0);
+            retval = retval.withSecondOfMinute(0);
         }
 
         if (op.equals("+")) {

--- a/integration-tests/cucumber-tests-core/src/test/java/org/opensmartgridplatform/cucumber/core/DateTimeHelper.java
+++ b/integration-tests/cucumber-tests-core/src/test/java/org/opensmartgridplatform/cucumber/core/DateTimeHelper.java
@@ -53,12 +53,11 @@ public class DateTimeHelper {
      * @throws Exception
      */
     public static DateTime getDateTime(final String dateString) {
-
-        DateTime retval;
-
         if (dateString.isEmpty()) {
             return null;
         }
+
+        DateTime retval = DateTime.now(getCentralEuropeanTimeZone()).withTimeAtStartOfDay();
 
         final String pattern = "([a-z ]*)[ ]*([+-]?)[ ]*([0-9]*)[ ]*([a-z]*)";
         final Pattern r = Pattern.compile(pattern);
@@ -85,23 +84,18 @@ public class DateTimeHelper {
         whenMatcher.find();
         switch (whenMatcher.group(1)) {
         case "tomorrow":
-            retval = DateTime.now().plusDays(1);
+            retval = retval.plusDays(1);
             break;
         case "yesterday":
-            retval = DateTime.now().minusDays(1);
+            retval = retval.minusDays(1);
             break;
         case "now":
         case "today":
-            retval = DateTime.now();
             break;
         default:
             throw new IllegalArgumentException("Invalid dateString [" + dateString
                     + "], expected the string to begin with tomorrow, yesterday or now or today");
         }
-
-        // Normalize the seconds and milliseconds to zero
-        retval = retval.withSecondOfMinute(0);
-        retval = retval.withMillisOfSecond(0);
 
         if (whenMatcher.groupCount() > 1 && whenMatcher.group(2).equals("at")) {
 
@@ -117,8 +111,6 @@ public class DateTimeHelper {
                 throw new IllegalArgumentException(
                         "Invalid dateString [" + dateString + "], expected \"midday\", \"noon\" or \"midnight\"");
             }
-            retval = retval.withMinuteOfHour(0);
-            retval = retval.withSecondOfMinute(0);
         }
 
         if (op.equals("+")) {

--- a/integration-tests/cucumber-tests-core/src/test/java/org/opensmartgridplatform/cucumber/core/TestGetDateTime.java
+++ b/integration-tests/cucumber-tests-core/src/test/java/org/opensmartgridplatform/cucumber/core/TestGetDateTime.java
@@ -10,21 +10,20 @@ package org.opensmartgridplatform.cucumber.core;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.joda.time.DateTime;
-import org.junit.jupiter.api.Assertions;
+import org.joda.time.DateTimeZone;
 import org.junit.jupiter.api.Test;
 
 public class TestGetDateTime {
 
+    private DateTimeZone cetTime = DateTimeHelper.getCentralEuropeanTimeZone();
+
     @Test
     public void testGetDateTime() {
-        try {
-            final DateTime nowPlus4 = new DateTime().plusMinutes(4);
-            final DateTime nowPlus6 = new DateTime().plusMinutes(6);
-            final DateTime dt = DateTimeHelper.getDateTime("now + 5 minutes");
-            assertThat(nowPlus4.getMillis() < dt.getMillis()).isTrue();
-            assertThat(nowPlus6.getMillis() > dt.getMillis()).isTrue();
-        } catch (final Exception e) {
-            Assertions.fail("error parsing date " + e);
-        }
+        final DateTime nowPlus4 = new DateTime(this.cetTime).plusMinutes(4);
+        final DateTime nowPlus6 = new DateTime(this.cetTime).plusMinutes(6);
+
+        final DateTime dt = DateTimeHelper.getDateTime("now + 5 minutes");
+
+        assertThat(dt).isStrictlyBetween(nowPlus4, nowPlus6);
     }
 }


### PR DESCRIPTION
Cucumber step data that has flexible date references like "tomorrow at
noon + 1 hour" is parsed returning dates in central European time zone.