### PR TITLE
FLEX-5297 Send end of initialization ASDU on first connection

### DIFF
--- a/osgp/protocol-adapter-iec60870/osgp-iec60870/src/main/java/org/opensmartgridplatform/iec60870/Iec60870ServerEventListener.java
+++ b/osgp/protocol-adapter-iec60870/osgp-iec60870/src/main/java/org/opensmartgridplatform/iec60870/Iec60870ServerEventListener.java
@@ -8,9 +8,15 @@
 package org.opensmartgridplatform.iec60870;
 
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.openmuc.j60870.ASdu;
+import org.openmuc.j60870.ASduType;
+import org.openmuc.j60870.CauseOfTransmission;
 import org.openmuc.j60870.Connection;
 import org.openmuc.j60870.ServerEventListener;
+import org.openmuc.j60870.ie.IeCauseOfInitialization;
+import org.openmuc.j60870.ie.InformationObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,15 +30,28 @@ public class Iec60870ServerEventListener implements ServerEventListener {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Iec60870ServerEventListener.class);
 
+    private static final ASdu END_OF_INITIALIZATION = new ASdu(ASduType.M_EI_NA_1, false,
+            CauseOfTransmission.INITIALIZED, false, false, 0, 0,
+            new InformationObject(0, new IeCauseOfInitialization(0, false)));
+
     private final Iec60870ConnectionRegistry iec60870ConnectionRegistry;
     private final Iec60870AsduHandlerRegistry iec60870AsduHandlerRegistry;
     private final int connectionTimeout;
+    private final boolean sendEndOfInitialization;
+    private AtomicBoolean initializationComplete = new AtomicBoolean(false);
 
     public Iec60870ServerEventListener(final Iec60870ConnectionRegistry iec60870ConnectionRegistry,
             final Iec60870AsduHandlerRegistry iec60870AsduHandlerRegistry, final int connectionTimeout) {
+        this(iec60870ConnectionRegistry, iec60870AsduHandlerRegistry, connectionTimeout, false);
+    }
+
+    public Iec60870ServerEventListener(final Iec60870ConnectionRegistry iec60870ConnectionRegistry,
+            final Iec60870AsduHandlerRegistry iec60870AsduHandlerRegistry, final int connectionTimeout,
+            final boolean sendEndOfInitialization) {
         this.iec60870ConnectionRegistry = iec60870ConnectionRegistry;
         this.iec60870AsduHandlerRegistry = iec60870AsduHandlerRegistry;
         this.connectionTimeout = connectionTimeout;
+        this.sendEndOfInitialization = sendEndOfInitialization;
     }
 
     @Override
@@ -47,9 +66,22 @@ public class Iec60870ServerEventListener implements ServerEventListener {
             LOGGER.error("Exception occurred while connection ({}) was waiting for StartDT.", connection, e);
             return;
         }
-
+        this.sendEndOfInitializationOnFirstConnection(connection);
         this.iec60870ConnectionRegistry.registerConnection(connection);
         LOGGER.info("Connection ({}) listening for incoming commands.", connection);
+    }
+
+    private void sendEndOfInitializationOnFirstConnection(final Connection connection) {
+        if (this.sendEndOfInitialization && this.initializationComplete.compareAndSet(false, true)) {
+            try {
+                LOGGER.info("Sending end of initialization ASDU on first connection");
+                connection.send(END_OF_INITIALIZATION);
+            } catch (final IOException e) {
+                LOGGER.error("Sending end of initialization ASDU on first connection failed", e);
+            }
+        } else {
+            LOGGER.debug("Not sending end of initialization ASDU as initialization was already complete");
+        }
     }
 
     @Override
@@ -61,5 +93,4 @@ public class Iec60870ServerEventListener implements ServerEventListener {
     public void connectionAttemptFailed(final IOException e) {
         LOGGER.warn("Connection attempt failed: {}", e.getMessage());
     }
-
 }

