### PR TITLE
Feature/slim 2184 datasource config

### DIFF
--- a/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/AbstractOsgpSchedulerConfig.java
+++ b/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/AbstractOsgpSchedulerConfig.java
@@ -35,6 +35,9 @@ public class AbstractOsgpSchedulerConfig extends AbstractSchedulingConfig {
     @Value("${quartz.scheduler.start.attempt.sleep.time:30000}")
     private long startAttemptSleepTime;
 
+    @Value("${quartz.scheduler.use.properties:true}")
+    private boolean useProperties;
+
     private int startAttemptCount = 0;
 
     private final String schedulerName;
@@ -69,6 +72,7 @@ public class AbstractOsgpSchedulerConfig extends AbstractSchedulingConfig {
                 .withJobStoreDbUsername(this.databaseUsername)
                 .withJobStoreDbPassword(this.databasePassword)
                 .withJobStoreDbDriver(this.databaseDriver)
+                .withUseProperties(this.useProperties)
                 .build();
 
         final Scheduler quartzScheduler = this.constructAndStartQuartzScheduler(schedulingConfigProperties);

--- a/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/AbstractOsgpSchedulerConfig.java
+++ b/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/AbstractOsgpSchedulerConfig.java
@@ -35,9 +35,6 @@ public class AbstractOsgpSchedulerConfig extends AbstractSchedulingConfig {
     @Value("${quartz.scheduler.start.attempt.sleep.time:30000}")
     private long startAttemptSleepTime;
 
-    @Value("${quartz.scheduler.use.properties:true}")
-    private boolean useProperties;
-
     private int startAttemptCount = 0;
 
     private final String schedulerName;
@@ -72,7 +69,6 @@ public class AbstractOsgpSchedulerConfig extends AbstractSchedulingConfig {
                 .withJobStoreDbUsername(this.databaseUsername)
                 .withJobStoreDbPassword(this.databasePassword)
                 .withJobStoreDbDriver(this.databaseDriver)
-                .withUseProperties(this.useProperties)
                 .build();
 
         final Scheduler quartzScheduler = this.constructAndStartQuartzScheduler(schedulingConfigProperties);

--- a/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/AbstractSchedulingConfig.java
+++ b/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/AbstractSchedulingConfig.java
@@ -194,7 +194,7 @@ public abstract class AbstractSchedulingConfig extends AbstractConfig {
         properties.put("org.quartz.jobStore.driverDelegateClass", PostgreSQLDelegate.class.getName());
         properties.put("org.quartz.jobStore.tablePrefix", "QRTZ_");
         properties.put("org.quartz.jobStore.useProperties",
-                Boolean.valueOf(schedulingConfigProperties.isUseProperties()).toString());
+                schedulingConfigProperties.isUseProperties());
         properties.put("org.quartz.jobStore.isClustered", Boolean.TRUE.toString());
         properties.put("org.quartz.jobStore.misfireThreshold", "60000");
         properties.put("org.quartz.jobStore.dataSource", "quartzDefault");

--- a/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/AbstractSchedulingConfig.java
+++ b/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/AbstractSchedulingConfig.java
@@ -193,7 +193,8 @@ public abstract class AbstractSchedulingConfig extends AbstractConfig {
         properties.put("org.quartz.jobStore.class", JobStoreTX.class.getName());
         properties.put("org.quartz.jobStore.driverDelegateClass", PostgreSQLDelegate.class.getName());
         properties.put("org.quartz.jobStore.tablePrefix", "QRTZ_");
-        properties.put("org.quartz.jobStore.useProperties", Boolean.TRUE.toString());
+        properties.put("org.quartz.jobStore.useProperties",
+                Boolean.valueOf(schedulingConfigProperties.isUseProperties()).toString());
         properties.put("org.quartz.jobStore.isClustered", Boolean.TRUE.toString());
         properties.put("org.quartz.jobStore.misfireThreshold", "60000");
         properties.put("org.quartz.jobStore.dataSource", "quartzDefault");

--- a/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/HibernateNamingStrategy.java
+++ b/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/HibernateNamingStrategy.java
@@ -37,6 +37,6 @@ public class HibernateNamingStrategy extends PhysicalNamingStrategyStandardImpl 
         final String regex = "([a-z])([A-Z])";
         final String replacement = "$1_$2";
         final String newName = identifier.getText().replaceAll(regex, replacement).toLowerCase();
-        return Identifier.toIdentifier(newName);
+        return Identifier.toIdentifier(newName, identifier.isQuoted());
     }
 }

--- a/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/SchedulingConfigProperties.java
+++ b/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/SchedulingConfigProperties.java
@@ -22,6 +22,7 @@ public class SchedulingConfigProperties {
     private final String jobStoreDbPassword;
     private final String jobStoreDbDriver;
     private final String maxConnections;
+    private final boolean useProperties;
 
     private SchedulingConfigProperties(final Builder builder) {
         this.jobClass = builder.jobClass;
@@ -33,6 +34,7 @@ public class SchedulingConfigProperties {
         this.jobStoreDbPassword = builder.jobStoreDbPassword;
         this.jobStoreDbDriver = builder.jobStoreDbDriver;
         this.maxConnections = builder.maxConnections;
+        this.useProperties = builder.useProperties;
     }
 
     public static class Builder {
@@ -46,6 +48,7 @@ public class SchedulingConfigProperties {
         private String jobStoreDbPassword = null;
         private String jobStoreDbDriver = null;
         private String maxConnections = DEFAULT_MAX_CONNECTIONS;
+        private boolean useProperties = true;
 
         public SchedulingConfigProperties build() {
             return new SchedulingConfigProperties(this);
@@ -95,6 +98,11 @@ public class SchedulingConfigProperties {
             this.maxConnections = maxConnections;
             return this;
         }
+
+        public Builder withUseProperties(final boolean useProperties) {
+            this.useProperties = useProperties;
+            return this;
+        }
     }
 
     public static Builder newBuilder() {
@@ -135,6 +143,10 @@ public class SchedulingConfigProperties {
 
     public String getMaxConnections() {
         return this.maxConnections;
+    }
+
+    public boolean isUseProperties() {
+        return this.useProperties;
     }
 
 }

--- a/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/scheduling/OsgpScheduler.java
+++ b/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/scheduling/OsgpScheduler.java
@@ -13,6 +13,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.TimeZone;
 
+import org.joda.time.DateTimeZone;
 import org.opensmartgridplatform.shared.application.config.AbstractOsgpSchedulerConfig;
 import org.quartz.CronScheduleBuilder;
 import org.quartz.Job;
@@ -135,7 +136,7 @@ public class OsgpScheduler {
      * @return A {@link Trigger} instance.
      */
     public Trigger createJobTrigger(final JobDetail jobDetail, final String cronExpression) {
-        return this.createJobTrigger(jobDetail, cronExpression, TimeZone.getDefault());
+        return this.createJobTrigger(jobDetail, cronExpression, DateTimeZone.UTC.toTimeZone());
     }
 
     /**
@@ -187,7 +188,7 @@ public class OsgpScheduler {
      */
     public void createAndScheduleJob(final Class<? extends Job> jobClass, final String cronExpression)
             throws SchedulerException {
-        this.createAndScheduleJob(jobClass, cronExpression, TimeZone.getDefault());
+        this.createAndScheduleJob(jobClass, cronExpression, DateTimeZone.UTC.toTimeZone());
     }
 
     public void deleteScheduledJob(final Class<? extends Job> jobClass) throws SchedulerException {

--- a/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/scheduling/OsgpScheduler.java
+++ b/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/scheduling/OsgpScheduler.java
@@ -115,11 +115,11 @@ public class OsgpScheduler {
      */
     public Trigger createJobTrigger(final JobDetail jobDetail, final String cronExpression, final TimeZone timeZone) {
         return TriggerBuilder.newTrigger()
-                             .forJob(jobDetail)
-                             .withIdentity(jobDetail.getKey().getName() + "-Trigger")
-                             .forJob(jobDetail)
-                             .withSchedule(CronScheduleBuilder.cronSchedule(cronExpression).inTimeZone(timeZone))
-                             .build();
+                .forJob(jobDetail)
+                .withIdentity(jobDetail.getKey().getName() + "-Trigger")
+                .forJob(jobDetail)
+                .withSchedule(CronScheduleBuilder.cronSchedule(cronExpression).inTimeZone(timeZone))
+                .build();
     }
 
     /**
@@ -135,7 +135,7 @@ public class OsgpScheduler {
      * @return A {@link Trigger} instance.
      */
     public Trigger createJobTrigger(final JobDetail jobDetail, final String cronExpression) {
-        return createJobTrigger(jobDetail, cronExpression, TimeZone.getDefault());
+        return this.createJobTrigger(jobDetail, cronExpression, TimeZone.getDefault());
     }
 
     /**
@@ -187,7 +187,7 @@ public class OsgpScheduler {
      */
     public void createAndScheduleJob(final Class<? extends Job> jobClass, final String cronExpression)
             throws SchedulerException {
-        createAndScheduleJob(jobClass, cronExpression, TimeZone.getDefault());
+        this.createAndScheduleJob(jobClass, cronExpression, TimeZone.getDefault());
     }
 
     public void deleteScheduledJob(final Class<? extends Job> jobClass) throws SchedulerException {

--- a/osgp/shared/shared/src/test/java/org/opensmartgridplatform/shared/application/config/HibernateNamingStrategyTest.java
+++ b/osgp/shared/shared/src/test/java/org/opensmartgridplatform/shared/application/config/HibernateNamingStrategyTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 Alliander N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.opensmartgridplatform.shared.application.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.hibernate.boot.model.naming.Identifier;
+import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class HibernateNamingStrategyTest {
+
+    @Mock
+    private JdbcEnvironment context;
+
+    private HibernateNamingStrategy hibernateNamingStrategy;
+
+    @BeforeEach
+    public void setup() {
+        this.hibernateNamingStrategy = HibernateNamingStrategy.INSTANCE;
+    }
+
+    @Test
+    void testToPhysicalTableName() {
+        assertTableName(Identifier.toIdentifier("user", false), Identifier.toIdentifier("user", false));
+        assertTableName(Identifier.toIdentifier("userId", false), Identifier.toIdentifier("user_id", false));
+        assertTableName(Identifier.toIdentifier("user", true), Identifier.toIdentifier("user", true));
+        assertTableName(Identifier.toIdentifier("userId", true), Identifier.toIdentifier("user_id", true));
+    }
+
+    @Test
+    void testToPhysicalColumnName() {
+        assertColumnName(Identifier.toIdentifier("user", false), Identifier.toIdentifier("user", false));
+        assertColumnName(Identifier.toIdentifier("userId", false), Identifier.toIdentifier("user_id", false));
+        assertColumnName(Identifier.toIdentifier("user", true), Identifier.toIdentifier("user", true));
+        assertColumnName(Identifier.toIdentifier("userId", true), Identifier.toIdentifier("user_id", true));
+    }
+
+    private void assertTableName(Identifier source, Identifier expectedIdentifier) {
+        Identifier result = hibernateNamingStrategy.toPhysicalTableName(source, context);
+        assertThat(result.getText()).isEqualTo(expectedIdentifier.getText());
+        assertThat(result.isQuoted()).isEqualTo(expectedIdentifier.isQuoted());
+    }
+
+    private void assertColumnName(Identifier source, Identifier expectedIdentifier) {
+        Identifier result = hibernateNamingStrategy.toPhysicalColumnName(source, context);
+        assertThat(result.getText()).isEqualTo(expectedIdentifier.getText());
+        assertThat(result.isQuoted()).isEqualTo(expectedIdentifier.isQuoted());
+    }
+}


### PR DESCRIPTION
This PR contains 3 changes:
1. Made useProperties configurable for Scheduling, default values stay the same.
2. HibernateNamingStrategy.java the naming strategy lost the quotes parameter (this is needed, if a table or column name uses a privileged name like "user")
3. Added the timezone argument for the cron-expressions to the OsgpScheduler.java