### PR TITLE
Clear quartz scheduler on startup and not on shutdown, this causes is…

### DIFF
--- a/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/scheduling/OsgpScheduler.java
+++ b/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/scheduling/OsgpScheduler.java
@@ -44,6 +44,10 @@ public class OsgpScheduler {
   public OsgpScheduler(final Scheduler quartzScheduler) throws SchedulerException {
     this.quartzScheduler = quartzScheduler;
     LOGGER.info("Starting {}.", quartzScheduler.getSchedulerName());
+    // Clear existing jobs, to make sure the latest version is loaded
+    // and deleted triggers are removed from the database
+    this.quartzScheduler.clear();
+    LOGGER.info("Existing scheduler cleared for scheduler {}.", quartzScheduler.getSchedulerName());
   }
 
   /**
@@ -55,7 +59,6 @@ public class OsgpScheduler {
   public void shutdown() throws SchedulerException {
     LOGGER.info("Stopping {}.", this.quartzScheduler.getSchedulerName());
     this.quartzScheduler.shutdown(true);
-    this.quartzScheduler.clear();
   }
 
   /**

--- a/osgp/shared/shared/src/test/java/org/opensmartgridplatform/shared/application/scheduling/OsgpSchedulerTest.java
+++ b/osgp/shared/shared/src/test/java/org/opensmartgridplatform/shared/application/scheduling/OsgpSchedulerTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 Alliander N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.opensmartgridplatform.shared.application.scheduling;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+
+@ExtendWith(MockitoExtension.class)
+class OsgpSchedulerTest {
+
+  @Mock private Scheduler quartzScheduler;
+
+  @InjectMocks private OsgpScheduler osgpScheduler;
+
+  @Test
+  void testClearOnConstructor() throws SchedulerException {
+    reset(this.quartzScheduler);
+    this.osgpScheduler = new OsgpScheduler(this.quartzScheduler);
+    verify(this.quartzScheduler).clear();
+  }
+
+  @Test
+  void testShutdown() throws SchedulerException {
+    reset(this.quartzScheduler);
+    this.osgpScheduler.shutdown();
+    verify(this.quartzScheduler).shutdown(true);
+    // Clearing on shutdown causes issues when deploying in Kubernetes
+    verify(this.quartzScheduler, never()).clear();
+  }
+}


### PR DESCRIPTION
The clear method on the scheduler, causes the triggers to be deleted in quartz.
When clearing the scheduler on shutdown, this causes quartz triggers to be removed when the application is stopped.
In kubernetes, the Rolling Update strategy first starts new instances, and the removes instances.
And because removing of an instances deletes the triggers, they are gone in the database, until a new instance is started.

This changes clears the triggers on startup, and then creates the new triggers in the scheduler based on the property files

Clearing of the triggers is required because if a trigger is removed in the application, you also want to deleted it from the database. 