### PR TITLE
Fixes license headers and line endings

### DIFF
--- a/osgp/platform/osgp-adapter-ws-core/src/test/java/org/opensmartgridplatform/adapter/ws/core/application/mapping/DeviceConverterTest.java
+++ b/osgp/platform/osgp-adapter-ws-core/src/test/java/org/opensmartgridplatform/adapter/ws/core/application/mapping/DeviceConverterTest.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright 2021 Alliander N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
 package org.opensmartgridplatform.adapter.ws.core.application.mapping;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -170,7 +179,7 @@ public class DeviceConverterTest {
     assertThat(jaxbDevice.getOutputSettings().size()).isEqualTo(3);
     for (int i = 0; i < 3; i++) {
       assertThat(device.getOutputSettings().get(i).getAlias())
-          .isEqualTo(jaxbDevice.getOutputSettings().get(i).getAlias());
+      .isEqualTo(jaxbDevice.getOutputSettings().get(i).getAlias());
     }
     assertThat(jaxbDevice.getTechnicalInstallationDate()).isEqualTo(xmlGregorianCalendar);
 
@@ -193,7 +202,7 @@ public class DeviceConverterTest {
     assertThat(mappedBack.getOutputSettings().size()).isEqualTo(3);
     for (int i = 0; i < 3; i++) {
       assertThat(device.getOutputSettings().get(i).getAlias())
-          .isEqualTo(mappedBack.getOutputSettings().get(i).getAlias());
+      .isEqualTo(mappedBack.getOutputSettings().get(i).getAlias());
     }
     assertThat(mappedBack.getTechnicalInstallationDate()).isEqualTo(date);
   }

--- a/osgp/platform/osgp-adapter-ws-core/src/test/java/org/opensmartgridplatform/adapter/ws/core/application/mapping/DeviceConverterTest.java
+++ b/osgp/platform/osgp-adapter-ws-core/src/test/java/org/opensmartgridplatform/adapter/ws/core/application/mapping/DeviceConverterTest.java
@@ -179,7 +179,7 @@ public class DeviceConverterTest {
     assertThat(jaxbDevice.getOutputSettings().size()).isEqualTo(3);
     for (int i = 0; i < 3; i++) {
       assertThat(device.getOutputSettings().get(i).getAlias())
-      .isEqualTo(jaxbDevice.getOutputSettings().get(i).getAlias());
+          .isEqualTo(jaxbDevice.getOutputSettings().get(i).getAlias());
     }
     assertThat(jaxbDevice.getTechnicalInstallationDate()).isEqualTo(xmlGregorianCalendar);
 
@@ -202,7 +202,7 @@ public class DeviceConverterTest {
     assertThat(mappedBack.getOutputSettings().size()).isEqualTo(3);
     for (int i = 0; i < 3; i++) {
       assertThat(device.getOutputSettings().get(i).getAlias())
-      .isEqualTo(mappedBack.getOutputSettings().get(i).getAlias());
+          .isEqualTo(mappedBack.getOutputSettings().get(i).getAlias());
     }
     assertThat(mappedBack.getTechnicalInstallationDate()).isEqualTo(date);
   }

--- a/osgp/platform/osgp-adapter-ws-smartmetering/src/main/java/org/opensmartgridplatform/adapter/ws/smartmetering/application/mapping/CosemDateTimeConverter.java
+++ b/osgp/platform/osgp-adapter-ws-smartmetering/src/main/java/org/opensmartgridplatform/adapter/ws/smartmetering/application/mapping/CosemDateTimeConverter.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright 2021 Alliander N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
 package org.opensmartgridplatform.adapter.ws.smartmetering.application.mapping;
 
 import java.nio.ByteBuffer;

--- a/osgp/platform/osgp-adapter-ws-smartmetering/src/main/java/org/opensmartgridplatform/adapter/ws/smartmetering/application/mapping/CosemTimeConverter.java
+++ b/osgp/platform/osgp-adapter-ws-smartmetering/src/main/java/org/opensmartgridplatform/adapter/ws/smartmetering/application/mapping/CosemTimeConverter.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright 2021 Alliander N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
 package org.opensmartgridplatform.adapter.ws.smartmetering.application.mapping;
 
 import ma.glasnost.orika.CustomConverter;

--- a/osgp/platform/osgp-adapter-ws-smartmetering/src/test/java/org/opensmartgridplatform/adapter/ws/smartmetering/application/mapping/CosemDateConverterTest.java
+++ b/osgp/platform/osgp-adapter-ws-smartmetering/src/test/java/org/opensmartgridplatform/adapter/ws/smartmetering/application/mapping/CosemDateConverterTest.java
@@ -1,3 +1,11 @@
+/*
+ * Copyright 2015 Smart Society Services B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
 package org.opensmartgridplatform.adapter.ws.smartmetering.application.mapping;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -7,14 +15,6 @@ import ma.glasnost.orika.impl.DefaultMapperFactory;
 import org.junit.jupiter.api.Test;
 import org.opensmartgridplatform.domain.core.valueobjects.smartmetering.CosemDate;
 
-/*
- * Copyright 2015 Smart Society Services B.V.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
- * except in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- */
 public class CosemDateConverterTest {
 
   private static final byte FIRST_BYTE_FOR_YEAR = (byte) 0x07;
@@ -24,11 +24,11 @@ public class CosemDateConverterTest {
   private static final byte BYTE_FOR_DAY_OF_MONTH = 7;
   private static final byte BYTE_FOR_DAY_OF_WEEK = (byte) 0xFF;
   private static final byte[] COSEMDATE_BYTE_ARRAY = {
-    FIRST_BYTE_FOR_YEAR,
-    SECOND_BYTE_FOR_YEAR,
-    BYTE_FOR_MONTH,
-    BYTE_FOR_DAY_OF_MONTH,
-    BYTE_FOR_DAY_OF_WEEK
+      FIRST_BYTE_FOR_YEAR,
+      SECOND_BYTE_FOR_YEAR,
+      BYTE_FOR_MONTH,
+      BYTE_FOR_DAY_OF_MONTH,
+      BYTE_FOR_DAY_OF_WEEK
   };
   private MapperFactory mapperFactory = new DefaultMapperFactory.Builder().build();
 

--- a/osgp/platform/osgp-adapter-ws-smartmetering/src/test/java/org/opensmartgridplatform/adapter/ws/smartmetering/application/mapping/CosemDateConverterTest.java
+++ b/osgp/platform/osgp-adapter-ws-smartmetering/src/test/java/org/opensmartgridplatform/adapter/ws/smartmetering/application/mapping/CosemDateConverterTest.java
@@ -24,11 +24,11 @@ public class CosemDateConverterTest {
   private static final byte BYTE_FOR_DAY_OF_MONTH = 7;
   private static final byte BYTE_FOR_DAY_OF_WEEK = (byte) 0xFF;
   private static final byte[] COSEMDATE_BYTE_ARRAY = {
-      FIRST_BYTE_FOR_YEAR,
-      SECOND_BYTE_FOR_YEAR,
-      BYTE_FOR_MONTH,
-      BYTE_FOR_DAY_OF_MONTH,
-      BYTE_FOR_DAY_OF_WEEK
+    FIRST_BYTE_FOR_YEAR,
+    SECOND_BYTE_FOR_YEAR,
+    BYTE_FOR_MONTH,
+    BYTE_FOR_DAY_OF_MONTH,
+    BYTE_FOR_DAY_OF_WEEK
   };
   private MapperFactory mapperFactory = new DefaultMapperFactory.Builder().build();
 

--- a/osgp/platform/osgp-domain-core/src/test/java/org/opensmartgridplatform/domain/core/valueobjects/smartmetering/SetRandomisationSettingsRequestDataTest.java
+++ b/osgp/platform/osgp-domain-core/src/test/java/org/opensmartgridplatform/domain/core/valueobjects/smartmetering/SetRandomisationSettingsRequestDataTest.java
@@ -19,68 +19,68 @@ public class SetRandomisationSettingsRequestDataTest {
   @Test
   public void testInvalidDirectAttach() throws FunctionalException {
     assertThatExceptionOfType(FunctionalException.class)
-    .isThrownBy(
-        () -> {
-          new SetRandomisationSettingsRequestData(
-              SetRandomisationSettingsRequestData.MIN_VALUE_DIRECT_ATTACH - 1,
-              SetRandomisationSettingsRequestData.MIN_VALUE_RANDOMIZATION_START_WINDOW,
-              SetRandomisationSettingsRequestData.MIN_VALUE_MULTIPLICATION_FACTOR,
-              SetRandomisationSettingsRequestData.MIN_VALUE_NUMBER_OF_RETRIES)
-          .validate();
-        });
+        .isThrownBy(
+            () -> {
+              new SetRandomisationSettingsRequestData(
+                      SetRandomisationSettingsRequestData.MIN_VALUE_DIRECT_ATTACH - 1,
+                      SetRandomisationSettingsRequestData.MIN_VALUE_RANDOMIZATION_START_WINDOW,
+                      SetRandomisationSettingsRequestData.MIN_VALUE_MULTIPLICATION_FACTOR,
+                      SetRandomisationSettingsRequestData.MIN_VALUE_NUMBER_OF_RETRIES)
+                  .validate();
+            });
   }
 
   @Test
   public void testInvalidMultiplicationFactor() throws FunctionalException {
     assertThatExceptionOfType(FunctionalException.class)
-    .isThrownBy(
-        () -> {
-          new SetRandomisationSettingsRequestData(
-              SetRandomisationSettingsRequestData.MIN_VALUE_DIRECT_ATTACH,
-              SetRandomisationSettingsRequestData.MAX_VALUE_RANDOMIZATION_START_WINDOW,
-              SetRandomisationSettingsRequestData.MAX_VALUE_MULTIPLICATION_FACTOR + 1,
-              SetRandomisationSettingsRequestData.MIN_VALUE_NUMBER_OF_RETRIES)
-          .validate();
-        });
+        .isThrownBy(
+            () -> {
+              new SetRandomisationSettingsRequestData(
+                      SetRandomisationSettingsRequestData.MIN_VALUE_DIRECT_ATTACH,
+                      SetRandomisationSettingsRequestData.MAX_VALUE_RANDOMIZATION_START_WINDOW,
+                      SetRandomisationSettingsRequestData.MAX_VALUE_MULTIPLICATION_FACTOR + 1,
+                      SetRandomisationSettingsRequestData.MIN_VALUE_NUMBER_OF_RETRIES)
+                  .validate();
+            });
   }
 
   @Test
   public void testInvalidNumberOfRetries() throws FunctionalException {
     assertThatExceptionOfType(FunctionalException.class)
-    .isThrownBy(
-        () -> {
-          new SetRandomisationSettingsRequestData(
-              SetRandomisationSettingsRequestData.MIN_VALUE_DIRECT_ATTACH,
-              SetRandomisationSettingsRequestData.MAX_VALUE_RANDOMIZATION_START_WINDOW,
-              SetRandomisationSettingsRequestData.MAX_VALUE_MULTIPLICATION_FACTOR,
-              SetRandomisationSettingsRequestData.MAX_VALUE_NUMBER_OF_RETRIES + 1)
-          .validate();
-        });
+        .isThrownBy(
+            () -> {
+              new SetRandomisationSettingsRequestData(
+                      SetRandomisationSettingsRequestData.MIN_VALUE_DIRECT_ATTACH,
+                      SetRandomisationSettingsRequestData.MAX_VALUE_RANDOMIZATION_START_WINDOW,
+                      SetRandomisationSettingsRequestData.MAX_VALUE_MULTIPLICATION_FACTOR,
+                      SetRandomisationSettingsRequestData.MAX_VALUE_NUMBER_OF_RETRIES + 1)
+                  .validate();
+            });
   }
 
   @Test
   public void testInvalidRandomisationStartWindow() throws FunctionalException {
     assertThatExceptionOfType(FunctionalException.class)
-    .isThrownBy(
-        () -> {
-          new SetRandomisationSettingsRequestData(
-              SetRandomisationSettingsRequestData.MIN_VALUE_DIRECT_ATTACH,
-              SetRandomisationSettingsRequestData.MAX_VALUE_RANDOMIZATION_START_WINDOW + 1,
-              SetRandomisationSettingsRequestData.MIN_VALUE_MULTIPLICATION_FACTOR,
-              SetRandomisationSettingsRequestData.MIN_VALUE_NUMBER_OF_RETRIES)
-          .validate();
-        });
+        .isThrownBy(
+            () -> {
+              new SetRandomisationSettingsRequestData(
+                      SetRandomisationSettingsRequestData.MIN_VALUE_DIRECT_ATTACH,
+                      SetRandomisationSettingsRequestData.MAX_VALUE_RANDOMIZATION_START_WINDOW + 1,
+                      SetRandomisationSettingsRequestData.MIN_VALUE_MULTIPLICATION_FACTOR,
+                      SetRandomisationSettingsRequestData.MIN_VALUE_NUMBER_OF_RETRIES)
+                  .validate();
+            });
   }
 
   @Test
   public void testValidRequestData() {
     try {
       new SetRandomisationSettingsRequestData(
-          SetRandomisationSettingsRequestData.MAX_VALUE_DIRECT_ATTACH,
-          SetRandomisationSettingsRequestData.MIN_VALUE_RANDOMIZATION_START_WINDOW,
-          SetRandomisationSettingsRequestData.MIN_VALUE_MULTIPLICATION_FACTOR,
-          SetRandomisationSettingsRequestData.MIN_VALUE_NUMBER_OF_RETRIES)
-      .validate();
+              SetRandomisationSettingsRequestData.MAX_VALUE_DIRECT_ATTACH,
+              SetRandomisationSettingsRequestData.MIN_VALUE_RANDOMIZATION_START_WINDOW,
+              SetRandomisationSettingsRequestData.MIN_VALUE_MULTIPLICATION_FACTOR,
+              SetRandomisationSettingsRequestData.MIN_VALUE_NUMBER_OF_RETRIES)
+          .validate();
     } catch (final FunctionalException e) {
       fail("");
     }

--- a/osgp/platform/osgp-domain-core/src/test/java/org/opensmartgridplatform/domain/core/valueobjects/smartmetering/SetRandomisationSettingsRequestDataTest.java
+++ b/osgp/platform/osgp-domain-core/src/test/java/org/opensmartgridplatform/domain/core/valueobjects/smartmetering/SetRandomisationSettingsRequestDataTest.java
@@ -1,11 +1,3 @@
-package org.opensmartgridplatform.domain.core.valueobjects.smartmetering;
-
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.assertj.core.api.Assertions.fail;
-
-import org.junit.jupiter.api.Test;
-import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
-
 /*
  * Copyright 2019 Smart Society Services B.V.
  *
@@ -14,73 +6,81 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  */
+package org.opensmartgridplatform.domain.core.valueobjects.smartmetering;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
+
 public class SetRandomisationSettingsRequestDataTest {
 
   @Test
   public void testInvalidDirectAttach() throws FunctionalException {
     assertThatExceptionOfType(FunctionalException.class)
-        .isThrownBy(
-            () -> {
-              new SetRandomisationSettingsRequestData(
-                      SetRandomisationSettingsRequestData.MIN_VALUE_DIRECT_ATTACH - 1,
-                      SetRandomisationSettingsRequestData.MIN_VALUE_RANDOMIZATION_START_WINDOW,
-                      SetRandomisationSettingsRequestData.MIN_VALUE_MULTIPLICATION_FACTOR,
-                      SetRandomisationSettingsRequestData.MIN_VALUE_NUMBER_OF_RETRIES)
-                  .validate();
-            });
+    .isThrownBy(
+        () -> {
+          new SetRandomisationSettingsRequestData(
+              SetRandomisationSettingsRequestData.MIN_VALUE_DIRECT_ATTACH - 1,
+              SetRandomisationSettingsRequestData.MIN_VALUE_RANDOMIZATION_START_WINDOW,
+              SetRandomisationSettingsRequestData.MIN_VALUE_MULTIPLICATION_FACTOR,
+              SetRandomisationSettingsRequestData.MIN_VALUE_NUMBER_OF_RETRIES)
+          .validate();
+        });
   }
 
   @Test
   public void testInvalidMultiplicationFactor() throws FunctionalException {
     assertThatExceptionOfType(FunctionalException.class)
-        .isThrownBy(
-            () -> {
-              new SetRandomisationSettingsRequestData(
-                      SetRandomisationSettingsRequestData.MIN_VALUE_DIRECT_ATTACH,
-                      SetRandomisationSettingsRequestData.MAX_VALUE_RANDOMIZATION_START_WINDOW,
-                      SetRandomisationSettingsRequestData.MAX_VALUE_MULTIPLICATION_FACTOR + 1,
-                      SetRandomisationSettingsRequestData.MIN_VALUE_NUMBER_OF_RETRIES)
-                  .validate();
-            });
+    .isThrownBy(
+        () -> {
+          new SetRandomisationSettingsRequestData(
+              SetRandomisationSettingsRequestData.MIN_VALUE_DIRECT_ATTACH,
+              SetRandomisationSettingsRequestData.MAX_VALUE_RANDOMIZATION_START_WINDOW,
+              SetRandomisationSettingsRequestData.MAX_VALUE_MULTIPLICATION_FACTOR + 1,
+              SetRandomisationSettingsRequestData.MIN_VALUE_NUMBER_OF_RETRIES)
+          .validate();
+        });
   }
 
   @Test
   public void testInvalidNumberOfRetries() throws FunctionalException {
     assertThatExceptionOfType(FunctionalException.class)
-        .isThrownBy(
-            () -> {
-              new SetRandomisationSettingsRequestData(
-                      SetRandomisationSettingsRequestData.MIN_VALUE_DIRECT_ATTACH,
-                      SetRandomisationSettingsRequestData.MAX_VALUE_RANDOMIZATION_START_WINDOW,
-                      SetRandomisationSettingsRequestData.MAX_VALUE_MULTIPLICATION_FACTOR,
-                      SetRandomisationSettingsRequestData.MAX_VALUE_NUMBER_OF_RETRIES + 1)
-                  .validate();
-            });
+    .isThrownBy(
+        () -> {
+          new SetRandomisationSettingsRequestData(
+              SetRandomisationSettingsRequestData.MIN_VALUE_DIRECT_ATTACH,
+              SetRandomisationSettingsRequestData.MAX_VALUE_RANDOMIZATION_START_WINDOW,
+              SetRandomisationSettingsRequestData.MAX_VALUE_MULTIPLICATION_FACTOR,
+              SetRandomisationSettingsRequestData.MAX_VALUE_NUMBER_OF_RETRIES + 1)
+          .validate();
+        });
   }
 
   @Test
   public void testInvalidRandomisationStartWindow() throws FunctionalException {
     assertThatExceptionOfType(FunctionalException.class)
-        .isThrownBy(
-            () -> {
-              new SetRandomisationSettingsRequestData(
-                      SetRandomisationSettingsRequestData.MIN_VALUE_DIRECT_ATTACH,
-                      SetRandomisationSettingsRequestData.MAX_VALUE_RANDOMIZATION_START_WINDOW + 1,
-                      SetRandomisationSettingsRequestData.MIN_VALUE_MULTIPLICATION_FACTOR,
-                      SetRandomisationSettingsRequestData.MIN_VALUE_NUMBER_OF_RETRIES)
-                  .validate();
-            });
+    .isThrownBy(
+        () -> {
+          new SetRandomisationSettingsRequestData(
+              SetRandomisationSettingsRequestData.MIN_VALUE_DIRECT_ATTACH,
+              SetRandomisationSettingsRequestData.MAX_VALUE_RANDOMIZATION_START_WINDOW + 1,
+              SetRandomisationSettingsRequestData.MIN_VALUE_MULTIPLICATION_FACTOR,
+              SetRandomisationSettingsRequestData.MIN_VALUE_NUMBER_OF_RETRIES)
+          .validate();
+        });
   }
 
   @Test
   public void testValidRequestData() {
     try {
       new SetRandomisationSettingsRequestData(
-              SetRandomisationSettingsRequestData.MAX_VALUE_DIRECT_ATTACH,
-              SetRandomisationSettingsRequestData.MIN_VALUE_RANDOMIZATION_START_WINDOW,
-              SetRandomisationSettingsRequestData.MIN_VALUE_MULTIPLICATION_FACTOR,
-              SetRandomisationSettingsRequestData.MIN_VALUE_NUMBER_OF_RETRIES)
-          .validate();
+          SetRandomisationSettingsRequestData.MAX_VALUE_DIRECT_ATTACH,
+          SetRandomisationSettingsRequestData.MIN_VALUE_RANDOMIZATION_START_WINDOW,
+          SetRandomisationSettingsRequestData.MIN_VALUE_MULTIPLICATION_FACTOR,
+          SetRandomisationSettingsRequestData.MIN_VALUE_NUMBER_OF_RETRIES)
+      .validate();
     } catch (final FunctionalException e) {
       fail("");
     }

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/configuration/service/GetConfigurationObjectService.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/configuration/service/GetConfigurationObjectService.java
@@ -35,16 +35,16 @@ public abstract class GetConfigurationObjectService implements ProtocolService {
     final AttributeAddress attributeAddress =
         AttributeAddressFactory.getConfigurationObjectAddress();
     conn.getDlmsMessageListener()
-    .setDescription(
-        String.format(
-            "Retrieve current ConfigurationObject, attribute: %s",
-            JdlmsObjectToStringUtil.describeAttributes(attributeAddress)));
+        .setDescription(
+            String.format(
+                "Retrieve current ConfigurationObject, attribute: %s",
+                JdlmsObjectToStringUtil.describeAttributes(attributeAddress)));
     return this.getConfigurationObject(this.getGetResult(conn, attributeAddress));
   }
 
   private GetResult getGetResult(
       final DlmsConnectionManager conn, final AttributeAddress attributeAddress)
-          throws ProtocolAdapterException {
+      throws ProtocolAdapterException {
     LOGGER.info("Get current ConfigurationObject using AttributeAddress {}", attributeAddress);
     try {
       return this.handleBadResults(conn.getConnection().get(attributeAddress));
@@ -76,9 +76,9 @@ public abstract class GetConfigurationObjectService implements ProtocolService {
     for (int index = 0; index < word.length(); index++) {
       if (word.charAt(index) == '1') {
         this.getFlagType(index)
-        .ifPresent(
-            configurationFlagType ->
-            flags.add(new ConfigurationFlagDto(configurationFlagType, true)));
+            .ifPresent(
+                configurationFlagType ->
+                    flags.add(new ConfigurationFlagDto(configurationFlagType, true)));
       }
     }
     return flags;

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/configuration/service/GetConfigurationObjectService.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/configuration/service/GetConfigurationObjectService.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright 2021 Alliander N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
 package org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.configuration.service;
 
 import java.io.IOException;
@@ -26,16 +35,16 @@ public abstract class GetConfigurationObjectService implements ProtocolService {
     final AttributeAddress attributeAddress =
         AttributeAddressFactory.getConfigurationObjectAddress();
     conn.getDlmsMessageListener()
-        .setDescription(
-            String.format(
-                "Retrieve current ConfigurationObject, attribute: %s",
-                JdlmsObjectToStringUtil.describeAttributes(attributeAddress)));
+    .setDescription(
+        String.format(
+            "Retrieve current ConfigurationObject, attribute: %s",
+            JdlmsObjectToStringUtil.describeAttributes(attributeAddress)));
     return this.getConfigurationObject(this.getGetResult(conn, attributeAddress));
   }
 
   private GetResult getGetResult(
       final DlmsConnectionManager conn, final AttributeAddress attributeAddress)
-      throws ProtocolAdapterException {
+          throws ProtocolAdapterException {
     LOGGER.info("Get current ConfigurationObject using AttributeAddress {}", attributeAddress);
     try {
       return this.handleBadResults(conn.getConnection().get(attributeAddress));
@@ -67,9 +76,9 @@ public abstract class GetConfigurationObjectService implements ProtocolService {
     for (int index = 0; index < word.length(); index++) {
       if (word.charAt(index) == '1') {
         this.getFlagType(index)
-            .ifPresent(
-                configurationFlagType ->
-                    flags.add(new ConfigurationFlagDto(configurationFlagType, true)));
+        .ifPresent(
+            configurationFlagType ->
+            flags.add(new ConfigurationFlagDto(configurationFlagType, true)));
       }
     }
     return flags;

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/configuration/service/ProtocolServiceLookup.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/configuration/service/ProtocolServiceLookup.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright 2021 Alliander N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
 package org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.configuration.service;
 
 import java.util.List;
@@ -33,7 +42,7 @@ public class ProtocolServiceLookup {
         .findAny()
         .orElseThrow(
             () ->
-                new ProtocolAdapterException(
-                    String.format("Cannot find %s for protocol %s", type, protocol)));
+            new ProtocolAdapterException(
+                String.format("Cannot find %s for protocol %s", type, protocol)));
   }
 }

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/configuration/service/ProtocolServiceLookup.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/configuration/service/ProtocolServiceLookup.java
@@ -42,7 +42,7 @@ public class ProtocolServiceLookup {
         .findAny()
         .orElseThrow(
             () ->
-            new ProtocolAdapterException(
-                String.format("Cannot find %s for protocol %s", type, protocol)));
+                new ProtocolAdapterException(
+                    String.format("Cannot find %s for protocol %s", type, protocol)));
   }
 }

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/dlmsobjectconfig/DlmsObjectConfigConfiguration.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/dlmsobjectconfig/DlmsObjectConfigConfiguration.java
@@ -1,10 +1,3 @@
-package org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.dlmsobjectconfig;
-
-import java.util.ArrayList;
-import java.util.List;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-
 /*
  * Copyright 2019 Smart Society Services B.V.
  *
@@ -13,6 +6,13 @@ import org.springframework.context.annotation.Configuration;
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  */
+package org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.dlmsobjectconfig;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
 @Configuration
 public class DlmsObjectConfigConfiguration {
 

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/misc/FindEventsCommandExecutorTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/misc/FindEventsCommandExecutorTest.java
@@ -84,7 +84,7 @@ public class FindEventsCommandExecutorTest {
     when(this.dlmsHelper.asDataObject(this.findEventsRequestDto.getFrom())).thenReturn(fromDate);
     when(this.dlmsHelper.asDataObject(this.findEventsRequestDto.getUntil())).thenReturn(toDate);
     when(this.dlmsHelper.convertDataObjectToDateTime(any(DataObject.class)))
-    .thenReturn(new CosemDateTimeDto());
+        .thenReturn(new CosemDateTimeDto());
     when(this.conn.getDlmsMessageListener()).thenReturn(this.dlmsMessageListener);
     when(this.conn.getConnection()).thenReturn(this.dlmsConnection);
     when(this.dlmsConnection.get(any(AttributeAddress.class))).thenReturn(this.getResult);
@@ -120,7 +120,7 @@ public class FindEventsCommandExecutorTest {
     }
 
     verify(this.dlmsHelper, times(events.size()))
-    .convertDataObjectToDateTime(any(DataObject.class));
+        .convertDataObjectToDateTime(any(DataObject.class));
   }
 
   @Test
@@ -129,11 +129,11 @@ public class FindEventsCommandExecutorTest {
     when(this.getResult.getResultCode()).thenReturn(AccessResultCode.OTHER_REASON);
 
     assertThatExceptionOfType(ProtocolAdapterException.class)
-    .isThrownBy(
-        () -> {
-          new FindEventsCommandExecutor(this.dlmsHelper, this.dataObjectToEventListConverter)
-          .execute(this.conn, this.dlmsDevice, this.findEventsRequestDto);
-        });
+        .isThrownBy(
+            () -> {
+              new FindEventsCommandExecutor(this.dlmsHelper, this.dataObjectToEventListConverter)
+                  .execute(this.conn, this.dlmsDevice, this.findEventsRequestDto);
+            });
   }
 
   @Test
@@ -142,11 +142,11 @@ public class FindEventsCommandExecutorTest {
     when(this.dlmsConnection.get(any(AttributeAddress.class))).thenReturn(null);
 
     assertThatExceptionOfType(ProtocolAdapterException.class)
-    .isThrownBy(
-        () -> {
-          new FindEventsCommandExecutor(this.dlmsHelper, this.dataObjectToEventListConverter)
-          .execute(this.conn, this.dlmsDevice, this.findEventsRequestDto);
-        });
+        .isThrownBy(
+            () -> {
+              new FindEventsCommandExecutor(this.dlmsHelper, this.dataObjectToEventListConverter)
+                  .execute(this.conn, this.dlmsDevice, this.findEventsRequestDto);
+            });
   }
 
   private List<DataObject> generateDataObjects() {
@@ -154,16 +154,16 @@ public class FindEventsCommandExecutorTest {
     final List<DataObject> dataObjects = new ArrayList<>();
 
     IntStream.rangeClosed(77, 89)
-    .forEach(
-        code -> {
-          final DataObject eventCode = DataObject.newInteger16Data((short) code);
-          final DataObject eventTime =
-              DataObject.newDateTimeData(new CosemDateTime(2018, 12, 31, 23, code - 60, 0, 0));
+        .forEach(
+            code -> {
+              final DataObject eventCode = DataObject.newInteger16Data((short) code);
+              final DataObject eventTime =
+                  DataObject.newDateTimeData(new CosemDateTime(2018, 12, 31, 23, code - 60, 0, 0));
 
-          final DataObject struct = DataObject.newStructureData(eventTime, eventCode);
+              final DataObject struct = DataObject.newStructureData(eventTime, eventCode);
 
-          dataObjects.add(struct);
-        });
+              dataObjects.add(struct);
+            });
 
     return dataObjects;
   }

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/misc/FindEventsCommandExecutorTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/misc/FindEventsCommandExecutorTest.java
@@ -1,3 +1,11 @@
+/*
+ * Copyright 2019 Smart Society Services B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
 package org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.misc;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -38,14 +46,6 @@ import org.opensmartgridplatform.dto.valueobjects.smartmetering.EventDto;
 import org.opensmartgridplatform.dto.valueobjects.smartmetering.EventLogCategoryDto;
 import org.opensmartgridplatform.dto.valueobjects.smartmetering.FindEventsRequestDto;
 
-/*
- * Copyright 2019 Smart Society Services B.V.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
- * except in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class FindEventsCommandExecutorTest {
@@ -84,7 +84,7 @@ public class FindEventsCommandExecutorTest {
     when(this.dlmsHelper.asDataObject(this.findEventsRequestDto.getFrom())).thenReturn(fromDate);
     when(this.dlmsHelper.asDataObject(this.findEventsRequestDto.getUntil())).thenReturn(toDate);
     when(this.dlmsHelper.convertDataObjectToDateTime(any(DataObject.class)))
-        .thenReturn(new CosemDateTimeDto());
+    .thenReturn(new CosemDateTimeDto());
     when(this.conn.getDlmsMessageListener()).thenReturn(this.dlmsMessageListener);
     when(this.conn.getConnection()).thenReturn(this.dlmsConnection);
     when(this.dlmsConnection.get(any(AttributeAddress.class))).thenReturn(this.getResult);
@@ -120,7 +120,7 @@ public class FindEventsCommandExecutorTest {
     }
 
     verify(this.dlmsHelper, times(events.size()))
-        .convertDataObjectToDateTime(any(DataObject.class));
+    .convertDataObjectToDateTime(any(DataObject.class));
   }
 
   @Test
@@ -129,11 +129,11 @@ public class FindEventsCommandExecutorTest {
     when(this.getResult.getResultCode()).thenReturn(AccessResultCode.OTHER_REASON);
 
     assertThatExceptionOfType(ProtocolAdapterException.class)
-        .isThrownBy(
-            () -> {
-              new FindEventsCommandExecutor(this.dlmsHelper, this.dataObjectToEventListConverter)
-                  .execute(this.conn, this.dlmsDevice, this.findEventsRequestDto);
-            });
+    .isThrownBy(
+        () -> {
+          new FindEventsCommandExecutor(this.dlmsHelper, this.dataObjectToEventListConverter)
+          .execute(this.conn, this.dlmsDevice, this.findEventsRequestDto);
+        });
   }
 
   @Test
@@ -142,11 +142,11 @@ public class FindEventsCommandExecutorTest {
     when(this.dlmsConnection.get(any(AttributeAddress.class))).thenReturn(null);
 
     assertThatExceptionOfType(ProtocolAdapterException.class)
-        .isThrownBy(
-            () -> {
-              new FindEventsCommandExecutor(this.dlmsHelper, this.dataObjectToEventListConverter)
-                  .execute(this.conn, this.dlmsDevice, this.findEventsRequestDto);
-            });
+    .isThrownBy(
+        () -> {
+          new FindEventsCommandExecutor(this.dlmsHelper, this.dataObjectToEventListConverter)
+          .execute(this.conn, this.dlmsDevice, this.findEventsRequestDto);
+        });
   }
 
   private List<DataObject> generateDataObjects() {
@@ -154,16 +154,16 @@ public class FindEventsCommandExecutorTest {
     final List<DataObject> dataObjects = new ArrayList<>();
 
     IntStream.rangeClosed(77, 89)
-        .forEach(
-            code -> {
-              final DataObject eventCode = DataObject.newInteger16Data((short) code);
-              final DataObject eventTime =
-                  DataObject.newDateTimeData(new CosemDateTime(2018, 12, 31, 23, code - 60, 0, 0));
+    .forEach(
+        code -> {
+          final DataObject eventCode = DataObject.newInteger16Data((short) code);
+          final DataObject eventTime =
+              DataObject.newDateTimeData(new CosemDateTime(2018, 12, 31, 23, code - 60, 0, 0));
 
-              final DataObject struct = DataObject.newStructureData(eventTime, eventCode);
+          final DataObject struct = DataObject.newStructureData(eventTime, eventCode);
 
-              dataObjects.add(struct);
-            });
+          dataObjects.add(struct);
+        });
 
     return dataObjects;
   }

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/monitoring/GetPowerQualityProfileCommandExecutorTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/monitoring/GetPowerQualityProfileCommandExecutorTest.java
@@ -1,3 +1,11 @@
+/*
+ * Copyright 2019 Smart Society Services B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
 package org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.monitoring;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -13,20 +21,12 @@ import org.opensmartgridplatform.adapter.protocol.dlms.domain.factories.DlmsConn
 import org.opensmartgridplatform.adapter.protocol.dlms.exceptions.ProtocolAdapterException;
 import org.opensmartgridplatform.dto.valueobjects.smartmetering.GetPowerQualityProfileRequestDataDto;
 
-/*
- * Copyright 2019 Smart Society Services B.V.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
- * except in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- */
 @ExtendWith(MockitoExtension.class)
 public class GetPowerQualityProfileCommandExecutorTest {
 
   @Mock
   private GetPowerQualityProfileNoSelectiveAccessHandler
-      getPowerQualityProfileNoSelectiveAccessHandler;
+  getPowerQualityProfileNoSelectiveAccessHandler;
 
   @Mock
   private GetPowerQualityProfileSelectiveAccessHandler getPowerQualityProfileSelectiveAccessHandler;
@@ -46,10 +46,10 @@ public class GetPowerQualityProfileCommandExecutorTest {
     this.executor.execute(this.conn, dlmsDevice, this.getPowerQualityProfileRequestDataDto);
 
     verify(this.getPowerQualityProfileSelectiveAccessHandler)
-        .handle(
-            any(DlmsConnectionManager.class),
-            any(DlmsDevice.class),
-            any(GetPowerQualityProfileRequestDataDto.class));
+    .handle(
+        any(DlmsConnectionManager.class),
+        any(DlmsDevice.class),
+        any(GetPowerQualityProfileRequestDataDto.class));
   }
 
   @Test
@@ -61,9 +61,9 @@ public class GetPowerQualityProfileCommandExecutorTest {
     this.executor.execute(this.conn, dlmsDevice, this.getPowerQualityProfileRequestDataDto);
 
     verify(this.getPowerQualityProfileNoSelectiveAccessHandler)
-        .handle(
-            any(DlmsConnectionManager.class),
-            any(DlmsDevice.class),
-            any(GetPowerQualityProfileRequestDataDto.class));
+    .handle(
+        any(DlmsConnectionManager.class),
+        any(DlmsDevice.class),
+        any(GetPowerQualityProfileRequestDataDto.class));
   }
 }

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/monitoring/GetPowerQualityProfileCommandExecutorTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/monitoring/GetPowerQualityProfileCommandExecutorTest.java
@@ -26,7 +26,7 @@ public class GetPowerQualityProfileCommandExecutorTest {
 
   @Mock
   private GetPowerQualityProfileNoSelectiveAccessHandler
-  getPowerQualityProfileNoSelectiveAccessHandler;
+      getPowerQualityProfileNoSelectiveAccessHandler;
 
   @Mock
   private GetPowerQualityProfileSelectiveAccessHandler getPowerQualityProfileSelectiveAccessHandler;
@@ -46,10 +46,10 @@ public class GetPowerQualityProfileCommandExecutorTest {
     this.executor.execute(this.conn, dlmsDevice, this.getPowerQualityProfileRequestDataDto);
 
     verify(this.getPowerQualityProfileSelectiveAccessHandler)
-    .handle(
-        any(DlmsConnectionManager.class),
-        any(DlmsDevice.class),
-        any(GetPowerQualityProfileRequestDataDto.class));
+        .handle(
+            any(DlmsConnectionManager.class),
+            any(DlmsDevice.class),
+            any(GetPowerQualityProfileRequestDataDto.class));
   }
 
   @Test
@@ -61,9 +61,9 @@ public class GetPowerQualityProfileCommandExecutorTest {
     this.executor.execute(this.conn, dlmsDevice, this.getPowerQualityProfileRequestDataDto);
 
     verify(this.getPowerQualityProfileNoSelectiveAccessHandler)
-    .handle(
-        any(DlmsConnectionManager.class),
-        any(DlmsDevice.class),
-        any(GetPowerQualityProfileRequestDataDto.class));
+        .handle(
+            any(DlmsConnectionManager.class),
+            any(DlmsDevice.class),
+            any(GetPowerQualityProfileRequestDataDto.class));
   }
 }

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/monitoring/GetPowerQualityProfileNoSelectiveAccessHandlerTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/monitoring/GetPowerQualityProfileNoSelectiveAccessHandlerTest.java
@@ -57,22 +57,22 @@ public class GetPowerQualityProfileNoSelectiveAccessHandlerTest {
             new ArrayList<>());
 
     when(this.dlmsHelper.getAndCheck(
-        any(DlmsConnectionManager.class),
-        any(DlmsDevice.class),
-        any(String.class),
-        any(AttributeAddress.class)))
-    .thenReturn(
-        this.createPartialNotAllowedCaptureObjects(),
-        this.createProfileEntries(),
-        this.createPartialNotAllowedCaptureObjects(),
-        this.createProfileEntries());
+            any(DlmsConnectionManager.class),
+            any(DlmsDevice.class),
+            any(String.class),
+            any(AttributeAddress.class)))
+        .thenReturn(
+            this.createPartialNotAllowedCaptureObjects(),
+            this.createProfileEntries(),
+            this.createPartialNotAllowedCaptureObjects(),
+            this.createProfileEntries());
 
     when(this.dlmsHelper.readLogicalName(any(DataObject.class), any(String.class)))
-    .thenCallRealMethod();
+        .thenCallRealMethod();
     when(this.dlmsHelper.readObjectDefinition(any(DataObject.class), any(String.class)))
-    .thenCallRealMethod();
+        .thenCallRealMethod();
     when(this.dlmsHelper.readLongNotNull(any(DataObject.class), any(String.class)))
-    .thenCallRealMethod();
+        .thenCallRealMethod();
     when(this.dlmsHelper.readLong(any(DataObject.class), any(String.class))).thenCallRealMethod();
     when(this.dlmsHelper.convertDataObjectToDateTime(any(DataObject.class))).thenCallRealMethod();
     when(this.dlmsHelper.fromDateTimeValue(any())).thenCallRealMethod();
@@ -90,12 +90,12 @@ public class GetPowerQualityProfileNoSelectiveAccessHandlerTest {
 
     assertThat(responseDto.getPowerQualityProfileResponseDatas().size()).isEqualTo(2);
     assertThat(responseDto.getPowerQualityProfileResponseDatas().get(0).getCaptureObjects().size())
-    .isEqualTo(2);
+        .isEqualTo(2);
     assertThat(responseDto.getPowerQualityProfileResponseDatas().get(0).getProfileEntries().size())
-    .isEqualTo(4);
+        .isEqualTo(4);
 
     for (final ProfileEntryDto profileEntryDto :
-      responseDto.getPowerQualityProfileResponseDatas().get(0).getProfileEntries()) {
+        responseDto.getPowerQualityProfileResponseDatas().get(0).getProfileEntries()) {
       assertThat(profileEntryDto.getProfileEntryValues().size()).isEqualTo(2);
     }
   }

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/monitoring/GetPowerQualityProfileNoSelectiveAccessHandlerTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/monitoring/GetPowerQualityProfileNoSelectiveAccessHandlerTest.java
@@ -1,3 +1,11 @@
+/*
+ * Copyright 2019 Smart Society Services B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
 package org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.monitoring;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -27,14 +35,6 @@ import org.opensmartgridplatform.dto.valueobjects.smartmetering.GetPowerQualityP
 import org.opensmartgridplatform.dto.valueobjects.smartmetering.GetPowerQualityProfileResponseDto;
 import org.opensmartgridplatform.dto.valueobjects.smartmetering.ProfileEntryDto;
 
-/*
- * Copyright 2019 Smart Society Services B.V.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
- * except in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- */
 @ExtendWith(MockitoExtension.class)
 public class GetPowerQualityProfileNoSelectiveAccessHandlerTest {
 
@@ -57,22 +57,22 @@ public class GetPowerQualityProfileNoSelectiveAccessHandlerTest {
             new ArrayList<>());
 
     when(this.dlmsHelper.getAndCheck(
-            any(DlmsConnectionManager.class),
-            any(DlmsDevice.class),
-            any(String.class),
-            any(AttributeAddress.class)))
-        .thenReturn(
-            this.createPartialNotAllowedCaptureObjects(),
-            this.createProfileEntries(),
-            this.createPartialNotAllowedCaptureObjects(),
-            this.createProfileEntries());
+        any(DlmsConnectionManager.class),
+        any(DlmsDevice.class),
+        any(String.class),
+        any(AttributeAddress.class)))
+    .thenReturn(
+        this.createPartialNotAllowedCaptureObjects(),
+        this.createProfileEntries(),
+        this.createPartialNotAllowedCaptureObjects(),
+        this.createProfileEntries());
 
     when(this.dlmsHelper.readLogicalName(any(DataObject.class), any(String.class)))
-        .thenCallRealMethod();
+    .thenCallRealMethod();
     when(this.dlmsHelper.readObjectDefinition(any(DataObject.class), any(String.class)))
-        .thenCallRealMethod();
+    .thenCallRealMethod();
     when(this.dlmsHelper.readLongNotNull(any(DataObject.class), any(String.class)))
-        .thenCallRealMethod();
+    .thenCallRealMethod();
     when(this.dlmsHelper.readLong(any(DataObject.class), any(String.class))).thenCallRealMethod();
     when(this.dlmsHelper.convertDataObjectToDateTime(any(DataObject.class))).thenCallRealMethod();
     when(this.dlmsHelper.fromDateTimeValue(any())).thenCallRealMethod();
@@ -90,12 +90,12 @@ public class GetPowerQualityProfileNoSelectiveAccessHandlerTest {
 
     assertThat(responseDto.getPowerQualityProfileResponseDatas().size()).isEqualTo(2);
     assertThat(responseDto.getPowerQualityProfileResponseDatas().get(0).getCaptureObjects().size())
-        .isEqualTo(2);
+    .isEqualTo(2);
     assertThat(responseDto.getPowerQualityProfileResponseDatas().get(0).getProfileEntries().size())
-        .isEqualTo(4);
+    .isEqualTo(4);
 
     for (final ProfileEntryDto profileEntryDto :
-        responseDto.getPowerQualityProfileResponseDatas().get(0).getProfileEntries()) {
+      responseDto.getPowerQualityProfileResponseDatas().get(0).getProfileEntries()) {
       assertThat(profileEntryDto.getProfileEntryValues().size()).isEqualTo(2);
     }
   }

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/monitoring/GetPowerQualityProfileSelectiveAccessHandlerTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/monitoring/GetPowerQualityProfileSelectiveAccessHandlerTest.java
@@ -57,22 +57,22 @@ public class GetPowerQualityProfileSelectiveAccessHandlerTest {
             new ArrayList<>());
 
     when(this.dlmsHelper.getAndCheck(
-        any(DlmsConnectionManager.class),
-        any(DlmsDevice.class),
-        any(String.class),
-        any(AttributeAddress.class)))
-    .thenReturn(
-        this.createCaptureObjects(),
-        this.createProfileEntries(),
-        this.createCaptureObjectsProfile2(),
-        this.createProfileEntries());
+            any(DlmsConnectionManager.class),
+            any(DlmsDevice.class),
+            any(String.class),
+            any(AttributeAddress.class)))
+        .thenReturn(
+            this.createCaptureObjects(),
+            this.createProfileEntries(),
+            this.createCaptureObjectsProfile2(),
+            this.createProfileEntries());
 
     when(this.dlmsHelper.readLogicalName(any(DataObject.class), any(String.class)))
-    .thenCallRealMethod();
+        .thenCallRealMethod();
     when(this.dlmsHelper.readObjectDefinition(any(DataObject.class), any(String.class)))
-    .thenCallRealMethod();
+        .thenCallRealMethod();
     when(this.dlmsHelper.readLongNotNull(any(DataObject.class), any(String.class)))
-    .thenCallRealMethod();
+        .thenCallRealMethod();
     when(this.dlmsHelper.readLong(any(DataObject.class), any(String.class))).thenCallRealMethod();
     when(this.dlmsHelper.convertDataObjectToDateTime(any(DataObject.class))).thenCallRealMethod();
     when(this.dlmsHelper.fromDateTimeValue(any())).thenCallRealMethod();
@@ -90,12 +90,12 @@ public class GetPowerQualityProfileSelectiveAccessHandlerTest {
 
     assertThat(responseDto.getPowerQualityProfileResponseDatas().size()).isEqualTo(2);
     assertThat(responseDto.getPowerQualityProfileResponseDatas().get(0).getCaptureObjects().size())
-    .isEqualTo(3);
+        .isEqualTo(3);
     assertThat(responseDto.getPowerQualityProfileResponseDatas().get(0).getProfileEntries().size())
-    .isEqualTo(4);
+        .isEqualTo(4);
 
     for (final ProfileEntryDto profileEntryDto :
-      responseDto.getPowerQualityProfileResponseDatas().get(0).getProfileEntries()) {
+        responseDto.getPowerQualityProfileResponseDatas().get(0).getProfileEntries()) {
       assertThat(profileEntryDto.getProfileEntryValues().size()).isEqualTo(3);
     }
   }

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/monitoring/GetPowerQualityProfileSelectiveAccessHandlerTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/monitoring/GetPowerQualityProfileSelectiveAccessHandlerTest.java
@@ -1,3 +1,11 @@
+/*
+ * Copyright 2019 Smart Society Services B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
 package org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.monitoring;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -27,14 +35,6 @@ import org.opensmartgridplatform.dto.valueobjects.smartmetering.GetPowerQualityP
 import org.opensmartgridplatform.dto.valueobjects.smartmetering.GetPowerQualityProfileResponseDto;
 import org.opensmartgridplatform.dto.valueobjects.smartmetering.ProfileEntryDto;
 
-/*
- * Copyright 2019 Smart Society Services B.V.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
- * except in compliance with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- */
 @ExtendWith(MockitoExtension.class)
 public class GetPowerQualityProfileSelectiveAccessHandlerTest {
 
@@ -57,22 +57,22 @@ public class GetPowerQualityProfileSelectiveAccessHandlerTest {
             new ArrayList<>());
 
     when(this.dlmsHelper.getAndCheck(
-            any(DlmsConnectionManager.class),
-            any(DlmsDevice.class),
-            any(String.class),
-            any(AttributeAddress.class)))
-        .thenReturn(
-            this.createCaptureObjects(),
-            this.createProfileEntries(),
-            this.createCaptureObjectsProfile2(),
-            this.createProfileEntries());
+        any(DlmsConnectionManager.class),
+        any(DlmsDevice.class),
+        any(String.class),
+        any(AttributeAddress.class)))
+    .thenReturn(
+        this.createCaptureObjects(),
+        this.createProfileEntries(),
+        this.createCaptureObjectsProfile2(),
+        this.createProfileEntries());
 
     when(this.dlmsHelper.readLogicalName(any(DataObject.class), any(String.class)))
-        .thenCallRealMethod();
+    .thenCallRealMethod();
     when(this.dlmsHelper.readObjectDefinition(any(DataObject.class), any(String.class)))
-        .thenCallRealMethod();
+    .thenCallRealMethod();
     when(this.dlmsHelper.readLongNotNull(any(DataObject.class), any(String.class)))
-        .thenCallRealMethod();
+    .thenCallRealMethod();
     when(this.dlmsHelper.readLong(any(DataObject.class), any(String.class))).thenCallRealMethod();
     when(this.dlmsHelper.convertDataObjectToDateTime(any(DataObject.class))).thenCallRealMethod();
     when(this.dlmsHelper.fromDateTimeValue(any())).thenCallRealMethod();
@@ -90,12 +90,12 @@ public class GetPowerQualityProfileSelectiveAccessHandlerTest {
 
     assertThat(responseDto.getPowerQualityProfileResponseDatas().size()).isEqualTo(2);
     assertThat(responseDto.getPowerQualityProfileResponseDatas().get(0).getCaptureObjects().size())
-        .isEqualTo(3);
+    .isEqualTo(3);
     assertThat(responseDto.getPowerQualityProfileResponseDatas().get(0).getProfileEntries().size())
-        .isEqualTo(4);
+    .isEqualTo(4);
 
     for (final ProfileEntryDto profileEntryDto :
-        responseDto.getPowerQualityProfileResponseDatas().get(0).getProfileEntries()) {
+      responseDto.getPowerQualityProfileResponseDatas().get(0).getProfileEntries()) {
       assertThat(profileEntryDto.getProfileEntryValues().size()).isEqualTo(3);
     }
   }


### PR DESCRIPTION
Adds some missing license headers, moves license headers to the top of
the file where they were added as documentation on the class instead of
the file.
Some of these modified files had Windows style line endings (carriage
return plus linefeed), these are fixed as well.