### PR TITLE
OC-718 ~ Default ping size to 1

### DIFF
--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/resources/osgp-adapter-protocol-dlms.properties
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/resources/osgp-adapter-protocol-dlms.properties
@@ -55,7 +55,7 @@ device.ping.enabled=false
 # Number of echo requests to send, set to 0 for default
 device.ping.count=1
 # The packetsize for the number of data bytes to send with an echo request, -1 for default
-device.ping.size=0
+device.ping.size=1
 # The timeout to wait for an echo reply, PT0S for default
 device.ping.timeout=PT7S
 # Whether to lookup symbolic names for host addresses, comment out for default


### PR DESCRIPTION
device.ping.size=0 is not always resulting in an echo reply.
Therefore setting the default to device.ping.size=1