### PR TITLE
SLIM-1883 ~ Fixes device management operation name

### DIFF
--- a/osgp/shared/osgp-ws-admin/src/main/resources/DeviceManagement.wsdl
+++ b/osgp/shared/osgp-ws-admin/src/main/resources/DeviceManagement.wsdl
@@ -512,7 +512,7 @@
       </wsdl:output>
     </wsdl:operation>
 
-    <wsdl:operation name="SetCommunicationNetworkInformationProtocol">
+    <wsdl:operation name="SetCommunicationNetworkInformation">
       <soap:operation soapAction="" />
       <wsdl:input name="SetCommunicationNetworkInformationRequest">
         <soap:header message="tns:SoapHeaders" part="OrganisationIdentification"


### PR DESCRIPTION
Fixes the operation name in the admin device management WSDL to match
the name defined for port type DeviceManagementPort.