### PR TITLE
FLEX-5300 Add 60870-5-104 LMD connection monitoring

### DIFF
--- a/osgp/platform/osgp-adapter-domain-publiclighting/src/main/java/org/opensmartgridplatform/adapter/domain/publiclighting/application/config/SchedulingConfigForDeviceConnection104LmdScheduledTask.java
+++ b/osgp/platform/osgp-adapter-domain-publiclighting/src/main/java/org/opensmartgridplatform/adapter/domain/publiclighting/application/config/SchedulingConfigForDeviceConnection104LmdScheduledTask.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2020 Alliander N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.opensmartgridplatform.adapter.domain.publiclighting.application.config;
+
+import java.util.concurrent.Executor;
+
+import org.opensmartgridplatform.adapter.domain.publiclighting.application.tasks.DeviceConnection104LmdScheduledTask;
+import org.opensmartgridplatform.shared.application.config.AbstractConfig;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.SchedulingConfigurer;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.config.CronTask;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+import org.springframework.scheduling.support.CronTrigger;
+
+@EnableScheduling
+@Configuration
+@PropertySource("classpath:osgp-adapter-domain-publiclighting.properties")
+@PropertySource(value = "file:${osgp/Global/config}", ignoreResourceNotFound = true)
+@PropertySource(value = "file:${osgp/Core/config}", ignoreResourceNotFound = true)
+public class SchedulingConfigForDeviceConnection104LmdScheduledTask extends AbstractConfig
+        implements SchedulingConfigurer {
+
+    private static final String CRON_EXPRESSION = "scheduling.task.device.connection.104.lmd.cron.expression";
+    private static final String POOL_SIZE = "scheduling.task.device.connection.104.lmd.pool.size";
+    private static final String MAX_ALLOWED_AGE = "scheduling.task.device.connection.104.lmd.max.allowed.age";
+
+    @Autowired
+    private DeviceConnection104LmdScheduledTask deviceConnection104LmdScheduledTask;
+
+    @Override
+    public void configureTasks(final ScheduledTaskRegistrar taskRegistrar) {
+        taskRegistrar.setScheduler(this.deviceConnection104LmdTaskScheduler());
+        taskRegistrar.addCronTask(new CronTask(this.deviceConnection104LmdScheduledTask,
+                this.deviceConnection104LmdScheduledTaskCronTrigger()));
+    }
+
+    public CronTrigger deviceConnection104LmdScheduledTaskCronTrigger() {
+        final String cron = this.environment.getRequiredProperty(CRON_EXPRESSION);
+        return new CronTrigger(cron);
+    }
+
+    @Bean(destroyMethod = "shutdown")
+    public Executor deviceConnection104LmdTaskScheduler() {
+        final ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
+        taskScheduler.setPoolSize(this.getNonRequiredIntegerPropertyValue(POOL_SIZE, 10));
+        taskScheduler
+                .setThreadNamePrefix("osgp-adapter-domain-publiclighting-device-connection-104-lmd-scheduled-task-");
+        taskScheduler.setWaitForTasksToCompleteOnShutdown(false);
+        return taskScheduler;
+    }
+
+    @Bean
+    public int deviceConnection104LmdScheduledTaskMaximumAllowedAge() {
+        return Integer.parseInt(this.environment.getRequiredProperty(MAX_ALLOWED_AGE));
+    }
+}

