### PR TITLE
FLEX-5395 Add configuration of IP addresses that may be duplicated

### DIFF
--- a/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/application/services/DeviceNetworkAddressCleanupService.java
+++ b/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/application/services/DeviceNetworkAddressCleanupService.java
@@ -1,0 +1,218 @@
+/**
+ * Copyright 2020 Smart Society Services B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.opensmartgridplatform.core.application.services;
+
+import java.math.BigInteger;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.opensmartgridplatform.domain.core.entities.Device;
+import org.opensmartgridplatform.domain.core.repositories.DeviceRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
+
+@Service
+public class DeviceNetworkAddressCleanupService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DeviceNetworkAddressCleanupService.class);
+
+    private final boolean allowMultipleDevicesPerNetworkAddress;
+    private final List<String> ipRangesAllowingMultipleDevicesPerAddress;
+    private final Predicate<InetAddress> duplicatesAllowedByConfiguration;
+    private final DeviceRepository deviceRepository;
+
+    @Autowired
+    public DeviceNetworkAddressCleanupService(final DeviceRepository deviceRepository,
+            @Value("${device.network.address.cleanup.never}") final boolean allowMultipleDevicesPerNetworkAddress,
+            @Value("#{'${device.network.address.cleanup.duplicates.allowed}'.split(',')}") final List<String> ipRangesAllowingMultipleDevicesPerAddress) {
+        this.deviceRepository = deviceRepository;
+        this.allowMultipleDevicesPerNetworkAddress = allowMultipleDevicesPerNetworkAddress;
+
+        if (ipRangesAllowingMultipleDevicesPerAddress == null) {
+            this.ipRangesAllowingMultipleDevicesPerAddress = Collections.emptyList();
+        } else {
+            this.ipRangesAllowingMultipleDevicesPerAddress = Collections
+                    .unmodifiableList(ipRangesAllowingMultipleDevicesPerAddress.stream()
+                            .filter(StringUtils::isNotBlank)
+                            .collect(Collectors.toList()));
+        }
+        this.duplicatesAllowedByConfiguration = this.duplicatesAllowed(this.ipRangesAllowingMultipleDevicesPerAddress);
+
+        if (this.allowMultipleDevicesPerNetworkAddress) {
+            LOGGER.info(
+                    "DeviceNetworkAddressCleanupService initialized, network addresses will never be cleaned, as device.network.address.cleanup.never=true");
+        } else if (this.ipRangesAllowingMultipleDevicesPerAddress.isEmpty()) {
+            LOGGER.info(
+                    "DeviceNetworkAddressCleanupService initialized, duplicated network addresses will be cleaned, except for the loopback address (e.g. 127.0.0.1)");
+        } else {
+            LOGGER.info(
+                    "DeviceNetworkAddressCleanupService initialized, duplicated network addresses will be cleaned, except for the loopback address (e.g. 127.0.0.1), or addresses configured as device.network.address.cleanup.duplicates.allowed: {}",
+                    this.ipRangesAllowingMultipleDevicesPerAddress);
+        }
+    }
+
+    private Predicate<InetAddress> duplicatesAllowed(final List<String> configuredRanges) {
+        if (CollectionUtils.isEmpty(configuredRanges)) {
+            return inetAddress -> false;
+        }
+
+        final List<Predicate<BigInteger>> rangePredicates = configuredRanges.stream()
+                .map(this::rangePredicate)
+                .collect(Collectors.toList());
+
+        return inetAddress -> {
+            if (inetAddress == null) {
+                return true;
+            }
+            final BigInteger bigIntegerValue = this.asBigInteger(inetAddress);
+            return rangePredicates.stream().anyMatch(p -> p.test(bigIntegerValue));
+        };
+    }
+
+    private BigInteger asBigInteger(final InetAddress inetAddress) {
+        if (inetAddress == null) {
+            return null;
+        }
+        final byte[] address = inetAddress.getAddress();
+        final byte[] addressWithLeadingZero = new byte[address.length + 1];
+        System.arraycopy(address, 0, addressWithLeadingZero, 1, address.length);
+        return new BigInteger(addressWithLeadingZero);
+    }
+
+    private InetAddress asInetAddress(final String host) {
+        if (StringUtils.isBlank(host)) {
+            throw new IllegalArgumentException("InetAddress must not be blank");
+        }
+        try {
+            return InetAddress.getByName(host);
+        } catch (final UnknownHostException e) {
+            throw new IllegalArgumentException("Invalid InetAddress: \"" + host + "\"", e);
+        }
+    }
+
+    private Predicate<BigInteger> rangePredicate(final String configuredRange) {
+        if (!configuredRange.contains("-")) {
+            final InetAddress configuredInetAddress = this.asInetAddress(configuredRange);
+            final BigInteger bigIntegerValue = this.asBigInteger(configuredInetAddress);
+            return bigInteger -> bigInteger != null && bigIntegerValue != null
+                    && bigInteger.compareTo(bigIntegerValue) == 0;
+        }
+
+        final String[] fromTo = this.fromTo(configuredRange);
+
+        final InetAddress configuredInetAddressFrom = this.asInetAddress(fromTo[0]);
+        final InetAddress configuredInetAddressTo = this.asInetAddress(fromTo[1]);
+
+        final byte[] fromBytes = configuredInetAddressFrom.getAddress();
+        final byte[] toBytes = configuredInetAddressTo.getAddress();
+        if (fromBytes.length != toBytes.length) {
+            throw new IllegalArgumentException("Ivalid range configuration: \"" + configuredRange + "\", from ("
+                    + fromBytes.length + ") and to (" + toBytes.length + ") have different lengths");
+        }
+
+        final BigInteger fromValue = this.asBigInteger(configuredInetAddressFrom);
+        final BigInteger toValue = this.asBigInteger(configuredInetAddressTo);
+        if (fromValue.compareTo(toValue) > 0) {
+            throw new IllegalArgumentException(
+                    "Incorrect range configuration (from > to): \"" + configuredRange + "\"");
+        }
+
+        return bigInteger -> bigInteger != null && bigInteger.compareTo(fromValue) >= 0
+                && bigInteger.compareTo(toValue) <= 0;
+    }
+
+    private String[] fromTo(final String configuredRange) {
+        final String[] fromTo = configuredRange.split("\\s*+-\\s*+");
+        if (fromTo.length != 2) {
+            throw new IllegalArgumentException("Incorrect range configuration: \"" + configuredRange
+                    + "\", expected 2 parts, found: " + fromTo.length);
+        }
+        return fromTo;
+    }
+
+    /**
+     * Make sure that no other device than the one identified by
+     * {@code deviceIdentification} has the given {@code address} as network
+     * address, by removing the network address with other devices where it is
+     * stored.
+     *
+     * @param deviceIdentification
+     *            identification of the only device that is allowed to have the
+     *            given {@code address} as its network address
+     * @param host
+     *            the network address that may not remain stored with other
+     *            devices than the one identified by the given
+     *            {@code deviceIdentification}
+     * @throws UnknownHostException
+     */
+    public void clearDuplicateAddresses(final String deviceIdentification, final String host)
+            throws UnknownHostException {
+
+        this.clearDuplicateAddresses(deviceIdentification, InetAddress.getByName(host));
+    }
+
+    /**
+     * Make sure that no other device than the one identified by
+     * {@code deviceIdentification} has the given {@code address} as network
+     * address, by removing the network address with other devices where it is
+     * stored.
+     *
+     * @param deviceIdentification
+     *            identification of the only device that is allowed to have the
+     *            given {@code address} as its network address
+     * @param inetAddress
+     *            the network address that may not remain stored with other
+     *            devices than the one identified by the given
+     *            {@code deviceIdentification}
+     */
+    public void clearDuplicateAddresses(final String deviceIdentification, final InetAddress inetAddress) {
+
+        if (this.allowDuplicateEntries(inetAddress)) {
+            if (inetAddress != null) {
+                if (this.allowMultipleDevicesPerNetworkAddress) {
+                    LOGGER.info("Not clearing duplicate network addresses, as these are allowed by configuration.");
+                } else {
+                    LOGGER.info(
+                            "Not clearing duplicate network addresses, as {} is part of a configured exception in: {}",
+                            inetAddress.getHostAddress(), this.ipRangesAllowingMultipleDevicesPerAddress);
+                }
+            }
+            return;
+        }
+
+        this.deviceRepository.findByNetworkAddress(inetAddress)
+                .stream()
+                .filter(this.clearAddressForDevice(deviceIdentification))
+                .forEach(this::clearNetworkAddress);
+    }
+
+    public boolean allowDuplicateEntries(final InetAddress inetAddress) {
+        return this.allowMultipleDevicesPerNetworkAddress || inetAddress == null || inetAddress.isLoopbackAddress()
+                || this.duplicatesAllowedByConfiguration.test(inetAddress);
+    }
+
+    private Predicate<Device> clearAddressForDevice(final String exceptForThisIdentification) {
+        return device -> !device.getDeviceIdentification().equals(exceptForThisIdentification);
+    }
+
+    private void clearNetworkAddress(final Device device) {
+        LOGGER.info("Clearing duplicate network address {} with device {}", device.getIpAddress(),
+                device.getDeviceIdentification());
+        device.clearNetworkAddress();
+        this.deviceRepository.save(device);
+    }
+}

