### PR TITLE
OC-606 Resolve context initialization issues adapter DA kafka

### DIFF
--- a/osgp/platform/osgp-adapter-kafka-distributionautomation/pom.xml
+++ b/osgp/platform/osgp-adapter-kafka-distributionautomation/pom.xml
@@ -177,6 +177,10 @@
       <artifactId>spring-kafka</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.kafka</groupId>
       <artifactId>spring-kafka-test</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
Deployment of osgp-adapter-kafka-distributionautomation failed
with an error creating bean with name "kafkaProducerConfig",
cause by ClassNotFoundException with class
com.fasterxml.jackson.annotation.JsonView.
Adding jackson-databind to the dependencies makes the class
available, so that context initialization succeeds on deployment
in a servlet container.