--- a/osgp/protocol-adapter-iec60870/osgp-protocol-adapter-iec60870/src/main/java/org/opensmartgridplatform/adapter/protocol/iec60870/domain/services/asduhandlers/EndOfInitializationAsduHandler.java
+++ b/osgp/protocol-adapter-iec60870/osgp-protocol-adapter-iec60870/src/main/java/org/opensmartgridplatform/adapter/protocol/iec60870/domain/services/asduhandlers/EndOfInitializationAsduHandler.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2020 Smart Society Services B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.opensmartgridplatform.adapter.protocol.iec60870.domain.services.asduhandlers;
+
+import org.openmuc.j60870.ASdu;
+import org.openmuc.j60870.ASduType;
+import org.opensmartgridplatform.adapter.protocol.iec60870.domain.services.AbstractClientAsduHandler;
+import org.opensmartgridplatform.adapter.protocol.iec60870.domain.valueobjects.ResponseMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Abstract class providing an implementation for handling end of initialization
+ * ASDUs.
+ */
+@Component
+public class EndOfInitializationAsduHandler extends AbstractClientAsduHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EndOfInitializationAsduHandler.class);
+
+    public EndOfInitializationAsduHandler() {
+        super(ASduType.M_EI_NA_1);
+    }
+
+    @Override
+    public void handleAsdu(final ASdu asdu, final ResponseMetadata responseMetadata) {
+        LOGGER.info("Controlled station for device {} is available after remote initialization.",
+                responseMetadata.getDeviceIdentification());
+    }
+}

--- a/osgp/protocol-adapter-iec60870/osgp-protocol-simulator-iec60870/src/main/java/org/opensmartgridplatform/simulator/protocol/iec60870/Iec60870SimulatorApplication.java
+++ b/osgp/protocol-adapter-iec60870/osgp-protocol-simulator-iec60870/src/main/java/org/opensmartgridplatform/simulator/protocol/iec60870/Iec60870SimulatorApplication.java
@@ -7,15 +7,16 @@
  */
 package org.opensmartgridplatform.simulator.protocol.iec60870;
 
-import org.springframework.boot.SpringApplication;
+import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.builder.SpringApplicationBuilder;
 
 @SpringBootApplication(exclude = { DataSourceAutoConfiguration.class })
 public class Iec60870SimulatorApplication {
 
     public static void main(final String[] args) {
-        SpringApplication.run(Iec60870SimulatorApplication.class, args);
+        new SpringApplicationBuilder(Iec60870SimulatorApplication.class).web(WebApplicationType.NONE).run(args);
     }
 
 }

--- a/osgp/protocol-adapter-iec60870/osgp-protocol-simulator-iec60870/src/main/java/org/opensmartgridplatform/simulator/protocol/iec60870/Iec60870SimulatorConfig.java
+++ b/osgp/protocol-adapter-iec60870/osgp-protocol-simulator-iec60870/src/main/java/org/opensmartgridplatform/simulator/protocol/iec60870/Iec60870SimulatorConfig.java
@@ -40,6 +40,9 @@ public class Iec60870SimulatorConfig {
     @Value("${iec60870.simulator.connection.timeout}")
     private int connectionTimeout;
 
+    @Value("${iec60870.simulator.sendEndOfInitialization:false}")
+    private boolean sendEndOfInitialization;
+
     @Value("${iec60870.simulator.port:2404}")
     private int port;
 
@@ -52,7 +55,7 @@ public class Iec60870SimulatorConfig {
         LOGGER.debug("Creating IEC60870 Simulator Bean.");
 
         final Iec60870Server server = new Iec60870Server(new Iec60870ServerEventListener(iec60870ConnectionRegistry,
-                iec60870AsduHandlerRegistry, this.connectionTimeout), this.port);
+                iec60870AsduHandlerRegistry, this.connectionTimeout, this.sendEndOfInitialization), this.port);
 
         LOGGER.debug("Starting IEC60870 Simulator.");
         server.start();

--- a/osgp/protocol-adapter-iec60870/osgp-protocol-simulator-iec60870/src/main/resources/osgp-protocol-simulator-iec60870.properties
+++ b/osgp/protocol-adapter-iec60870/osgp-protocol-simulator-iec60870/src/main/resources/osgp-protocol-simulator-iec60870.properties
@@ -1,2 +1,3 @@
 iec60870.simulator.connection.timeout=5000
+iec60870.simulator.sendEndOfInitialization=true
 iec60870.simulator.port=2404


### PR DESCRIPTION
Updates the Iec60870ServerEventListener, so it can be created in a way
that makes sure it sends an end of initialization ASDU when the first
connection to the server is created.
The current implementation assumes a couple of things, that may need to
be modified with later insights (for instance the information object
address to be used is set to 0, and the IeCauseOfInitialization is
created with values 0 and false).

The Iec60870SimulatorConfig is extended with a boolean value
(sendEndOfInitialization) indicating whether the end of initialization
ASDU is sent when a first connection is established or not. This value
is used when creating an Iec60870Server as option with the server event
listener.

A client ASDU handler (EndOfInitializationAsduHandler) is added, mainly
to prevent errors about unknown ASDU types in the logging. For now its
implementation only has some informational log output.