--- a/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/application/services/DeviceRegistrationMessageService.java
+++ b/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/application/services/DeviceRegistrationMessageService.java
@@ -30,8 +30,6 @@ public class DeviceRegistrationMessageService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DeviceRegistrationMessageService.class);
 
-    private static final String LOCAL_HOST = "127.0.0.1";
-
     @Autowired
     private DeviceRepository deviceRepository;
 
@@ -77,8 +75,7 @@ public class DeviceRegistrationMessageService {
             device = this.createNewDevice(deviceIdentification, deviceType);
         }
 
-        final InetAddress inetAddress = LOCAL_HOST.equals(ipAddress) ? InetAddress.getLoopbackAddress()
-                : InetAddress.getByName(ipAddress);
+        final InetAddress inetAddress = InetAddress.getByName(ipAddress);
         device.updateRegistrationData(inetAddress, deviceType);
         device.updateConnectionDetailsToSuccess();
 

--- a/osgp/platform/osgp-core/src/main/resources/osgp-core.properties
+++ b/osgp/platform/osgp-core/src/main/resources/osgp-core.properties
@@ -236,3 +236,24 @@ max.retry.count=3
 
 # The grid operator organisation.
 netmanagement.organisation=test-org
+
+
+# =========================================================
+# === NETWORK ADDRESS CLEANUP CONFIG                    ===
+# =========================================================
+
+# If device.network.address.cleanup.never is true, cleanup will not be
+# performed and all network addresses may be used with multiple devices.
+device.network.address.cleanup.never=false
+# If device.network.address.cleanup.never is false, ranges can be
+# configured for network addresses that may be shared between devices.
+# This allows to configure ranges of addresses of simulators which run
+# on different ports of the same host, as one example of a scenario this
+# could be used with.
+# Notice that there is no need to configure the loopback address (for
+# instance 127.0.0.1) as an exception, since this is always allowed as
+# the network address of multiple devices (assumed to be simulated for
+# the purpose of running tests on a machine).
+# This is a comma separated list of either literal IP addresses, or of
+# ranges with a from address and a to address separated by a dash (-).
+device.network.address.cleanup.duplicates.allowed=

