### PR TITLE
FLEX-5474 Add reboot behavior to the OSLP web device simulator

### DIFF
--- a/osgp/protocol-adapter-oslp/web-device-simulator/pom.xml
+++ b/osgp/protocol-adapter-oslp/web-device-simulator/pom.xml
@@ -15,7 +15,7 @@
   <artifactId>web-device-simulator</artifactId>
   <name>osgp-web-device-simulator</name>
   <packaging>war</packaging>
-  <!-- Description, Organization, Licenses, URL and Distribution Management elements are needed for the maven-jxr-plugin 
+  <!-- Description, Organization, Licenses, URL and Distribution Management elements are needed for the maven-jxr-plugin
     to generate a maven site -->
   <description>Device simulator for OSLP smart devices.</description>
 
@@ -179,6 +179,39 @@
       <groupId>org.opensmartgridplatform</groupId>
       <artifactId>shared</artifactId>
     </dependency>
+
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/osgp/protocol-adapter-oslp/web-device-simulator/src/main/java/org/opensmartgridplatform/webdevicesimulator/application/config/ApplicationContext.java
+++ b/osgp/protocol-adapter-oslp/web-device-simulator/src/main/java/org/opensmartgridplatform/webdevicesimulator/application/config/ApplicationContext.java
@@ -116,6 +116,9 @@ public class ApplicationContext {
     @Value("${message.source.use.code.as.default.message:true}")
     private boolean messageSourceUseCodeAsDefaultMessage;
 
+    @Value("${reboot.delay.seconds:5}")
+    private int rebootDelayInSeconds;
+
     @Value("${response.delay.time:10}")
     private long responseDelayTime;
     @Value("${response.delay.random.range:20}")
@@ -270,6 +273,11 @@ public class ApplicationContext {
     @Bean
     public SwitchingServices switchingServices() {
         return new SwitchingServices();
+    }
+
+    @Bean
+    public Integer rebootDelayInSeconds() {
+        return this.rebootDelayInSeconds;
     }
 
     @Bean

--- a/osgp/protocol-adapter-oslp/web-device-simulator/src/main/java/org/opensmartgridplatform/webdevicesimulator/application/services/DeviceManagementService.java
+++ b/osgp/protocol-adapter-oslp/web-device-simulator/src/main/java/org/opensmartgridplatform/webdevicesimulator/application/services/DeviceManagementService.java
@@ -45,6 +45,9 @@ public class DeviceManagementService {
     @Autowired
     private Boolean checkboxEventNotificationValue;
 
+    @Autowired
+    private Integer rebootDelayInSeconds;
+
     public List<EventNotificationToBeSent> getEventNotificationToBeSent() {
         return EVENT_NOTIFICATION_TO_BE_SENT;
     }
@@ -123,5 +126,13 @@ public class DeviceManagementService {
 
     public void setEventNotification(final Boolean eventNotification) {
         this.checkboxEventNotificationValue = eventNotification;
+    }
+
+    public int getRebootDelay() {
+        return this.rebootDelayInSeconds;
+    }
+
+    public void setRebootDelay(final int rebootDelayInSeconds) {
+        this.rebootDelayInSeconds = rebootDelayInSeconds;
     }
 }

--- a/osgp/protocol-adapter-oslp/web-device-simulator/src/main/java/org/opensmartgridplatform/webdevicesimulator/service/OslpChannelHandler.java
+++ b/osgp/protocol-adapter-oslp/web-device-simulator/src/main/java/org/opensmartgridplatform/webdevicesimulator/service/OslpChannelHandler.java
@@ -11,15 +11,20 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.security.PrivateKey;
-import java.text.ParseException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Random;
+import java.util.SortedSet;
 import java.util.Timer;
 import java.util.TimerTask;
+import java.util.TreeSet;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -80,6 +85,9 @@ import io.netty.channel.SimpleChannelInboundHandler;
 public class OslpChannelHandler extends SimpleChannelInboundHandler<OslpEnvelope> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OslpChannelHandler.class);
+
+    private static final SortedSet<String> REBOOTING_DEVICE_IDS = Collections.synchronizedSortedSet(new TreeSet<>());
+
     private final Lock lock = new ReentrantLock();
     private final ConcurrentMap<String, Callback> callbacks = new ConcurrentHashMap<>();
     private final List<OutOfSequenceEvent> outOfSequenceList = new ArrayList<>();
@@ -295,6 +303,15 @@ public class OslpChannelHandler extends SimpleChannelInboundHandler<OslpEnvelope
     @Override
     public void channelRead0(final ChannelHandlerContext ctx, final OslpEnvelope message) throws Exception {
 
+        final String deviceUid = Base64.encodeBase64String(message.getDeviceId());
+        if (this.isRebooting(message.getDeviceId())) {
+            LOGGER.warn("Disconnect device {}, simulating unavailability while rebooting", deviceUid);
+            ctx.disconnect();
+            return;
+        } else {
+            LOGGER.info("Process envelope for device {}, not rebooting", deviceUid);
+        }
+
         this.oslpLogItemRepository.save(new OslpLogItem(message.getDeviceId(),
                 this.getDeviceIdentificationFromMessage(message.getPayloadMessage()), true,
                 message.getPayloadMessage()));
@@ -370,12 +387,9 @@ public class OslpChannelHandler extends SimpleChannelInboundHandler<OslpEnvelope
         } else {
             LOGGER.warn("Received message wasn't properly secured.");
         }
-
-        ctx.fireChannelRead(message);
     }
 
     @Override
-
     public void channelActive(final ChannelHandlerContext ctx) throws Exception {
         LOGGER.info("Channel {} active.", ctx.channel().id());
         super.channelActive(ctx);
@@ -470,7 +484,7 @@ public class OslpChannelHandler extends SimpleChannelInboundHandler<OslpEnvelope
     }
 
     private Oslp.Message handleRequest(final OslpEnvelope message, final int sequenceNumber)
-            throws DeviceSimulatorException, ParseException {
+            throws DeviceSimulatorException {
         final Oslp.Message request = message.getPayloadMessage();
 
         // Create response message
@@ -588,7 +602,7 @@ public class OslpChannelHandler extends SimpleChannelInboundHandler<OslpEnvelope
         } else if (request.hasSetRebootRequest()) {
             response = createSetRebootResponse();
 
-            this.sendDelayedDeviceRegistration(device);
+            this.simulateReboot(device);
         } else if (request.hasSetTransitionRequest()) {
             this.handleSetTransitionRequest(device, request.getSetTransitionRequest());
 
@@ -604,35 +618,69 @@ public class OslpChannelHandler extends SimpleChannelInboundHandler<OslpEnvelope
         return response;
     }
 
-    private void sendDelayedDeviceRegistration(final Device device) {
+    private void startRebooting(final String deviceUid) {
+        LOGGER.info("Blocking further requests for {} while rebooting", deviceUid);
+        REBOOTING_DEVICE_IDS.add(deviceUid);
+    }
+
+    private void finishRebooting(final String deviceUid) {
+        REBOOTING_DEVICE_IDS.remove(deviceUid);
+        LOGGER.info("Accepting new requests for {} after rebooting", deviceUid);
+    }
+
+    private boolean isRebooting(final byte[] deviceId) {
+        final String deviceUid = Base64.encodeBase64String(deviceId);
+        LOGGER.info("Checking whether device {} is rebooting", deviceUid);
+        return REBOOTING_DEVICE_IDS.contains(deviceUid);
+    }
+
+    private DeviceMessageStatus performDeviceRegistration(final Device device) {
         if (device == null) {
-            return;
+            return DeviceMessageStatus.FAILURE;
         }
 
         final String deviceIdentification = device.getDeviceIdentification();
-        if (StringUtils.isEmpty(deviceIdentification)) {
-            return;
+        if (!StringUtils.hasText(deviceIdentification)) {
+            return DeviceMessageStatus.FAILURE;
         }
 
-        new Timer().schedule(new TimerTask() {
-
-            @Override
-            public void run() {
-                try {
-                    LOGGER.info("Sending DeviceRegistrationRequest for device: {}", deviceIdentification);
-                    final DeviceMessageStatus deviceMessageStatus = OslpChannelHandler.this.registerDevice
-                            .sendRegisterDeviceCommand(device.getId(), true);
-                    if (DeviceMessageStatus.OK.equals(deviceMessageStatus)) {
-                        LOGGER.info("Sending ConfirmDeviceRegistrationRequest for device: {}", deviceIdentification);
-                        OslpChannelHandler.this.registerDevice.sendConfirmDeviceRegistrationCommand(device.getId());
-                    }
-                } catch (final Exception e) {
-                    LOGGER.error("Caught exception during sendDelayedDeviceRegistration() for device : "
-                            + deviceIdentification, e);
-                }
+        try {
+            LOGGER.info("Sending DeviceRegistrationRequest for device: {}", deviceIdentification);
+            final DeviceMessageStatus deviceMessageStatus = OslpChannelHandler.this.registerDevice
+                    .sendRegisterDeviceCommand(device.getId(), true);
+            if (DeviceMessageStatus.OK.equals(deviceMessageStatus)) {
+                LOGGER.info("Sending ConfirmDeviceRegistrationRequest for device: {}", deviceIdentification);
+                return OslpChannelHandler.this.registerDevice.sendConfirmDeviceRegistrationCommand(device.getId());
+            } else {
+                LOGGER.info(
+                        "Not sending ConfirmDeviceRegistrationRequest for device: {} because DeviceRegistrationRequest ended with status: {}",
+                        deviceIdentification, deviceMessageStatus);
             }
+        } catch (final Exception e) {
+            LOGGER.error("Exception during registration process of device: {}", deviceIdentification, e);
+        }
+        return DeviceMessageStatus.FAILURE;
+    }
 
-        }, 2000);
+    private CompletableFuture<DeviceMessageStatus> simulateReboot(final Device device) {
+        final String deviceUid = device.getDeviceUid();
+        this.startRebooting(deviceUid);
+        return CompletableFuture.supplyAsync(() -> {
+            DeviceMessageStatus result = DeviceMessageStatus.FAILURE;
+            try {
+                result = Executors.newSingleThreadScheduledExecutor()
+                        .schedule(() -> this.performDeviceRegistration(device),
+                                this.deviceManagementService.getRebootDelay(), TimeUnit.SECONDS)
+                        .get();
+            } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+                LOGGER.error("simulateReboot was interrupted", e);
+            } catch (final ExecutionException e) {
+                LOGGER.error("simulateReboot threw an Exception", e);
+            }
+            this.finishRebooting(deviceUid);
+            return result;
+        });
     }
 
     private void handleSetScheduleRequest(final Device device, final SetScheduleRequest setScheduleRequest) {
@@ -871,13 +919,25 @@ public class OslpChannelHandler extends SimpleChannelInboundHandler<OslpEnvelope
         LOGGER.debug("handle UpdateFirmwareRequest for device: {}, with serialized size of {}",
                 device.getDeviceIdentification(), request.getSerializedSize());
 
-        this.sendDelayedDeviceRegistration(device);
-
-        // Send a firmware activation event after the device registration has
-        // (likely) been finished
-        final Oslp.Event event = Oslp.Event.FIRMWARE_EVENTS_ACTIVATING;
-        final String description = "A new firmware is activated";
-        this.sendEventWithCustomDelay(device, event, description, 7000);
+        this.simulateReboot(device).thenAccept(deviceMessageStatus -> {
+            if (DeviceMessageStatus.NOT_FOUND == deviceMessageStatus) {
+                LOGGER.error("Device {} not found handling update firmware request", device.getDeviceIdentification());
+                return;
+            }
+            final Oslp.Event event;
+            final String description;
+            if (DeviceMessageStatus.OK == deviceMessageStatus) {
+                event = Oslp.Event.FIRMWARE_EVENTS_ACTIVATING;
+                description = "A new firmware is activated";
+            } else {
+                LOGGER.warn("Device {} has issues registering after reboot handling update firmware request",
+                        device.getDeviceIdentification());
+                event = Oslp.Event.FIRMWARE_EVENTS_DOWNLOAD_FAILED;
+                description = "Failure rebooting and registrating device during firmware activation";
+            }
+            this.sendEventWithCustomDelay(device, event, description,
+                    Math.max(1, 7 - this.deviceManagementService.getRebootDelay()));
+        });
     }
 
     private void handleSetConfigurationRequest(final Device device,

--- a/osgp/protocol-adapter-oslp/web-device-simulator/src/main/java/org/opensmartgridplatform/webdevicesimulator/web/controller/DelayRequest.java
+++ b/osgp/protocol-adapter-oslp/web-device-simulator/src/main/java/org/opensmartgridplatform/webdevicesimulator/web/controller/DelayRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Smart Society Services B.V.
+ * Copyright 2020 Alliander N.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
  *
@@ -10,20 +10,20 @@ package org.opensmartgridplatform.webdevicesimulator.web.controller;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class AutonomousRequest {
-    private final Boolean autonomousStatus;
+public class DelayRequest {
+    private final Integer delay;
 
     @JsonCreator
-    public AutonomousRequest(@JsonProperty("autonomousStatus") final Boolean autonomousStatus) {
-        this.autonomousStatus = autonomousStatus;
+    public DelayRequest(@JsonProperty("delay") final Integer delay) {
+        this.delay = delay;
     }
 
-    public Boolean getAutonomousStatus() {
-        return this.autonomousStatus;
+    public Integer getDelay() {
+        return this.delay;
     }
 
     @Override
     public String toString() {
-        return String.format("AutonomousRequest[autonomousStatus=%s]", this.autonomousStatus);
+        return String.format("DelayRequest[delay=%s]", this.delay);
     }
 }

--- a/osgp/protocol-adapter-oslp/web-device-simulator/src/main/java/org/opensmartgridplatform/webdevicesimulator/web/controller/DeviceManagementController.java
+++ b/osgp/protocol-adapter-oslp/web-device-simulator/src/main/java/org/opensmartgridplatform/webdevicesimulator/web/controller/DeviceManagementController.java
@@ -7,6 +7,7 @@
  */
 package org.opensmartgridplatform.webdevicesimulator.web.controller;
 
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -28,11 +29,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.SessionAttributes;
@@ -65,11 +66,15 @@ public class DeviceManagementController extends AbstractController {
     protected static final String LIGHT_SWITCHING_CHECK_JSON_URL = "/devices/lightSwitchingCheck/json";
     protected static final String EVENT_NOTIFICATION_CHECK_JSON_URL = "/devices/eventNotificationCheck/json";
 
+    protected static final String REBOOT_DELAY_SECONDS_JSON_URL = "/devices/rebootDelaySeconds/json";
+
     protected static final String DEVICE_REGISTRATION_CHECK_URL = "/devices/deviceRegistrationCheck";
     protected static final String DEVICE_REBOOT_CHECK_URL = "/devices/deviceRebootCheck";
     protected static final String TARIFF_SWITCHING_CHECK_URL = "/devices/tariffSwitchingCheck";
     protected static final String LIGHT_SWITCHING_CHECK_URL = "/devices/lightSwitchingCheck";
     protected static final String EVENT_NOTIFICATION_CHECK_URL = "/devices/eventNotificationCheck";
+
+    protected static final String REBOOT_DELAY_SECONDS_URL = "/devices/rebootDelaySeconds";
 
     protected static final String MODEL_ATTRIBUTE_DEVICES = "devices";
     protected static final String MODEL_ATTRIBUTE_ISAUTONOMOUS = "isAutonomous";
@@ -104,13 +109,15 @@ public class DeviceManagementController extends AbstractController {
 
     protected static final String DEFAULT_SORT_DIRECTION = "DESC";
 
+    private final Random byteGenerator = new SecureRandom();
+
     @Resource
     private DeviceManagementService deviceManagementService;
 
     @Autowired
     private RegisterDevice registerDevice;
 
-    @RequestMapping(value = DEVICES_URL, method = RequestMethod.GET)
+    @GetMapping(value = DEVICES_URL)
     public String showDevices(
             @RequestParam(value = "devicesPerPage", required = false, defaultValue = "20") final Integer devicesPerPage,
             @RequestParam(value = "sort", required = false, defaultValue = DEFAULT_SORT_DIRECTION) final String sort,
@@ -120,7 +127,7 @@ public class DeviceManagementController extends AbstractController {
         return DEVICES_VIEW;
     }
 
-    @RequestMapping(value = "/devices/{pageNumber}", method = RequestMethod.GET)
+    @GetMapping(value = "/devices/{pageNumber}")
     public String showPageOFDevices(@PathVariable final Integer pageNumber,
             @RequestParam(value = "devicesPerPage", required = false, defaultValue = "20") final Integer devicesPerPage,
             @RequestParam(value = "sort", required = false, defaultValue = DEFAULT_SORT_DIRECTION) final String sort,
@@ -130,7 +137,7 @@ public class DeviceManagementController extends AbstractController {
         return DEVICES_VIEW;
     }
 
-    @RequestMapping(value = "/devices/{deviceIdentification}/{pageNumber}", method = RequestMethod.GET)
+    @GetMapping(value = "/devices/{deviceIdentification}/{pageNumber}")
     public String showPageOFDevices(@PathVariable final String deviceIdentification,
             @PathVariable final Integer pageNumber,
             @RequestParam(value = "devicesPerPage", required = false, defaultValue = "20") final Integer devicesPerPage,
@@ -177,77 +184,114 @@ public class DeviceManagementController extends AbstractController {
         LOGGER.debug("Fetched data: {} records, {} pages", page.getContent().size(), page.getTotalPages());
     }
 
-    @RequestMapping(value = DEVICE_REGISTRATION_CHECK_URL, method = RequestMethod.POST)
+    private ResponseEntity<String> badRequestResponse(final Object request) {
+        LOGGER.warn("Bad Request: {}", request);
+        return ResponseEntity.badRequest().build();
+    }
+
+    @PostMapping(value = DEVICE_REGISTRATION_CHECK_URL)
     public ResponseEntity<String> setDeviceRegistrationValue(@RequestBody final AutonomousRequest request) {
+        if (request == null || request.getAutonomousStatus() == null) {
+            return this.badRequestResponse(request);
+        }
 
         this.deviceManagementService.setdeviceRegistration(request.getAutonomousStatus());
 
         return ResponseEntity.ok().build();
     }
 
-    @RequestMapping(value = DEVICE_REGISTRATION_CHECK_JSON_URL, method = RequestMethod.GET)
+    @GetMapping(value = DEVICE_REGISTRATION_CHECK_JSON_URL)
     @ResponseBody
     public Boolean getDeviceRegistrationState() {
         return this.deviceManagementService.getDevRegistration();
     }
 
-    @RequestMapping(value = DEVICE_REBOOT_CHECK_URL, method = RequestMethod.POST)
-    public ResponseEntity<String> getDeviceRebootValue(@RequestBody final AutonomousRequest request) {
+    @PostMapping(value = DEVICE_REBOOT_CHECK_URL)
+    public ResponseEntity<String> setDeviceRebootValue(@RequestBody final AutonomousRequest request) {
+        if (request == null || request.getAutonomousStatus() == null) {
+            return this.badRequestResponse(request);
+        }
 
         this.deviceManagementService.setDeviceReboot(request.getAutonomousStatus());
 
         return ResponseEntity.ok().build();
     }
 
-    @RequestMapping(value = DEVICE_REBOOT_CHECK_JSON_URL, method = RequestMethod.GET)
+    @GetMapping(value = DEVICE_REBOOT_CHECK_JSON_URL)
     @ResponseBody
     public Boolean getDeviceRebootState() {
         return this.deviceManagementService.getDevReboot();
     }
 
-    @RequestMapping(value = TARIFF_SWITCHING_CHECK_URL, method = RequestMethod.POST)
-    public ResponseEntity<String> getTariffSwitchingValue(@RequestBody final AutonomousRequest request) {
+    @PostMapping(value = TARIFF_SWITCHING_CHECK_URL)
+    public ResponseEntity<String> setTariffSwitchingValue(@RequestBody final AutonomousRequest request) {
+        if (request == null || request.getAutonomousStatus() == null) {
+            return this.badRequestResponse(request);
+        }
 
         this.deviceManagementService.setTariffSwitching(request.getAutonomousStatus());
 
         return ResponseEntity.ok().build();
     }
 
-    @RequestMapping(value = TARIFF_SWITCHING_CHECK_JSON_URL, method = RequestMethod.GET)
+    @GetMapping(value = TARIFF_SWITCHING_CHECK_JSON_URL)
     @ResponseBody
     public Boolean getTariffSwitchingState() {
         return this.deviceManagementService.getTariffSwitching();
     }
 
-    @RequestMapping(value = LIGHT_SWITCHING_CHECK_URL, method = RequestMethod.POST)
-    public ResponseEntity<String> getLightSwitchingValue(@RequestBody final AutonomousRequest request) {
+    @PostMapping(value = LIGHT_SWITCHING_CHECK_URL)
+    public ResponseEntity<String> setLightSwitchingValue(@RequestBody final AutonomousRequest request) {
+        if (request == null || request.getAutonomousStatus() == null) {
+            return this.badRequestResponse(request);
+        }
 
         this.deviceManagementService.setLightSwitching(request.getAutonomousStatus());
 
         return ResponseEntity.ok().build();
     }
 
-    @RequestMapping(value = LIGHT_SWITCHING_CHECK_JSON_URL, method = RequestMethod.GET)
+    @GetMapping(value = LIGHT_SWITCHING_CHECK_JSON_URL)
     @ResponseBody
     public Boolean getLightSwitchingState() {
         return this.deviceManagementService.getLightSwitching();
     }
 
-    @RequestMapping(value = EVENT_NOTIFICATION_CHECK_URL, method = RequestMethod.POST)
-    public ResponseEntity<String> getEventNotificationValue(@RequestBody final AutonomousRequest request) {
+    @PostMapping(value = EVENT_NOTIFICATION_CHECK_URL)
+    public ResponseEntity<String> setEventNotificationValue(@RequestBody final AutonomousRequest request) {
+        if (request == null || request.getAutonomousStatus() == null) {
+            return this.badRequestResponse(request);
+        }
 
         this.deviceManagementService.setEventNotification(request.getAutonomousStatus());
 
         return ResponseEntity.ok().build();
     }
 
-    @RequestMapping(value = EVENT_NOTIFICATION_CHECK_JSON_URL, method = RequestMethod.GET)
+    @GetMapping(value = EVENT_NOTIFICATION_CHECK_JSON_URL)
     @ResponseBody
     public Boolean getEventNotificationState() {
         return this.deviceManagementService.getEventNotification();
     }
 
-    @RequestMapping(value = DEVICE_CREATE_URL, method = RequestMethod.GET)
+    @PostMapping(value = REBOOT_DELAY_SECONDS_URL)
+    public ResponseEntity<String> setRebootDelaySeconds(@RequestBody final DelayRequest request) {
+        if (request == null || request.getDelay() == null || request.getDelay() < 0) {
+            return this.badRequestResponse(request);
+        }
+
+        this.deviceManagementService.setRebootDelay(request.getDelay());
+
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping(value = REBOOT_DELAY_SECONDS_JSON_URL)
+    @ResponseBody
+    public int getRebootDelaySeconds() {
+        return this.deviceManagementService.getRebootDelay();
+    }
+
+    @GetMapping(value = DEVICE_CREATE_URL)
     public String showCreateDevice(final Model model) {
         model.addAttribute(MODEL_ATTRIBUTE_DEVICE, new Device());
 
@@ -257,14 +301,13 @@ public class DeviceManagementController extends AbstractController {
     private byte[] createRandomDeviceUid() {
         // Generate random bytes for UID
         final byte[] deviceUid = new byte[OslpEnvelope.DEVICE_ID_LENGTH];
-        final Random byteGenerator = new Random();
-        byteGenerator.nextBytes(deviceUid);
+        this.byteGenerator.nextBytes(deviceUid);
         // Combine manufacturer id of 2 bytes (1 is AME) and device UID of 10
         // bytes.
         return ArrayUtils.addAll(new byte[] { 0, 1 }, deviceUid);
     }
 
-    @RequestMapping(value = DEVICE_CREATE_URL, method = RequestMethod.POST)
+    @PostMapping(value = DEVICE_CREATE_URL)
     public String createDevice(@ModelAttribute(MODEL_ATTRIBUTE_DEVICE) final Device created,
             final BindingResult bindingResult, final RedirectAttributes attributes) {
 
@@ -280,20 +323,20 @@ public class DeviceManagementController extends AbstractController {
             device = this.deviceManagementService.addDevice(created);
             this.addFeedbackMessage(attributes, FEEDBACK_MESSAGE_KEY_DEVICE_CREATED, device.getDeviceIdentification());
         } catch (final Exception e) {
-            LOGGER.error("Error creating device: {}", e);
+            LOGGER.error("Error creating device", e);
             this.setErrorFeedbackMessage(created, attributes);
         }
 
         return this.createRedirectViewPath(DEVICES_URL);
     }
 
-    @RequestMapping(value = DEVICE_EDIT_URL, method = RequestMethod.GET)
+    @GetMapping(value = DEVICE_EDIT_URL)
     public String showEditDevice(@PathVariable final Long deviceId, final Model model) {
         model.addAttribute(MODEL_ATTRIBUTE_DEVICE, this.deviceManagementService.findDevice(deviceId));
         return DEVICE_EDIT_VIEW;
     }
 
-    @RequestMapping(value = DEVICE_EDIT_URL, method = RequestMethod.POST)
+    @PostMapping(value = DEVICE_EDIT_URL)
     public String editDevice(@ModelAttribute(MODEL_ATTRIBUTE_DEVICE) final Device updated,
             @PathVariable final Long deviceId, final BindingResult bindingResult, final RedirectAttributes attributes,
             final Model model) {
@@ -325,7 +368,7 @@ public class DeviceManagementController extends AbstractController {
         return DEVICE_EDIT_VIEW;
     }
 
-    @RequestMapping(value = COMMAND_REGISTER_URL, method = RequestMethod.POST)
+    @PostMapping(value = COMMAND_REGISTER_URL)
     @ResponseBody
     public String sendRegisterDeviceCommand(@RequestBody final RegisterDeviceRequest request) {
         // Find device
@@ -343,7 +386,7 @@ public class DeviceManagementController extends AbstractController {
         }
     }
 
-    @RequestMapping(value = COMMAND_REGISTER_CONFIRM_URL, method = RequestMethod.POST)
+    @PostMapping(value = COMMAND_REGISTER_CONFIRM_URL)
     @ResponseBody
     public String sendConfirmDeviceRegistrationCommand(@RequestBody final ConfirmDeviceRegistrationRequest request) {
 
@@ -363,7 +406,7 @@ public class DeviceManagementController extends AbstractController {
 
     }
 
-    @RequestMapping(value = COMMAND_SENDNOTIFICATION_URL, method = RequestMethod.POST)
+    @PostMapping(value = COMMAND_SENDNOTIFICATION_URL)
     @ResponseBody
     public String sendEventNotificationCommandAll(@RequestBody final SendEventNotificationRequest request) {
 
@@ -382,13 +425,13 @@ public class DeviceManagementController extends AbstractController {
         }
     }
 
-    @RequestMapping(value = DEVICES_JSON_URL, method = RequestMethod.GET)
+    @GetMapping(value = DEVICES_JSON_URL)
     @ResponseBody
     public List<Device> getLightStates() {
         return this.deviceManagementService.findAllDevices();
     }
 
-    @RequestMapping(value = COMMAND_GET_SEQUENCE_NUMBER_URL, method = RequestMethod.POST)
+    @PostMapping(value = COMMAND_GET_SEQUENCE_NUMBER_URL)
     @ResponseBody
     public Integer getSequenceNumber(@RequestBody final GetSequenceNumberRequest getSequenceNumberRequest) {
         final Long deviceId = getSequenceNumberRequest.getDeviceId();
@@ -401,7 +444,7 @@ public class DeviceManagementController extends AbstractController {
         }
     }
 
-    @RequestMapping(value = COMMAND_SET_SEQUENCE_NUMBER_URL, method = RequestMethod.POST)
+    @PostMapping(value = COMMAND_SET_SEQUENCE_NUMBER_URL)
     @ResponseBody
     public Integer setSequenceNumber(@RequestBody final SetSequenceNumberRequest setSequenceNumberRequest) {
         final Long deviceId = setSequenceNumberRequest.getDeviceId();

--- a/osgp/protocol-adapter-oslp/web-device-simulator/src/main/resources/i18n/messages.properties
+++ b/osgp/protocol-adapter-oslp/web-device-simulator/src/main/resources/i18n/messages.properties
@@ -40,6 +40,7 @@ device.edit.page.device.reboot = DeviceReboot
 device.edit.page.device.tariff.switching = TariffSwitching
 device.edit.page.device.light.switching = LightSwitching
 device.edit.page.device.event.notification = EventNotification
+device.edit.page.device.reboot.delay = Reboot delay (seconds)
 device.edit.page.submit.label = Save Changes
 device.edit.page.commands.label = Commands
 device.edit.page.commands.send.label = Send OSLP Command

--- a/osgp/protocol-adapter-oslp/web-device-simulator/src/main/resources/web-device-simulator.properties
+++ b/osgp/protocol-adapter-oslp/web-device-simulator/src/main/resources/web-device-simulator.properties
@@ -63,6 +63,11 @@ oslp.security.provider=SunEC
 oslp.sequence.number.window=6
 oslp.sequence.number.maximum=65535
 
+# Reboot delay in seconds
+# When the device simulates a reboot, this delay will be applied before
+# the device starts the registration process following the reboot.
+reboot.delay.seconds=5
+
 # --- Response Delay Time in milliseconds ---
 # The response.delay.time value offers a fixed delay. The response.delay.random.range offers a maximum extra delay, which will be multiplied with a random value between 0.0 and 1.0. The values are optional properties, but if the response.delay.random.range value is set, the response.delay.time value has to be set as well (but can be 0 if needed).
 response.delay.time=10

--- a/osgp/protocol-adapter-oslp/web-device-simulator/src/main/webapp/WEB-INF/views/devices/list.jsp
+++ b/osgp/protocol-adapter-oslp/web-device-simulator/src/main/webapp/WEB-INF/views/devices/list.jsp
@@ -73,16 +73,18 @@ body {
                             <spring:message code="device.list.page.title" />
                         </h1>
                         <a href="/web-device-simulator/devices/create" class="btn btn-primary"><spring:message code="device.create.link.label" /></a>
-                            <spring:message code="device.edit.page.device.registration" />
-                            <input id="devRegistration" name="devRegistration" type="checkbox"/>
-                            <spring:message code="device.edit.page.device.reboot" />
-                            <input id="devReboot" name="devReboot" type="checkbox"/>
-                            <spring:message code="device.edit.page.device.tariff.switching" />
-                            <input id="tariffSwitching" name="tariffSwitching" type="checkbox"/>
-                            <spring:message code="device.edit.page.device.light.switching" />
-                            <input id="lightSwitching" name="lightSwitching" type="checkbox"/>
-                            <spring:message code="device.edit.page.device.event.notification" />
-                            <input id="eventListener" name="eventListener" type="checkbox"/>
+                        <label for="devRegistration" style="display: inline; margin-left: .5em;"><spring:message code="device.edit.page.device.registration" /></label>
+                        <input id="devRegistration" name="devRegistration" type="checkbox" style="display: inline;" />
+                        <label for="devReboot" style="display: inline; margin-left: .5em;"><spring:message code="device.edit.page.device.reboot" /></label>
+                        <input id="devReboot" name="devReboot" type="checkbox" style="display: inline;" />
+                        <label for="tariffSwitching" style="display: inline; margin-left: .5em;"><spring:message code="device.edit.page.device.tariff.switching" /></label>
+                        <input id="tariffSwitching" name="tariffSwitching" type="checkbox" style="display: inline;" />
+                        <label for="lightSwitching" style="display: inline; margin-left: .5em;"><spring:message code="device.edit.page.device.light.switching" /></label>
+                        <input id="lightSwitching" name="lightSwitching" type="checkbox" style="display: inline;" />
+                        <label for="eventListener" style="display: inline; margin-left: .5em;"><spring:message code="device.edit.page.device.event.notification" /></label>
+                        <input id="eventListener" name="eventListener" type="checkbox" style="display: inline;" />
+                        <label for="rebootDelay" style="display: inline; margin-left: .5em;"><spring:message code="device.edit.page.device.reboot.delay" /></label>
+                        <input id="rebootDelay" name="rebootDelay" type="text" style="display: inline; width: 3em;" />
                     </div>
                 </div>
                 <div class="row" style="margin-top: 25px">
@@ -218,7 +220,7 @@ body {
                         </c:choose>
                     </ul>
                 </div>
-                
+
             </div>
         </div>
 
@@ -232,8 +234,7 @@ body {
             function() {
 
                 $('#devRegistration').change(function() {
-                    var request = new Object();
-                    request.autonomousStatus = $('#devRegistration').prop('checked');
+                    var request = { autonomousStatus: $('#devRegistration').prop('checked') };
 
                     $.ajax({
                         type : 'POST',
@@ -246,8 +247,7 @@ body {
                 });
 
                 $('#devReboot').change(function() {
-                    var request = new Object();
-                    request.autonomousStatus = $('#devReboot').prop('checked');
+                    var request = { autonomousStatus: $('#devReboot').prop('checked') };
 
                     $.ajax({
                         type : 'POST',
@@ -258,10 +258,9 @@ body {
                         async : true
                     });
                 });
-                
+
                 $('#tariffSwitching').change(function() {
-                    var request = new Object();
-                    request.autonomousStatus = $('#tariffSwitching').prop('checked');
+                    var request = { autonomousStatus: $('#tariffSwitching').prop('checked') };
 
                     $.ajax({
                         type : 'POST',
@@ -274,8 +273,7 @@ body {
                 });
 
                 $('#lightSwitching').change(function() {
-                    var request = new Object();
-                    request.autonomousStatus = $('#lightSwitching').prop('checked');
+                    var request = { autonomousStatus: $('#lightSwitching').prop('checked') };
 
                     $.ajax({
                         type : 'POST',
@@ -288,12 +286,24 @@ body {
                 });
 
                 $('#eventListener').change(function() {
-                    var request = new Object();
-                    request.autonomousStatus = $('#eventListener').prop('checked');
+                    var request = { autonomousStatus: $('#eventListener').prop('checked') };
 
                     $.ajax({
                         type : 'POST',
                         url : '/web-device-simulator/devices/eventNotificationCheck',
+                        contentType : 'application/json',
+                        dataType : 'json',
+                        data : JSON.stringify(request),
+                        async : true
+                    });
+                });
+
+                document.getElementById('rebootDelay').addEventListener('input', function(e) {
+                    var request = { delay: Math.abs(e.target.value.replace(/\D/g, '')) };
+
+                    $.ajax({
+                        type : 'POST',
+                        url : '/web-device-simulator/devices/rebootDelaySeconds',
                         contentType : 'application/json',
                         dataType : 'json',
                         data : JSON.stringify(request),
@@ -362,12 +372,28 @@ body {
                     });
                 }
 
+                function fetchDelaySeconds() {
+                    $.ajax({
+                        type : 'GET',
+                        url : '/web-device-simulator/devices/rebootDelaySeconds/json',
+                        dataType : 'json',
+                        contentType : 'application/json',
+                        async : true,
+                        cache : false,
+                        success : function(data) {
+                            $('#rebootDelay').prop('value', data);
+                        }
+                    });
+                }
+
                 fetchCheckboxStates();
+                fetchDelaySeconds();
                 setInterval(refreshPage, 10000);
 
                 function refreshPage() {
                     window.location.reload();
                     fetchCheckboxStates();
+                    fetchDelaySeconds();
                 }
             });
 
@@ -386,7 +412,7 @@ body {
         });
 
         // a list of illegal tokens
-        var illegalTokens = ['~', '`', '!', '@', '#', '$', '¤', '€', '%', '^', '&', '*', '(', ')', '=', '+', 
+        var illegalTokens = ['~', '`', '!', '@', '#', '$', '¤', '€', '%', '^', '&', '*', '(', ')', '=', '+',
                              '{', '}', '[', ']', '|', '\\', ':',
                              ';', '\'', '"', '<', '>', ',', '.', '?', '/', ' '];
         // check if 'input' contains the 'token'
@@ -397,7 +423,7 @@ body {
         $('#setFilter').click(function() {
             // get the filter criteria entered by the user
             var devId = $('#deviceIdentification').val();
-            
+
             // check if the filter criteria is present
             if (devId) {
                 // loop through the list of illegal token
@@ -406,7 +432,7 @@ body {
                     // check if the illegal token is present in the filter criteria
                     if (contains(devId, token)) {
                         //alert('Dit teken mag niet worden gebruikt voor een deviceId: ' + token);
-                        
+
                         // preset the user with a clear error message
                         var messageToken = token === ' ' ? 'spatie' : token;
                         $('#errorMessage').html('Dit teken mag niet worden gebruikt voor een apparaat identificatie: ' + messageToken);
@@ -465,7 +491,7 @@ body {
             var page = '';
             var size = '';
             var sort = '';
-            
+
             if (devId) {
                 deviceIdentification = '/' + devId;
             }
@@ -476,7 +502,7 @@ body {
                 size = '?devicesPerPage=' + pageSize;
             }
             if (sortDirection) {
-                sort = '&sort=' + sortDirection; 
+                sort = '&sort=' + sortDirection;
             }
 
             window.location.href = '<c:url value="/devices"/>' + deviceIdentification + page + size + sort;

--- a/osgp/protocol-adapter-oslp/web-device-simulator/src/test/java/org/opensmartgridplatform/webdevicesimulator/Assertions.java
+++ b/osgp/protocol-adapter-oslp/web-device-simulator/src/test/java/org/opensmartgridplatform/webdevicesimulator/Assertions.java
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2020 Alliander N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.opensmartgridplatform.webdevicesimulator;
+
+import org.opensmartgridplatform.oslp.OslpEnvelope;
+
+public class Assertions extends org.assertj.core.api.Assertions {
+
+    public static OslpEnvelopeAssert assertThat(final OslpEnvelope oslpEnvelope) {
+        return new OslpEnvelopeAssert(oslpEnvelope);
+    }
+}

--- a/osgp/protocol-adapter-oslp/web-device-simulator/src/test/java/org/opensmartgridplatform/webdevicesimulator/DeviceSimulatorIT.java
+++ b/osgp/protocol-adapter-oslp/web-device-simulator/src/test/java/org/opensmartgridplatform/webdevicesimulator/DeviceSimulatorIT.java
@@ -1,0 +1,313 @@
+/**
+ * Copyright 2020 Alliander N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.opensmartgridplatform.webdevicesimulator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opensmartgridplatform.webdevicesimulator.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.security.SecureRandom;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.opensmartgridplatform.oslp.Oslp;
+import org.opensmartgridplatform.oslp.OslpDecoder;
+import org.opensmartgridplatform.oslp.OslpEncoder;
+import org.opensmartgridplatform.oslp.OslpEnvelope;
+import org.opensmartgridplatform.shared.infra.networking.DisposableNioEventLoopGroup;
+import org.opensmartgridplatform.webdevicesimulator.application.config.OslpConfig;
+import org.opensmartgridplatform.webdevicesimulator.application.services.DeviceManagementService;
+import org.opensmartgridplatform.webdevicesimulator.domain.entities.Device;
+import org.opensmartgridplatform.webdevicesimulator.domain.entities.DeviceMessageStatus;
+import org.opensmartgridplatform.webdevicesimulator.domain.entities.OslpLogItem;
+import org.opensmartgridplatform.webdevicesimulator.domain.repositories.OslpLogItemRepository;
+import org.opensmartgridplatform.webdevicesimulator.service.OslpSecurityHandler;
+import org.opensmartgridplatform.webdevicesimulator.service.RegisterDevice;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.handler.logging.ByteBufFormat;
+import io.netty.handler.logging.LogLevel;
+import io.netty.handler.logging.LoggingHandler;
+
+@ExtendWith(SpringExtension.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
+@ContextConfiguration(classes = { TestConfig.class, OslpConfig.class })
+class DeviceSimulatorIT {
+
+    private static final AtomicLong DEVICE_ID = new AtomicLong(0);
+
+    private static final int REBOOT_DELAY_IN_SECONDS = 1;
+
+    @Autowired
+    private OslpConfig oslpConfig;
+
+    @Autowired
+    private TestConfig testConfig;
+
+    @Autowired
+    private DeviceManagementService deviceManagementService;
+
+    @Autowired
+    private RegisterDevice registerDevice;
+
+    @Autowired
+    private OslpLogItemRepository oslpLogItemRepository;
+
+    private final Random random = new SecureRandom();
+
+    @Mock
+    private Consumer<OslpEnvelope> oslpEnvelopeConsumer;
+
+    @Captor
+    private ArgumentCaptor<OslpEnvelope> oslpEnvelopeCaptor;
+
+    @Captor
+    private ArgumentCaptor<OslpLogItem> oslpLogItemCaptor;
+
+    @BeforeEach
+    void setUp() {
+        when(this.deviceManagementService.getRebootDelay()).thenReturn(REBOOT_DELAY_IN_SECONDS);
+    }
+
+    @AfterEach
+    void tearDown() {
+        clearInvocations(this.oslpLogItemRepository, this.registerDevice);
+    }
+
+    @Test
+    void savesOslpLogItemsForRequestAndResponse() throws Exception {
+        final long id = DEVICE_ID.incrementAndGet();
+        final int sequenceNumber = this.aSequenceNumber();
+        final byte[] deviceUid = this.aDeviceUid();
+        final Device device = this.aDevice(id, String.format("TST-%03d", id), deviceUid, sequenceNumber);
+        when(this.deviceManagementService.findDevice(device.getDeviceUid())).thenReturn(device);
+        final Channel channel = this.activeChannelToSimulator();
+        channel.writeAndFlush(this.setRebootEnvelope(deviceUid, sequenceNumber));
+        channel.closeFuture().awaitUninterruptibly(1000 * (REBOOT_DELAY_IN_SECONDS + 1));
+        verify(this.oslpLogItemRepository, times(2)).save(this.oslpLogItemCaptor.capture());
+        final List<OslpLogItem> savedOslpLogItems = this.oslpLogItemCaptor.getAllValues();
+        savedOslpLogItems.forEach(savedOslpLogItem -> {
+            assertThat(savedOslpLogItem.getDeviceUid()).isEqualTo(device.getDeviceUid());
+        });
+        assertThat(savedOslpLogItems.get(0).isIncoming()).isTrue();
+        assertThat(savedOslpLogItems.get(1).isIncoming()).isFalse();
+    }
+
+    @Test
+    void sendsRegisterDeviceCommandOnRebootRequest() throws Exception {
+        final long id = DEVICE_ID.incrementAndGet();
+        final int sequenceNumber = this.aSequenceNumber();
+        final byte[] deviceUid = this.aDeviceUid();
+        final Device device = this.aDevice(id, String.format("TST-%03d", id), deviceUid, sequenceNumber);
+        when(this.deviceManagementService.findDevice(device.getDeviceUid())).thenReturn(device);
+        when(this.registerDevice.sendRegisterDeviceCommand(id, true)).thenReturn(DeviceMessageStatus.FAILURE);
+
+        final Channel channel = this.activeChannelToSimulator();
+        channel.writeAndFlush(this.setRebootEnvelope(deviceUid, sequenceNumber));
+        channel.closeFuture().awaitUninterruptibly(1000 * (REBOOT_DELAY_IN_SECONDS + 1));
+        verify(this.registerDevice).sendRegisterDeviceCommand(id, true);
+    }
+
+    @Test
+    void returnsASetRebootResponseOnRebootRequest() throws Exception {
+        final long id = DEVICE_ID.incrementAndGet();
+        final int sequenceNumber = this.aSequenceNumber();
+        final byte[] deviceUid = this.aDeviceUid();
+        final Device device = this.aDevice(id, String.format("TST-%03d", id), deviceUid, sequenceNumber);
+        when(this.deviceManagementService.findDevice(device.getDeviceUid())).thenReturn(device);
+        when(this.registerDevice.sendRegisterDeviceCommand(id, true)).thenReturn(DeviceMessageStatus.FAILURE);
+
+        final Channel channel = this.activeChannelToSimulator();
+        channel.writeAndFlush(this.setRebootEnvelope(deviceUid, sequenceNumber));
+        channel.closeFuture().awaitUninterruptibly(1000 * (REBOOT_DELAY_IN_SECONDS + 1));
+        verify(this.oslpEnvelopeConsumer).accept(this.oslpEnvelopeCaptor.capture());
+        final OslpEnvelope responseEnvelope = this.oslpEnvelopeCaptor.getValue();
+        assertThat(responseEnvelope).hasDeviceId(deviceUid).hasMessageWithName("setRebootResponse");
+    }
+
+    @Test
+    void doesNotProcessRequestsDuringRebootDelay() throws Exception {
+        this.whenUsingARebootDelayOf(60);
+        final long id = DEVICE_ID.incrementAndGet();
+        final int sequenceNumber = this.aSequenceNumber();
+        final byte[] deviceUid = this.aDeviceUid();
+        final Device device = this.aDevice(id, String.format("TST-%03d", id), deviceUid, sequenceNumber);
+        when(this.deviceManagementService.findDevice(device.getDeviceUid())).thenReturn(device);
+        when(this.registerDevice.sendRegisterDeviceCommand(id, true)).thenReturn(DeviceMessageStatus.FAILURE);
+        Channel channel = this.activeChannelToSimulator();
+        channel.writeAndFlush(this.setRebootEnvelope(deviceUid, sequenceNumber));
+        channel.closeFuture().awaitUninterruptibly(1000);
+        channel = this.activeChannelToSimulator();
+        channel.writeAndFlush(this.setRebootEnvelope(deviceUid, sequenceNumber));
+        channel.closeFuture().awaitUninterruptibly(1000);
+        verify(this.oslpLogItemRepository, times(2)).save(any(OslpLogItem.class));
+        verify(this.oslpEnvelopeConsumer).accept(any(OslpEnvelope.class));
+    }
+
+    @Test
+    void processesRequestAfterRebootDelay() throws Exception {
+        final long id = DEVICE_ID.incrementAndGet();
+        final int sequenceNumber = this.aSequenceNumber();
+        final byte[] deviceUid = this.aDeviceUid();
+        final Device device = this.aDevice(id, String.format("TST-%03d", id), deviceUid, sequenceNumber);
+        when(this.deviceManagementService.findDevice(device.getDeviceUid())).thenReturn(device);
+        when(this.registerDevice.sendRegisterDeviceCommand(id, true)).thenReturn(DeviceMessageStatus.FAILURE);
+        Channel channel = this.activeChannelToSimulator();
+        channel.writeAndFlush(this.setRebootEnvelope(deviceUid, sequenceNumber));
+        channel.closeFuture().awaitUninterruptibly(1000 * (REBOOT_DELAY_IN_SECONDS + 1));
+        channel = this.activeChannelToSimulator();
+        channel.writeAndFlush(this.setRebootEnvelope(deviceUid, sequenceNumber));
+        channel.closeFuture().awaitUninterruptibly(1000);
+        verify(this.oslpLogItemRepository, times(4)).save(any(OslpLogItem.class));
+        verify(this.oslpEnvelopeConsumer, times(2)).accept(any(OslpEnvelope.class));
+    }
+
+    @Test
+    void allowsRequestForOtherDeviceDuringRebootDelay() throws Exception {
+        this.whenUsingARebootDelayOf(60);
+        final long id1 = DEVICE_ID.incrementAndGet();
+        final int sequenceNumber1 = this.aSequenceNumber();
+        final byte[] deviceUid1 = this.aDeviceUid();
+        final Device device1 = this.aDevice(id1, String.format("TST-%03d", id1), deviceUid1, sequenceNumber1);
+        when(this.deviceManagementService.findDevice(device1.getDeviceUid())).thenReturn(device1);
+        when(this.registerDevice.sendRegisterDeviceCommand(id1, true)).thenReturn(DeviceMessageStatus.FAILURE);
+        final long id2 = DEVICE_ID.incrementAndGet();
+        final int sequenceNumber2 = this.aSequenceNumber();
+        final byte[] deviceUid2 = this.aDeviceUid();
+        final Device device2 = this.aDevice(id2, String.format("TST-%03d", id2), deviceUid2, sequenceNumber2);
+        when(this.deviceManagementService.findDevice(device2.getDeviceUid())).thenReturn(device2);
+        when(this.registerDevice.sendRegisterDeviceCommand(id2, true)).thenReturn(DeviceMessageStatus.FAILURE);
+        Channel channel = this.activeChannelToSimulator();
+        channel.writeAndFlush(this.setRebootEnvelope(deviceUid1, sequenceNumber1));
+        channel.closeFuture().awaitUninterruptibly(1000);
+        channel = this.activeChannelToSimulator();
+        channel.writeAndFlush(this.setRebootEnvelope(deviceUid2, sequenceNumber2));
+        channel.closeFuture().awaitUninterruptibly(1000);
+        verify(this.oslpLogItemRepository, times(4)).save(any(OslpLogItem.class));
+        verify(this.oslpEnvelopeConsumer, times(2)).accept(this.oslpEnvelopeCaptor.capture());
+        final List<OslpEnvelope> responseEnvelopes = this.oslpEnvelopeCaptor.getAllValues();
+        assertThat(responseEnvelopes.get(0)).hasDeviceId(deviceUid1).hasMessageWithName("setRebootResponse");
+        assertThat(responseEnvelopes.get(1)).hasDeviceId(deviceUid2).hasMessageWithName("setRebootResponse");
+    }
+
+    private int aSequenceNumber() {
+        return this.random.nextInt(-2 * Short.MIN_VALUE);
+    }
+
+    private byte[] aDeviceUid() {
+        final byte[] bytes = new byte[12];
+        this.random.nextBytes(bytes);
+        return bytes;
+    }
+
+    private Device aDevice(final Long id, final String deviceIdentification, final byte[] deviceUid,
+            final int sequenceNumber) {
+        final Device device = new Device();
+        ReflectionTestUtils.setField(device, "id", id);
+        device.setDeviceIdentification(deviceIdentification);
+        device.setDeviceUid(deviceUid);
+        device.setSequenceNumber(sequenceNumber);
+        return device;
+    }
+
+    private Channel activeChannelToSimulator() throws IOException {
+        final ChannelFuture channelFuture = this.testClientBootstrap()
+                .connect(this.oslpConfig.oslpAddressServer(), this.oslpConfig.oslpElsterPortServer());
+        if (!channelFuture.awaitUninterruptibly(this.oslpConfig.connectionTimeout(), TimeUnit.MILLISECONDS)) {
+            throw new IOException("Unable to connect");
+        }
+        channelFuture.addListener(new ChannelFutureListener() {
+            @Override
+            public void operationComplete(final ChannelFuture future) throws IOException {
+                final boolean success = future.isSuccess();
+                final boolean done = future.isDone();
+                final boolean cancelled = future.isCancelled();
+                System.out.printf("%nChannel operationComplete - success %b, done %b, cancelled %b%n%n", success, done,
+                        cancelled);
+            }
+        });
+        return channelFuture.channel();
+    }
+
+    private OslpEnvelope setRebootEnvelope(final byte[] deviceId, final int sequenceNumber) throws Exception {
+        return new OslpEnvelope.Builder().withProvider(this.oslpConfig.oslpSignatureProvider())
+                .withSignature(this.oslpConfig.oslpSignature())
+                .withPrimaryKey(this.testConfig.privateKeySigningServer())
+                .withSequenceNumber(ByteBuffer.allocate(2).putShort((short) sequenceNumber).array())
+                .withDeviceId(deviceId)
+                .withPayloadMessage(
+                        Oslp.Message.newBuilder().setSetRebootRequest(Oslp.SetRebootRequest.newBuilder()).build())
+                .build();
+    }
+
+    private Bootstrap testClientBootstrap() {
+
+        final Bootstrap bootstrap = new Bootstrap();
+        bootstrap.group(new DisposableNioEventLoopGroup());
+        bootstrap.channel(NioSocketChannel.class);
+        bootstrap.handler(new ChannelInitializer<SocketChannel>() {
+            @Override
+            protected void initChannel(final SocketChannel ch) throws Exception {
+                final ChannelPipeline pipeline = ch.pipeline();
+                pipeline.addLast("loggingHandler", new LoggingHandler(LogLevel.INFO, ByteBufFormat.HEX_DUMP));
+                pipeline.addLast("oslpEncoder", new OslpEncoder());
+                pipeline.addLast("oslpDecoder", new OslpDecoder(DeviceSimulatorIT.this.oslpConfig.oslpSignature(),
+                        DeviceSimulatorIT.this.oslpConfig.oslpSignatureProvider()));
+                final OslpSecurityHandler oslpSecurityHandler = new OslpSecurityHandler();
+                ReflectionTestUtils.setField(oslpSecurityHandler, "publicKey",
+                        DeviceSimulatorIT.this.testConfig.publicKeySimulator());
+                pipeline.addLast("oslpSecurity", oslpSecurityHandler);
+                pipeline.addLast(new OslpTestHandler(DeviceSimulatorIT.this.oslpEnvelopeConsumer));
+            }
+        });
+
+        bootstrap.option(ChannelOption.TCP_NODELAY, true);
+        bootstrap.option(ChannelOption.SO_KEEPALIVE, false);
+        bootstrap.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, this.oslpConfig.connectionTimeout());
+
+        return bootstrap;
+    }
+
+    private void whenUsingARebootDelayOf(final int rebootDelayInSeconds) {
+        reset(this.deviceManagementService);
+        when(this.deviceManagementService.getRebootDelay()).thenReturn(rebootDelayInSeconds);
+    }
+}

--- a/osgp/protocol-adapter-oslp/web-device-simulator/src/test/java/org/opensmartgridplatform/webdevicesimulator/OslpEnvelopeAssert.java
+++ b/osgp/protocol-adapter-oslp/web-device-simulator/src/test/java/org/opensmartgridplatform/webdevicesimulator/OslpEnvelopeAssert.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2020 Alliander N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.opensmartgridplatform.webdevicesimulator;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+import org.apache.commons.codec.binary.Base64;
+import org.assertj.core.api.AbstractAssert;
+import org.opensmartgridplatform.oslp.OslpEnvelope;
+
+import com.google.protobuf.GeneratedMessage;
+
+public class OslpEnvelopeAssert extends AbstractAssert<OslpEnvelopeAssert, OslpEnvelope> {
+
+    public OslpEnvelopeAssert(final OslpEnvelope actual) {
+        super(actual, OslpEnvelopeAssert.class);
+    }
+
+    public OslpEnvelopeAssert hasDeviceId(final byte[] expectedDeviceId) {
+        this.isNotNull();
+        assertArrayEquals(expectedDeviceId, this.actual.getDeviceId(),
+                String.format("Expected message to have deviceId %s, but found: %s",
+                        Base64.encodeBase64String(expectedDeviceId),
+                        Base64.encodeBase64String(this.actual.getDeviceId())));
+        return this;
+    }
+
+    public OslpEnvelopeAssert hasMessageWithName(final String expectedMessageName) {
+        this.isNotNull();
+        final String actualMessageName = this.messageName(this.actual);
+        if (expectedMessageName == null || !expectedMessageName.equals(actualMessageName)) {
+            this.failWithMessage("Expected OslpEnvelope to have a payload message containing a %s; found a %s",
+                    expectedMessageName, actualMessageName);
+        }
+        return this;
+    }
+
+    private String messageName(final OslpEnvelope oslpEnvelope) {
+        if (oslpEnvelope == null) {
+            return null;
+        }
+        return oslpEnvelope.getPayloadMessage()
+                .getAllFields()
+                .entrySet()
+                .stream()
+                .filter(entry -> entry.getValue() instanceof GeneratedMessage)
+                .map(entry -> entry.getKey().getName())
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/osgp/protocol-adapter-oslp/web-device-simulator/src/test/java/org/opensmartgridplatform/webdevicesimulator/OslpTestHandler.java
+++ b/osgp/protocol-adapter-oslp/web-device-simulator/src/test/java/org/opensmartgridplatform/webdevicesimulator/OslpTestHandler.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2020 Alliander N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.opensmartgridplatform.webdevicesimulator;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+
+import org.apache.commons.codec.binary.Base64;
+import org.opensmartgridplatform.oslp.OslpEnvelope;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.protobuf.GeneratedMessage;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+
+public class OslpTestHandler extends SimpleChannelInboundHandler<OslpEnvelope> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OslpTestHandler.class);
+
+    private final Consumer<OslpEnvelope> oslpEnvelopeConsumer;
+
+    public OslpTestHandler() {
+        this(oslpEnvelope -> LOGGER.info("Received OslpEnvelope for deviceUid {} containing a {}",
+                Base64.encodeBase64String(oslpEnvelope.getDeviceId()),
+                oslpEnvelope.getPayloadMessage()
+                        .getAllFields()
+                        .entrySet()
+                        .stream()
+                        .filter(entry -> entry.getValue() instanceof GeneratedMessage)
+                        .map(entry -> entry.getKey().getName())
+                        .findFirst()
+                        .orElse("?")));
+    }
+
+    public OslpTestHandler(final Consumer<OslpEnvelope> oslpEnvelopeConsumer) {
+        this.oslpEnvelopeConsumer = Objects.requireNonNull(oslpEnvelopeConsumer);
+    }
+
+    @Override
+    protected void channelRead0(final ChannelHandlerContext ctx, final OslpEnvelope msg) throws Exception {
+        msg.getPayloadMessage()
+                .getAllFields()
+                .entrySet()
+                .stream()
+                .filter(entry -> entry.getValue() instanceof GeneratedMessage)
+                .map(entry -> entry.getKey().getName())
+                .findFirst();
+        this.oslpEnvelopeConsumer.accept(msg);
+    }
+}

--- a/osgp/protocol-adapter-oslp/web-device-simulator/src/test/java/org/opensmartgridplatform/webdevicesimulator/TestConfig.java
+++ b/osgp/protocol-adapter-oslp/web-device-simulator/src/test/java/org/opensmartgridplatform/webdevicesimulator/TestConfig.java
@@ -1,0 +1,179 @@
+/**
+ * Copyright 2020 Alliander N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.opensmartgridplatform.webdevicesimulator;
+
+import static org.mockito.Mockito.mock;
+
+import java.io.IOException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+
+import org.opensmartgridplatform.shared.security.CertificateHelper;
+import org.opensmartgridplatform.webdevicesimulator.application.services.DeviceManagementService;
+import org.opensmartgridplatform.webdevicesimulator.application.services.OslpLogService;
+import org.opensmartgridplatform.webdevicesimulator.domain.repositories.DeviceRepository;
+import org.opensmartgridplatform.webdevicesimulator.domain.repositories.OslpLogItemRepository;
+import org.opensmartgridplatform.webdevicesimulator.service.RegisterDevice;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+
+@Configuration
+@PropertySource("classpath:web-device-simulator.properties")
+@PropertySource("classpath:web-device-simulator-test.properties")
+public class TestConfig {
+
+    @Value("${reboot.delay.seconds:5}")
+    private int rebootDelayInSeconds;
+
+    @Value("${response.delay.time:10}")
+    private long responseDelayTime;
+    @Value("${response.delay.random.range:20}")
+    private long responseDelayRandomRange;
+
+    @Value("${checkbox.device.registration.value:false}")
+    private boolean checkboxDeviceRegistration;
+    @Value("${checkbox.device.reboot.value:false}")
+    private boolean checkboxDeviceReboot;
+    @Value("${checkbox.light.switching.value:false}")
+    private boolean checkboxLightSwitching;
+    @Value("${checkbox.tariff.switching.value:false}")
+    private boolean checkboxTariffSwitching;
+    @Value("${checkbox.event.notification.value:false}")
+    private boolean checkboxEventNotification;
+
+    @Value("${configuration.ip.config.fixed.ip.address:192.168.0.100}")
+    private String ipConfigFixedIpAddress;
+    @Value("${configuration.ip.config.netmask:255.255.255.0}")
+    private String ipConfigNetmask;
+    @Value("${configuration.ip.config.gateway:192.168.0.1}")
+    private String ipConfigGateway;
+    @Value("${configuration.osgp.ip.address:168.63.97.65}")
+    private String osgpIpAddress;
+    @Value("${configuration.osgp.port.number:12122}")
+    private int osgpPortNumber;
+    @Value("${status.internal.ip.address:127.0.0.1}")
+    private String statusInternalIpAddress;
+
+    @Value("${oslp.security.test.signkey.path}")
+    private String privateKeySigningServerPath;
+    @Value("${oslp.security.simulator.verifykey.path}")
+    private String publicKeySimulatorPath;
+    @Value("${oslp.security.keytype}")
+    private String securityKeyType;
+    @Value("${oslp.security.provider}")
+    private String securityProvider;
+
+    @Bean
+    public Integer rebootDelayInSeconds() {
+        return this.rebootDelayInSeconds;
+    }
+
+    @Bean
+    public Long responseDelayTime() {
+        return this.responseDelayTime;
+    }
+
+    @Bean
+    public Long reponseDelayRandomRange() {
+        return this.responseDelayRandomRange;
+    }
+
+    @Bean
+    public Boolean checkboxDeviceRegistrationValue() {
+        return this.checkboxDeviceRegistration;
+    }
+
+    @Bean
+    public Boolean checkboxDeviceRebootValue() {
+        return this.checkboxDeviceReboot;
+    }
+
+    @Bean
+    public Boolean checkboxLightSwitchingValue() {
+        return this.checkboxLightSwitching;
+    }
+
+    @Bean
+    public Boolean checkboxTariffSwitchingValue() {
+        return this.checkboxTariffSwitching;
+    }
+
+    @Bean
+    public Boolean checkboxEventNotificationValue() {
+        return this.checkboxEventNotification;
+    }
+
+    @Bean
+    public String configurationIpConfigFixedIpAddress() {
+        return this.ipConfigFixedIpAddress;
+    }
+
+    @Bean
+    public String configurationIpConfigNetmask() {
+        return this.ipConfigNetmask;
+    }
+
+    @Bean
+    public String configurationIpConfigGateway() {
+        return this.ipConfigGateway;
+    }
+
+    @Bean
+    public String configurationOsgpIpAddress() {
+        return this.osgpIpAddress;
+    }
+
+    @Bean
+    public Integer configurationOsgpPortNumber() {
+        return this.osgpPortNumber;
+    }
+
+    @Bean
+    public String statusInternalIpAddress() {
+        return this.statusInternalIpAddress;
+    }
+
+    @Bean
+    public PrivateKey privateKeySigningServer() throws IOException {
+        return CertificateHelper.createPrivateKey(this.privateKeySigningServerPath, this.securityKeyType,
+                this.securityProvider);
+    }
+
+    @Bean
+    public PublicKey publicKeySimulator() throws IOException {
+        return CertificateHelper.createPublicKey(this.publicKeySimulatorPath, this.securityKeyType,
+                this.securityProvider);
+    }
+
+    @Bean
+    public DeviceRepository deviceRepository() {
+        return mock(DeviceRepository.class);
+    }
+
+    @Bean
+    public DeviceManagementService deviceManagementService() {
+        return mock(DeviceManagementService.class);
+    }
+
+    @Bean
+    public RegisterDevice registerDevice() {
+        return mock(RegisterDevice.class);
+    }
+
+    @Bean
+    public OslpLogItemRepository oslpLogItemRepository() {
+        return mock(OslpLogItemRepository.class);
+    }
+
+    @Bean
+    public OslpLogService oslpLogService() {
+        return mock(OslpLogService.class);
+    }
+}

--- a/osgp/protocol-adapter-oslp/web-device-simulator/src/test/resources/web-device-simulator-test.properties
+++ b/osgp/protocol-adapter-oslp/web-device-simulator/src/test/resources/web-device-simulator-test.properties
@@ -1,0 +1,3 @@
+#ECDSA security
+oslp.security.test.signkey.path=/etc/ssl/certs/oslp_test_ecdsa_private.der
+oslp.security.simulator.verifykey.path=/etc/ssl/certs/oslp_sim_ecdsa_public.der


### PR DESCRIPTION
When the OSLP web device simulator simulates a reboot a configurable
delay in seconds is applied before the device registration messages are
sent. During this delay the Netty channel for new requests will be
disconnected by the OlspChannelHandler.

The delay has a default value from configuration (reboot.delay.seconds)
and can be changed from the devices page in the web-device-simulator.

Fixes a number of warnings in the DeviceManagementController.
The general RequestMapping with a method is replaces by GetMapping or
PostMapping.
Some checks are done in the API methods that return a response for a
bad request in case there is something wrong with the provided data.
Some of the methods that were altering state have been renamed from get
to set.
The random for generating bytes is placed in a field instead of creating
a new one on each call in the method where it is used.
An incorrect logger statement with an exception is fixed.

The labels in the device list page have been placed in actual label
elements for the controls they belong with (making clicking the check
box inputs simpler as one side effect).

A call to fireChannelRead is removed from the OslpChannelHandler as it
is the last handler in the pipeline. Passing the message on beyond the
last handler triggers some debug level warning messages from Netty.