### PR TITLE
FLEX-5428 ~ Fixes list containing one event

### DIFF
--- a/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/application/services/EventNotificationMessageService.java
+++ b/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/application/services/EventNotificationMessageService.java
@@ -129,7 +129,7 @@ public class EventNotificationMessageService {
                 this.handleLightMeasurementDeviceEvents(deviceIdentification, eventNotifications);
             }
         }
-        
+
         this.handleSwitchDeviceEvents(device, switchDeviceEvents);
     }
 

--- a/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/application/services/EventNotificationMessageService.java
+++ b/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/application/services/EventNotificationMessageService.java
@@ -125,13 +125,12 @@ public class EventNotificationMessageService {
 
             if (this.isSwitchingEvent(eventType)) {
                 switchDeviceEvents.add(event);
-
-                this.handleSwitchDeviceEvents(device, switchDeviceEvents);
             } else if (this.isLightMeasurementEvent(eventType)) {
                 this.handleLightMeasurementDeviceEvents(deviceIdentification, eventNotifications);
             }
         }
-
+        
+        this.handleSwitchDeviceEvents(device, switchDeviceEvents);
     }
 
     private void handleSwitchDeviceEvents(final Device device, final List<Event> switchDeviceEvents)


### PR DESCRIPTION
Events received from the IEC 61850 light measurement simulator are sent to osgp-core as lists, containing exactly one event. The old code rejected those without checking the contents of the list.