### PR TITLE
Fixes timing issues in ChannelCache tests

### DIFF
--- a/osgp/protocol-adapter-oslp/osgp-adapter-protocol-oslp-elster/src/main/java/org/opensmartgridplatform/adapter/protocol/oslp/elster/infra/networking/ChannelCacheEntry.java
+++ b/osgp/protocol-adapter-oslp/osgp-adapter-protocol-oslp-elster/src/main/java/org/opensmartgridplatform/adapter/protocol/oslp/elster/infra/networking/ChannelCacheEntry.java
@@ -8,7 +8,7 @@
 package org.opensmartgridplatform.adapter.protocol.oslp.elster.infra.networking;
 
 import java.time.Instant;
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
@@ -26,8 +26,8 @@ public class ChannelCacheEntry {
         this.referenceCount = 0;
     }
 
-    public int incrementAndGetReferenceCount() {
-        this.lastRefreshedMillis.set(System.currentTimeMillis());
+    public int incrementAndGetReferenceCount(final long updateTimeMillis) {
+        this.lastRefreshedMillis.set(updateTimeMillis);
         synchronized (this) {
             this.referenceCount += 1;
             return this.referenceCount;
@@ -65,7 +65,7 @@ public class ChannelCacheEntry {
     public String toString() {
         return String.format("ChannelCacheEntry[channel: %s, referenceCount: %d, lastRefreshed: %s]",
                 this.channel.id().asShortText(), this.referenceCount,
-                ZonedDateTime.ofInstant(Instant.ofEpochMilli(this.getLastRefreshedMillis()), ZoneId.of("UTC")));
+                ZonedDateTime.ofInstant(Instant.ofEpochMilli(this.getLastRefreshedMillis()), ZoneOffset.UTC));
     }
 
     @Override

--- a/osgp/protocol-adapter-oslp/osgp-adapter-protocol-oslp-elster/src/test/java/org/opensmartgridplatform/adapter/protocol/oslp/elster/infra/networking/ControlledClock.java
+++ b/osgp/protocol-adapter-oslp/osgp-adapter-protocol-oslp-elster/src/test/java/org/opensmartgridplatform/adapter/protocol/oslp/elster/infra/networking/ControlledClock.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright 2020 Alliander N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.opensmartgridplatform.adapter.protocol.oslp.elster.infra.networking;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class ControlledClock extends Clock {
+
+    private final ZoneId zone;
+    private final AtomicLong millis;
+
+    public ControlledClock() {
+        this(ZoneOffset.UTC, 0);
+    }
+
+    public ControlledClock(final ZoneId zone, final long millis) {
+        this.zone = Objects.requireNonNull(zone, "zone");
+        if (millis < 0) {
+            throw new IllegalArgumentException(
+                    "millis must be non-negative, this clock works starting from the epoch: " + millis);
+        }
+        this.millis = new AtomicLong(millis);
+    }
+
+    @Override
+    public ZoneId getZone() {
+        return this.zone;
+    }
+
+    @Override
+    public Clock withZone(final ZoneId zone) {
+        return new ControlledClock(zone, this.millis.get());
+    }
+
+    /**
+     * Returns a copy of this clock with the provided time in milliseconds.
+     *
+     * @param millis
+     *            the number of milliseconds from the epoch of
+     *            1970-01-01T00:00:00Z that will be the time of the returned
+     *            clock
+     * @return a new clock based on this clock with the given number of
+     *         milliseconds as its time
+     */
+    public Clock withMillis(final long millis) {
+        return new ControlledClock(this.zone, millis);
+    }
+
+    @Override
+    public Instant instant() {
+        return Instant.ofEpochMilli(this.millis());
+    }
+
+    @Override
+    public long millis() {
+        return this.millis.get();
+    }
+
+    /**
+     * Advances the time of this clock with the provided number of milliseconds.
+     *
+     * @param millis
+     *            the number of milliseconds to advance this clock by,
+     *            non-negative
+     * @return the number of milliseconds from the epoch of 1970-01-01T00:00:00Z
+     *         that represents the new time of this clock
+     */
+    public long advanceMillis(final long millis) {
+        if (millis < 0) {
+            throw new IllegalArgumentException(
+                    "millis must be non-negative, this clock does not go back in time: " + millis);
+        }
+        final long newMillis = this.millis.addAndGet(millis);
+        if (newMillis < 0) {
+            this.millis.set(0);
+            throw new IllegalStateException("Clock ran out of time, reset to epoch: " + newMillis);
+        }
+        return newMillis;
+    }
+
+    /**
+     * Advances the time of this clock with one millisecond.
+     *
+     * @return the number of milliseconds from the epoch of 1970-01-01T00:00:00Z
+     *         that represents the new time of this clock
+     */
+    public long tick() {
+        return this.advanceMillis(1);
+    }
+}


### PR DESCRIPTION
With FLEX-5537 a ChannelCache was introduced as a replacement of a map
of channels.

The unit tests simulated a delay for the expiration time of the cache in
a way that was sensitive to timing issues when the tests were executed
using multiple threads under heavy load.

This changes the ChannelCache to depend on a Clock (by default just the
system clock) that can be controlled during the unit tests. This way
delays (passing of time) can be simulated in the tests without actually
resorting to sleeping or delayed execution with an executor.