### PR TITLE
Fixes ArrayIndexOutOfBoundsException on SOAP calls

### DIFF
--- a/osgp/shared/osgp-ws-admin/pom.xml
+++ b/osgp/shared/osgp-ws-admin/pom.xml
@@ -38,10 +38,13 @@
       <artifactId>spring-ws-core</artifactId>
     </dependency>
 
-    <!-- JAXB API -->
     <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>xerces</groupId>
+      <artifactId>xercesImpl</artifactId>
     </dependency>
   </dependencies>
 

--- a/osgp/shared/osgp-ws-core/pom.xml
+++ b/osgp/shared/osgp-ws-core/pom.xml
@@ -38,10 +38,13 @@
       <artifactId>spring-ws-core</artifactId>
     </dependency>
 
-    <!-- JAXB API -->
     <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>xerces</groupId>
+      <artifactId>xercesImpl</artifactId>
     </dependency>
   </dependencies>
 

--- a/osgp/shared/osgp-ws-distributionautomation/pom.xml
+++ b/osgp/shared/osgp-ws-distributionautomation/pom.xml
@@ -38,10 +38,13 @@
       <artifactId>spring-ws-core</artifactId>
     </dependency>
 
-    <!-- JAXB API -->
     <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>xerces</groupId>
+      <artifactId>xercesImpl</artifactId>
     </dependency>
   </dependencies>
 

--- a/osgp/shared/osgp-ws-microgrids/pom.xml
+++ b/osgp/shared/osgp-ws-microgrids/pom.xml
@@ -38,10 +38,13 @@
       <artifactId>spring-ws-core</artifactId>
     </dependency>
 
-    <!-- JAXB API -->
     <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>xerces</groupId>
+      <artifactId>xercesImpl</artifactId>
     </dependency>
   </dependencies>
 

--- a/osgp/shared/osgp-ws-publiclighting/pom.xml
+++ b/osgp/shared/osgp-ws-publiclighting/pom.xml
@@ -38,10 +38,13 @@
       <artifactId>spring-ws-core</artifactId>
     </dependency>
 
-    <!-- JAXB API -->
     <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>xerces</groupId>
+      <artifactId>xercesImpl</artifactId>
     </dependency>
   </dependencies>
 

--- a/osgp/shared/osgp-ws-smartmetering/pom.xml
+++ b/osgp/shared/osgp-ws-smartmetering/pom.xml
@@ -38,10 +38,13 @@
       <artifactId>spring-ws-core</artifactId>
     </dependency>
 
-    <!-- JAXB API -->
     <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>xerces</groupId>
+      <artifactId>xercesImpl</artifactId>
     </dependency>
   </dependencies>
 

--- a/osgp/shared/osgp-ws-tariffswitching/pom.xml
+++ b/osgp/shared/osgp-ws-tariffswitching/pom.xml
@@ -38,10 +38,13 @@
       <artifactId>spring-ws-core</artifactId>
     </dependency>
 
-    <!-- JAXB API -->
     <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>xerces</groupId>
+      <artifactId>xercesImpl</artifactId>
     </dependency>
   </dependencies>
 

--- a/super/pom.xml
+++ b/super/pom.xml
@@ -94,7 +94,8 @@
     <maven.enforcer.plugin.version>3.0.0-M3</maven.enforcer.plugin.version>
     <maven.enforcer.maven.version>3.0.0</maven.enforcer.maven.version>
     <jaxb2.maven.plugin.version>2.5.0</jaxb2.maven.plugin.version>
-    <jaxb.api.version>2.3.1</jaxb.api.version>
+    <jakarta.xml.bind.version>2.3.3</jakarta.xml.bind.version>
+    <xerces.version>2.12.0</xerces.version>
     <spotbugs.maven.plugin.version>4.0.0</spotbugs.maven.plugin.version>
     <pmd.maven.plugin.version>3.13.0</pmd.maven.plugin.version>
     <checkstyle.maven.plugin.version>3.1.1</checkstyle.maven.plugin.version>
@@ -457,11 +458,15 @@
         <version>${servlet.jstl.version}</version>
       </dependency>
 
-      <!--  Jaxb xml bind -->
       <dependency>
-        <groupId>javax.xml.bind</groupId>
-        <artifactId>jaxb-api</artifactId>
-        <version>${jaxb.api.version}</version>
+        <groupId>jakarta.xml.bind</groupId>
+        <artifactId>jakarta.xml.bind-api</artifactId>
+        <version>${jakarta.xml.bind.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>xerces</groupId>
+        <artifactId>xercesImpl</artifactId>
+        <version>${xerces.version}</version>
       </dependency>
 
       <!-- Joda Time (Date/Time functions) -->


### PR DESCRIPTION
ATTEMPT TO FIX `ArrayIndexOutOfBoundsException` ON SOAP CALLS - DO NOT MERGE
Exception is probably caused by having OpenJDK 11 as default java version locally.