--- a/osgp/platform/osgp-core/src/test/java/org/opensmartgridplatform/core/application/services/DeviceNetworkAddressCleanupServiceTest.java
+++ b/osgp/platform/osgp-core/src/test/java/org/opensmartgridplatform/core/application/services/DeviceNetworkAddressCleanupServiceTest.java
@@ -1,0 +1,168 @@
+/**
+ * Copyright 2020 Smart Society Services B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.opensmartgridplatform.core.application.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.InetAddress;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensmartgridplatform.domain.core.entities.Device;
+import org.opensmartgridplatform.domain.core.repositories.DeviceRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class DeviceNetworkAddressCleanupServiceTest {
+
+    private DeviceRepository deviceRepository;
+    private DeviceNetworkAddressCleanupService deviceNetworkAddressCleanupService;
+
+    @BeforeEach
+    public void setUp() {
+        this.deviceRepository = Mockito.mock(DeviceRepository.class);
+        final boolean allowMultipleDevicesPerNetworkAddress = false;
+        final List<String> ipRangesAllowingMultipleDevicesPerAddress = Collections.emptyList();
+        this.deviceNetworkAddressCleanupService = new DeviceNetworkAddressCleanupService(this.deviceRepository,
+                allowMultipleDevicesPerNetworkAddress, ipRangesAllowingMultipleDevicesPerAddress);
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void duplicateAddressesAreAllowedForLoopbackAddresses() throws Exception {
+        assertThat(this.deviceNetworkAddressCleanupService.allowDuplicateEntries(InetAddress.getLoopbackAddress()))
+                .isTrue();
+    }
+
+    @Test
+    public void noDevicesAreUpdatedWhenTheNetworkAddressIsNotUsed() throws Exception {
+        final String host = "192.168.0.13";
+        final InetAddress inetAddress = InetAddress.getByName(host);
+        this.theNetworkAddressIsNotUsed(inetAddress);
+
+        this.deviceNetworkAddressCleanupService.clearDuplicateAddresses("test-device", host);
+
+        verify(this.deviceRepository, times(1)).findByNetworkAddress(inetAddress);
+        verify(this.deviceRepository, never()).save(any(Device.class));
+    }
+
+    private void theNetworkAddressIsNotUsed(final InetAddress inetAddress) {
+        when(this.deviceRepository.findByNetworkAddress(inetAddress)).thenReturn(Collections.emptyList());
+    }
+
+    @Test
+    public void noDevicesAreUpdatedWhenDuplicateAddressesAreAllowed() throws Exception {
+        final String host = "192.168.0.13";
+        final InetAddress inetAddress = InetAddress.getByName(host);
+        final boolean allowMultipleDevicesPerNetworkAddress = true;
+        final List<String> ipRangesAllowingMultipleDevicesPerAddress = Collections.emptyList();
+        this.deviceNetworkAddressCleanupService = new DeviceNetworkAddressCleanupService(this.deviceRepository,
+                allowMultipleDevicesPerNetworkAddress, ipRangesAllowingMultipleDevicesPerAddress);
+
+        this.deviceNetworkAddressCleanupService.clearDuplicateAddresses("test-device", host);
+
+        verify(this.deviceRepository, never()).findByNetworkAddress(inetAddress);
+        verify(this.deviceRepository, never()).save(any(Device.class));
+    }
+
+    @Test
+    public void noDevicesAreUpdatedWhenTheNetworkAddressIsExplicitlyAllowedWithDuplicates() throws Exception {
+        final String host = "192.168.0.13";
+        final InetAddress inetAddress = InetAddress.getByName(host);
+        final boolean allowMultipleDevicesPerNetworkAddress = false;
+        final List<String> ipRangesAllowingMultipleDevicesPerAddress = Collections.singletonList(host);
+        this.deviceNetworkAddressCleanupService = new DeviceNetworkAddressCleanupService(this.deviceRepository,
+                allowMultipleDevicesPerNetworkAddress, ipRangesAllowingMultipleDevicesPerAddress);
+
+        this.deviceNetworkAddressCleanupService.clearDuplicateAddresses("test-device", host);
+
+        verify(this.deviceRepository, never()).findByNetworkAddress(inetAddress);
+        verify(this.deviceRepository, never()).save(any(Device.class));
+    }
+
+    @Test
+    public void noDevicesAreUpdatedWhenTheNetworkAddressIsPartOfARangeAllowingDuplicates() throws Exception {
+        final String host = "192.168.0.13";
+        final InetAddress inetAddress = InetAddress.getByName(host);
+        final boolean allowMultipleDevicesPerNetworkAddress = false;
+        final List<String> ipRangesAllowingMultipleDevicesPerAddress = Arrays.asList("10.123.18.131",
+                "192.168.0.1-192.168.0.20", "172.16.0.0-172.31.255.255");
+        this.deviceNetworkAddressCleanupService = new DeviceNetworkAddressCleanupService(this.deviceRepository,
+                allowMultipleDevicesPerNetworkAddress, ipRangesAllowingMultipleDevicesPerAddress);
+
+        this.deviceNetworkAddressCleanupService.clearDuplicateAddresses("test-device", host);
+
+        verify(this.deviceRepository, never()).findByNetworkAddress(inetAddress);
+        verify(this.deviceRepository, never()).save(any(Device.class));
+    }
+
+    @Test
+    public void loopbackAddressesAreAlwaysAllowedToHaveDuplicates() throws Exception {
+        final InetAddress loopbackAddress = InetAddress.getLoopbackAddress();
+        final String host = loopbackAddress.getHostAddress();
+        final boolean allowMultipleDevicesPerNetworkAddress = false;
+        final List<String> ipRangesAllowingMultipleDevicesPerAddress = Collections.emptyList();
+        this.deviceNetworkAddressCleanupService = new DeviceNetworkAddressCleanupService(this.deviceRepository,
+                allowMultipleDevicesPerNetworkAddress, ipRangesAllowingMultipleDevicesPerAddress);
+
+        this.deviceNetworkAddressCleanupService.clearDuplicateAddresses("test-device", host);
+
+        verify(this.deviceRepository, never()).findByNetworkAddress(loopbackAddress);
+        verify(this.deviceRepository, never()).save(any(Device.class));
+    }
+
+    @Test
+    public void devicesAreUpdatedWhenTheNetworkAddressIsNotAllowedToHaveDuplicates() throws Exception {
+        final String host = "192.168.0.13";
+        final InetAddress inetAddress = InetAddress.getByName(host);
+        this.theNetworkAddressIsUsedBy(inetAddress, "device1", "device2");
+        final boolean allowMultipleDevicesPerNetworkAddress = false;
+        final List<String> ipRangesAllowingMultipleDevicesPerAddress = Collections.emptyList();
+        this.deviceNetworkAddressCleanupService = new DeviceNetworkAddressCleanupService(this.deviceRepository,
+                allowMultipleDevicesPerNetworkAddress, ipRangesAllowingMultipleDevicesPerAddress);
+
+        this.deviceNetworkAddressCleanupService.clearDuplicateAddresses("test-device", host);
+
+        verify(this.deviceRepository, times(1)).findByNetworkAddress(inetAddress);
+        final ArgumentCaptor<Device> deviceCaptor = ArgumentCaptor.forClass(Device.class);
+        verify(this.deviceRepository, times(2)).save(deviceCaptor.capture());
+        final List<Device> savedDevices = deviceCaptor.getAllValues();
+        final boolean device1IsSavedWithClearedNetworkAddress = savedDevices.stream()
+                .anyMatch(device -> "device1".equals(device.getDeviceIdentification())
+                        && device.getNetworkAddress() == null);
+        assertThat(device1IsSavedWithClearedNetworkAddress).as("device1 is saved without network address").isTrue();
+        final boolean device2IsSavedWithClearedNetworkAddress = savedDevices.stream()
+                .anyMatch(device -> "device2".equals(device.getDeviceIdentification())
+                        && device.getNetworkAddress() == null);
+        assertThat(device2IsSavedWithClearedNetworkAddress).as("device2 is saved without network address").isTrue();
+    }
+
+    private void theNetworkAddressIsUsedBy(final InetAddress inetAddress, final String... deviceIdentifications) {
+        final List<Device> devicesWithSameNetworkAddress = Arrays.stream(deviceIdentifications)
+                .map(deviceIdentification -> {
+                    final Device device = new Device(deviceIdentification);
+                    device.updateRegistrationData(inetAddress, "deviceType");
+                    return device;
+                })
+                .collect(Collectors.toList());
+        when(this.deviceRepository.findByNetworkAddress(inetAddress)).thenReturn(devicesWithSameNetworkAddress);
+    }
+}

--- a/osgp/platform/osgp-core/src/test/java/org/opensmartgridplatform/core/application/services/DeviceRegistrationMessageServiceTest.java
+++ b/osgp/platform/osgp-core/src/test/java/org/opensmartgridplatform/core/application/services/DeviceRegistrationMessageServiceTest.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2020 Smart Society Services B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.opensmartgridplatform.core.application.services;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensmartgridplatform.domain.core.entities.Device;
+import org.opensmartgridplatform.domain.core.repositories.DeviceRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class DeviceRegistrationMessageServiceTest {
+
+    @Mock
+    private DeviceRepository deviceRepository;
+
+    @Mock
+    private DeviceNetworkAddressCleanupService deviceNetworkAddressCleanupService;
+
+    @InjectMocks
+    private DeviceRegistrationMessageService deviceRegistrationMessageService;
+
+    @Test
+    public void duplicateAddressesAreClearedWhenUpdatingRegistrationData() throws Exception {
+        final String deviceIdentification = "test-device";
+        final String ipAddress = "127.0.0.1";
+        final String deviceType = "DeviceType";
+        final boolean hasSchedule = false;
+        when(this.deviceRepository.findByDeviceIdentification(deviceIdentification))
+                .thenReturn(new Device(deviceIdentification));
+
+        this.deviceRegistrationMessageService.updateRegistrationData(deviceIdentification, ipAddress, deviceType,
+                hasSchedule);
+
+        verify(this.deviceNetworkAddressCleanupService).clearDuplicateAddresses(deviceIdentification, ipAddress);
+    }
+}


### PR DESCRIPTION
Upon device registration, the IP address of the registered device is
removed in the database for other devices where it is configured (with
the exception of the loopback address - localhost / 127.0.0.1).

These changes allow to either configure that such clean up should never
be performed (allowing multiple devices to share any network address),
or to configure a comma separated list of IP addresses or IP address
ranges that may be shared (for instance
"192.168.0.1,192.168.1.12-192.168.2.103" to allow sharing of 192.168.0.1
or any IP address from 192.168.1.12 to 192.168.2.103 inclusive).