--- a/osgp/platform/osgp-adapter-domain-publiclighting/src/main/java/org/opensmartgridplatform/adapter/domain/publiclighting/application/tasks/DeviceConnection104LmdScheduledTask.java
+++ b/osgp/platform/osgp-adapter-domain-publiclighting/src/main/java/org/opensmartgridplatform/adapter/domain/publiclighting/application/tasks/DeviceConnection104LmdScheduledTask.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2020 Alliander N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.opensmartgridplatform.adapter.domain.publiclighting.application.tasks;
+
+import java.util.List;
+
+import org.opensmartgridplatform.adapter.domain.publiclighting.application.config.SchedulingConfigForDeviceConnection104LmdScheduledTask;
+import org.opensmartgridplatform.domain.core.entities.LightMeasurementDevice;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Periodic task to ensure active connection to IEC 60870-5-104 light
+ * measurement devices.
+ *
+ * See
+ * {@link SchedulingConfigForDeviceConnection104LmdScheduledTask#deviceConnection104LmdScheduledTaskCronTrigger()}
+ * and
+ * {@link SchedulingConfigForDeviceConnection104LmdScheduledTask#deviceConnection104LmdTaskScheduler()}.
+ */
+@Component
+public class DeviceConnection104LmdScheduledTask extends BaseTask implements Runnable {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DeviceConnection104LmdScheduledTask.class);
+
+    private static final String PROTOCOL = "60870-5-104";
+
+    @Autowired
+    private int deviceConnection104LmdScheduledTaskMaximumAllowedAge;
+
+    @Override
+    public void run() {
+        LOGGER.info("Ensuring active connections with IEC 60870-5-104 light measurement devices");
+        try {
+            final List<LightMeasurementDevice> devices = this.findLightMeasurementDevicesByProtocol(PROTOCOL);
+            final List<LightMeasurementDevice> devicesToConnect = this.findLightMeasurementDevicesToConnect(devices,
+                    this.deviceConnection104LmdScheduledTaskMaximumAllowedAge);
+            this.connectLightMeasurementDevices(devicesToConnect);
+        } catch (final Exception e) {
+            LOGGER.error("Exception caught ensuring active connection to IEC 60870-5-104 light measurement devices", e);
+        }
+    }
+
+}

--- a/osgp/platform/osgp-adapter-domain-publiclighting/src/main/java/org/opensmartgridplatform/adapter/domain/publiclighting/application/tasks/DeviceConnectionScheduledTask.java
+++ b/osgp/platform/osgp-adapter-domain-publiclighting/src/main/java/org/opensmartgridplatform/adapter/domain/publiclighting/application/tasks/DeviceConnectionScheduledTask.java
@@ -9,17 +9,16 @@ package org.opensmartgridplatform.adapter.domain.publiclighting.application.task
 
 import java.util.List;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
-
 import org.opensmartgridplatform.adapter.domain.publiclighting.application.config.SchedulingConfigForDeviceConnectionScheduledTask;
 import org.opensmartgridplatform.domain.core.entities.Device;
 import org.opensmartgridplatform.domain.core.entities.DeviceModel;
 import org.opensmartgridplatform.domain.core.entities.LightMeasurementDevice;
 import org.opensmartgridplatform.domain.core.entities.Manufacturer;
 import org.opensmartgridplatform.domain.core.valueobjects.DeviceFunction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
 /**
  * Periodic task to ensure active connection to devices of a given manufacturer.
@@ -41,6 +40,8 @@ public class DeviceConnectionScheduledTask extends BaseTask implements Runnable 
 
     @Override
     public void run() {
+        LOGGER.info("Ensuring active connections with LMD devices of manufacturer '{}'",
+                this.deviceConnectionScheduledTaskManufacturerName);
         try {
             final Manufacturer manufacturer = this.findManufacturer(this.deviceConnectionScheduledTaskManufacturerName);
             if (manufacturer == null) {

--- a/osgp/platform/osgp-adapter-domain-publiclighting/src/main/java/org/opensmartgridplatform/adapter/domain/publiclighting/infra/jms/core/messageprocessors/PublicLightingGetLightSensorStatusResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-publiclighting/src/main/java/org/opensmartgridplatform/adapter/domain/publiclighting/infra/jms/core/messageprocessors/PublicLightingGetLightSensorStatusResponseMessageProcessor.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright 2020 Alliander N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.opensmartgridplatform.adapter.domain.publiclighting.infra.jms.core.messageprocessors;
+
+import javax.jms.JMSException;
+import javax.jms.ObjectMessage;
+
+import org.opensmartgridplatform.adapter.domain.publiclighting.application.services.AdHocManagementService;
+import org.opensmartgridplatform.dto.valueobjects.LightSensorStatusDto;
+import org.opensmartgridplatform.shared.exceptionhandling.ComponentType;
+import org.opensmartgridplatform.shared.exceptionhandling.OsgpException;
+import org.opensmartgridplatform.shared.infra.jms.BaseMessageProcessor;
+import org.opensmartgridplatform.shared.infra.jms.Constants;
+import org.opensmartgridplatform.shared.infra.jms.CorrelationIds;
+import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
+import org.opensmartgridplatform.shared.infra.jms.MessageType;
+import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
+import org.opensmartgridplatform.shared.infra.jms.ResponseMessageResultType;
+import org.opensmartgridplatform.shared.infra.jms.ResponseMessageSender;
+import org.opensmartgridplatform.shared.wsheaderattribute.priority.MessagePriorityEnum;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+/**
+ * Class for processing public lighting get light sensor status response
+ * messages
+ */
+@Component("domainPublicLightingGetLightSensorStatusResponseMessageProcessor")
+public class PublicLightingGetLightSensorStatusResponseMessageProcessor extends BaseMessageProcessor {
+
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(PublicLightingGetLightSensorStatusResponseMessageProcessor.class);
+
+    @Autowired
+    @Qualifier("domainPublicLightingAdHocManagementService")
+    private AdHocManagementService adHocManagementService;
+
+    @Autowired
+    protected PublicLightingGetLightSensorStatusResponseMessageProcessor(
+            final ResponseMessageSender webServiceResponseMessageSender,
+            @Qualifier("domainPublicLightingInboundOsgpCoreResponsesMessageProcessorMap") final MessageProcessorMap osgpCoreResponseMessageProcessorMap) {
+
+        super(webServiceResponseMessageSender, osgpCoreResponseMessageProcessorMap, MessageType.GET_LIGHT_SENSOR_STATUS,
+                ComponentType.DOMAIN_PUBLIC_LIGHTING);
+    }
+
+    @Override
+    public void processMessage(final ObjectMessage message) throws JMSException {
+        LOGGER.debug("Processing public lighting get light sensor status response message");
+
+        String correlationUid = null;
+        String messageType = null;
+        int messagePriority = MessagePriorityEnum.DEFAULT.getPriority();
+        String organisationIdentification = null;
+        String deviceIdentification = null;
+
+        ResponseMessage responseMessage;
+        ResponseMessageResultType responseMessageResultType = null;
+        OsgpException osgpException = null;
+        Object dataObject;
+
+        try {
+            correlationUid = message.getJMSCorrelationID();
+            messageType = message.getJMSType();
+            messagePriority = message.getJMSPriority();
+            organisationIdentification = message.getStringProperty(Constants.ORGANISATION_IDENTIFICATION);
+            deviceIdentification = message.getStringProperty(Constants.DEVICE_IDENTIFICATION);
+
+            responseMessage = (ResponseMessage) message.getObject();
+            responseMessageResultType = responseMessage.getResult();
+            osgpException = responseMessage.getOsgpException();
+            dataObject = responseMessage.getDataObject();
+        } catch (final JMSException e) {
+            LOGGER.error("UNRECOVERABLE ERROR, unable to read ObjectMessage instance, giving up.", e);
+            LOGGER.debug("correlationUid: {}", correlationUid);
+            LOGGER.debug("messageType: {}", messageType);
+            LOGGER.debug("messagePriority: {}", messagePriority);
+            LOGGER.debug("organisationIdentification: {}", organisationIdentification);
+            LOGGER.debug("deviceIdentification: {}", deviceIdentification);
+            LOGGER.debug("responseMessageResultType: {}", responseMessageResultType);
+            LOGGER.debug("deviceIdentification: {}", deviceIdentification);
+            LOGGER.debug("osgpException: ", osgpException);
+            return;
+        }
+
+        /*
+         * Following the way the PublicLightingGetStatusResponseMessageProcessor
+         * processes the messages coming through, the code could return here in
+         * case the correlationUid equals
+         * OsgpSystemCorrelationUid.CORRELATION_UID.
+         *
+         * If however the light sensor status response as handled here comes
+         * from the IEC 60870-5-104 protocol adapter, then the correlation UID
+         * is not matched with the request as long as FLEX-5349 is not done.
+         *
+         * For now, handling the light sensor status response in the ad hoc
+         * management service nothing will be forwarded to the web service
+         * layer. This means retrieving the status from the web service for the
+         * 60870-5-104 probably does not work (if so it probably already did not
+         * work before the introduction of this
+         * PublicLightingGetLightSensorStatusResponseMessageProcessor).
+         */
+
+        try {
+            LOGGER.info("Calling application service function to handle response: {}", messageType);
+
+            final LightSensorStatusDto lightSensorStatus = (LightSensorStatusDto) dataObject;
+
+            final CorrelationIds ids = new CorrelationIds(organisationIdentification, deviceIdentification,
+                    correlationUid);
+            this.adHocManagementService.handleGetLightSensorStatusResponse(lightSensorStatus, ids, messageType,
+                    messagePriority, responseMessageResultType, osgpException);
+
+        } catch (final Exception e) {
+            this.handleError(e, correlationUid, organisationIdentification, deviceIdentification, messageType,
+                    messagePriority);
+        }
+    }
+}

--- a/osgp/platform/osgp-adapter-domain-publiclighting/src/main/resources/osgp-adapter-domain-publiclighting.properties
+++ b/osgp/platform/osgp-adapter-domain-publiclighting/src/main/resources/osgp-adapter-domain-publiclighting.properties
@@ -84,10 +84,20 @@ jms.get.power.usage.history.response.time.to.live=3600000
 scheduling.task.device.connection.cron.expression=0 */10 * * * *
 # Number of threads in thread pool.
 scheduling.task.device.connection.pool.size=1
-# Name of the manufacturer (case sensitive) of devices to connect to. 
+# Name of the manufacturer (case sensitive) of devices to connect to.
 scheduling.task.device.connection.manufacturer.name=ABB
 # Maximal allowed age in hours of the latest event / communication for a device.
 scheduling.task.device.connection.max.allowed.age=2
+
+# =========================================================
+# ===   Device Connection settings IEC60870-5-104 LMD   ===
+# =========================================================
+# Interval of scheduled task.
+scheduling.task.device.connection.104.lmd.cron.expression=0 */10 * * * *
+# Number of threads in thread pool.
+scheduling.task.device.connection.104.lmd.pool.size=1
+# Maximal allowed age in hours of the latest communication with a device.
+scheduling.task.device.connection.104.lmd.max.allowed.age=2
 
 
 
@@ -99,7 +109,7 @@ scheduling.task.event.retrieval.cron.expression=0 0/30 0-6,17-23 * * *
 scheduling.task.event.retrieval.cron.timezone=Europe/Amsterdam
 # Number of threads in thread pool.
 scheduling.task.event.retrieval.pool.size=10
-# Name of the manufacturer (case sensitive) of devices to retrieve events for. 
+# Name of the manufacturer (case sensitive) of devices to retrieve events for.
 scheduling.task.event.retrieval.manufacturer.name=KAIFA
 # Maximal allowed age in hours of the latest event / communication for a device.
 scheduling.task.event.retrieval.max.allowed.age=24

--- a/osgp/platform/osgp-adapter-domain-shared/src/main/java/org/opensmartgridplatform/adapter/domain/shared/GetLightSensorStatusResponse.java
+++ b/osgp/platform/osgp-adapter-domain-shared/src/main/java/org/opensmartgridplatform/adapter/domain/shared/GetLightSensorStatusResponse.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2020 Alliander N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.opensmartgridplatform.adapter.domain.shared;
+
+import org.opensmartgridplatform.domain.core.valueobjects.LightSensorStatus;
+import org.opensmartgridplatform.shared.exceptionhandling.OsgpException;
+import org.opensmartgridplatform.shared.infra.jms.ResponseMessageResultType;
+
+public class GetLightSensorStatusResponse {
+
+    ResponseMessageResultType result;
+    OsgpException osgpException;
+    LightSensorStatus lightSensorStatus;
+
+    public GetLightSensorStatusResponse() {
+        // Empty constructor.
+    }
+
+    public ResponseMessageResultType getResult() {
+        return this.result;
+    }
+
+    public void setResult(final ResponseMessageResultType result) {
+        this.result = result;
+    }
+
+    public OsgpException getOsgpException() {
+        return this.osgpException;
+    }
+
+    public void setOsgpException(final OsgpException osgpException) {
+        this.osgpException = osgpException;
+    }
+
+    public LightSensorStatus getLightSensorStatus() {
+        return this.lightSensorStatus;
+    }
+
+    public void setLightSensorStatus(final LightSensorStatus lightSensorStatus) {
+        this.lightSensorStatus = lightSensorStatus;
+    }
+}

--- a/osgp/platform/osgp-domain-core/src/main/java/org/opensmartgridplatform/domain/core/repositories/LightMeasurementDeviceRepository.java
+++ b/osgp/platform/osgp-domain-core/src/main/java/org/opensmartgridplatform/domain/core/repositories/LightMeasurementDeviceRepository.java
@@ -7,12 +7,18 @@
  */
 package org.opensmartgridplatform.domain.core.repositories;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
+import java.util.Collection;
+import java.util.List;
 
 import org.opensmartgridplatform.domain.core.entities.LightMeasurementDevice;
+import org.opensmartgridplatform.domain.core.valueobjects.DeviceLifecycleStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 @Repository
 public interface LightMeasurementDeviceRepository extends JpaRepository<LightMeasurementDevice, Long> {
     LightMeasurementDevice findByDeviceIdentification(String deviceIdentification);
+
+    List<LightMeasurementDevice> findByInMaintenanceAndProtocolInfoProtocolAndDeviceLifecycleStatusIn(
+            boolean inMaintenance, String protocol, Collection<DeviceLifecycleStatus> deviceLifecycleStatuses);
 }

--- a/osgp/platform/osgp-domain-core/src/main/java/org/opensmartgridplatform/domain/core/valueobjects/LightSensorStatus.java
+++ b/osgp/platform/osgp-domain-core/src/main/java/org/opensmartgridplatform/domain/core/valueobjects/LightSensorStatus.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2020 Alliander N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.opensmartgridplatform.domain.core.valueobjects;
+
+import java.io.Serializable;
+
+public class LightSensorStatus implements Serializable {
+
+    private static final long serialVersionUID = -6385082207732463078L;
+
+    private final boolean on;
+
+    public LightSensorStatus(final boolean on) {
+        this.on = on;
+    }
+
+    public boolean isOn() {
+        return this.on;
+    }
+}


### PR DESCRIPTION
Makes sure connections are kept active for the light measurement devices
with protocol IEC 60870-5-104.

Adds DeviceConnection104LmdScheduledTask, a scheduled task that ensures
connections with (the gateways of) the IEC 60870-5-104 light measurement
devices.

Changes may probably be required when requests to the IEC 60870-5-104
light measurement devices will be handled from the web service layer.
This has not been addressed for FLEX-5300 since another item already is
on the backlog to make sure the correlation UID is kept between request
and response (FLEX-5349), which needs to be dealt with before the web
service responses can be matched with requests at all.