### PR TITLE
FLEX-5628 ~ Don't add device during registration

### DIFF
--- a/osgp/protocol-adapter-iec61850/osgp-protocol-adapter-iec61850/src/main/java/org/opensmartgridplatform/adapter/protocol/iec61850/application/services/DeviceRegistrationService.java
+++ b/osgp/protocol-adapter-iec61850/osgp-protocol-adapter-iec61850/src/main/java/org/opensmartgridplatform/adapter/protocol/iec61850/application/services/DeviceRegistrationService.java
@@ -203,4 +203,8 @@ public class DeviceRegistrationService {
             }
         }, DeviceRegistrationService.this.delayAfterDeviceRegistration);
     }
+
+    public boolean isKnownDevice(final String deviceIdentification) {
+        return this.ssldDataRepository.findByDeviceIdentification(deviceIdentification) != null;
+    }
 }

--- a/osgp/protocol-adapter-iec61850/osgp-protocol-adapter-iec61850/src/main/java/org/opensmartgridplatform/adapter/protocol/iec61850/infra/networking/Iec61850ChannelHandlerServer.java
+++ b/osgp/protocol-adapter-iec61850/osgp-protocol-adapter-iec61850/src/main/java/org/opensmartgridplatform/adapter/protocol/iec61850/infra/networking/Iec61850ChannelHandlerServer.java
@@ -67,6 +67,15 @@ public class Iec61850ChannelHandlerServer extends Iec61850ChannelHandler {
         this.logMessage(message);
 
         final String deviceIdentification = message.getDeviceIdentification();
+
+        if (this.deviceRegistrationService.isKnownDevice(deviceIdentification)) {
+            LOGGER.info("Device {} found, start processing this registration message", deviceIdentification);
+        } else {
+            LOGGER.warn("Ignoring this registration message, because there's no device having identification {}",
+                    deviceIdentification);
+            return;
+        }
+
         final IED ied = IED.FLEX_OVL;
         final String ipAddress;
 


### PR DESCRIPTION
When the IEC 61850 protocol adapter received a registration message from an unknown device, it processed the registration message anyway. Component osgp-core also created a new record for it in the osgp_core.device table. In the new situation, the registration message is not processed.