### PR TITLE
OC-596 ~ Configures release repo branch for Jenkins

### DIFF
--- a/jenkins/pipeline/osgp-pr-build.groovy
+++ b/jenkins/pipeline/osgp-pr-build.groovy
@@ -5,7 +5,7 @@ def servername = stream + '-at-pr-' + env.BUILD_NUMBER
 def playbook = stream + '-at.yml'
 
 // Choose the branch to use for SmartSocietyServices/release repository. Default value is 'master'.
-def branchReleaseRepo = 'master'
+def branchReleaseRepo = 'feature/OC-596-deploy-da-mqtt-components-in-nightly-and-pr-builds'
 
 void setBuildStatus(String message, String state) {
     echo "Set status on GitHub to: " + state + " with message: " + message

--- a/osgp/platform/osgp-adapter-kafka-distributionautomation/pom.xml
+++ b/osgp/platform/osgp-adapter-kafka-distributionautomation/pom.xml
@@ -177,6 +177,10 @@
       <artifactId>spring-kafka</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.kafka</groupId>
       <artifactId>spring-kafka-test</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
This change should not be preserved if the build works.

Configures the release repo branch at
feature/OC-596-deploy-da-mqtt-components-in-nightly-and-pr-builds
so the PR builds will give an indication whether the components
added in the OSGP playbook will be deployed without issues.