### PR TITLE
FDP-48 Include feeder asset label in event message

### DIFF
--- a/integration-tests/cucumber-tests-platform-distributionautomation/src/test/java/org/opensmartgridplatform/cucumber/platform/distributionautomation/PlatformDistributionAutomationKeys.java
+++ b/integration-tests/cucumber-tests-platform-distributionautomation/src/test/java/org/opensmartgridplatform/cucumber/platform/distributionautomation/PlatformDistributionAutomationKeys.java
@@ -15,6 +15,7 @@ public class PlatformDistributionAutomationKeys {
   public static final String DESCRIPTION = "description";
   public static final String FEEDER_NUMBER = "feeder number";
   public static final String FEEDER_NAME = "feeder name";
+  public static final String FEEDER_ASSET_LABEL = "asset label";
   public static final String INFORMATION_ELEMENT_VALUE = "InformationElementValue";
   public static final String INFORMATION_OBJECT_ADDRESS = "InformationObjectAddress";
   public static final String INFORMATION_OBJECT_TYPE = "InformationObjectType";

--- a/integration-tests/cucumber-tests-platform-distributionautomation/src/test/java/org/opensmartgridplatform/cucumber/platform/distributionautomation/glue/steps/MqttDeviceSteps.java
+++ b/integration-tests/cucumber-tests-platform-distributionautomation/src/test/java/org/opensmartgridplatform/cucumber/platform/distributionautomation/glue/steps/MqttDeviceSteps.java
@@ -125,6 +125,8 @@ public class MqttDeviceSteps {
         getString(parameters, PlatformDistributionAutomationKeys.BAY_POSITION);
     final String bayIdentification =
         getString(parameters, PlatformDistributionAutomationKeys.BAY_IDENTIFICATION);
+    final String assetLabel =
+        getString(parameters, PlatformDistributionAutomationKeys.FEEDER_ASSET_LABEL);
 
     final ArrayList<Name> names = new ArrayList<>();
     names.add(new Name(new NameType("gisbehuizingnummer"), substationIdentification));
@@ -132,6 +134,7 @@ public class MqttDeviceSteps {
     names.add(new Name(new NameType("msr naam"), substationName));
     names.add(new Name(new NameType("bay positie"), bayPosition));
     names.add(new Name(new NameType("bay identificatie"), bayIdentification));
+    names.add(new Name(new NameType("functieplaatslabel"), assetLabel));
     return names;
   }
 

--- a/integration-tests/cucumber-tests-platform-distributionautomation/src/test/java/org/opensmartgridplatform/cucumber/platform/distributionautomation/glue/steps/database/FeederSteps.java
+++ b/integration-tests/cucumber-tests-platform-distributionautomation/src/test/java/org/opensmartgridplatform/cucumber/platform/distributionautomation/glue/steps/database/FeederSteps.java
@@ -44,6 +44,9 @@ public class FeederSteps {
             settings,
             PlatformDistributionAutomationKeys.FEEDER_NAME,
             PlatformDistributionAutomationDefaults.FEEDER_NAME));
+    feeder.setAssetLabel(
+        ReadSettingsHelper.getString(
+            settings, PlatformDistributionAutomationKeys.FEEDER_ASSET_LABEL));
 
     this.feederRepository.save(feeder);
   }

--- a/integration-tests/cucumber-tests-platform-distributionautomation/src/test/resources/features/low-voltage/ProcessLowVoltageMessage.feature
+++ b/integration-tests/cucumber-tests-platform-distributionautomation/src/test/resources/features/low-voltage/ProcessLowVoltageMessage.feature
@@ -13,6 +13,7 @@ Feature: Low voltage message processing
       | substation identification | sub-1 |
       | feeder number             |     1 |
       | feeder name               | fdr-1 |
+      | asset label               | lbl-1 |
     When MQTT device "TST-01" sends a measurement report
       | payload | [{"gisnr":"sub-1", "versie":"2", "feeder":"1", "D": "02/10/2020 16:03:38", "uts":"1601647418", "data": [0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,1.9,2.0,2.1,2.2,2.3,2.4,2.5,2.6,2.7,2.8,2.9,3.0,3.1,3.2,3.3,3.4,3.5,3.6,3.7,3.8,3.9,4.0,4.1,5,6,7,8,9,0,1,2,3,4]}] |
     Then a message is published to Kafka
@@ -21,6 +22,7 @@ Feature: Low voltage message processing
       | substation name              | substation-1 |
       | bay position                 |            1 |
       | bay identification           | fdr-1        |
+      | asset label                  | lbl-1        |
       | numberOfElements             |           51 |
       | measurement1_description     | U-L1-E       |
       | measurement1_unitSymbol      | V            |

--- a/osgp/platform/osgp-adapter-kafka-distributionautomation/src/main/java/org/opensmartgridplatform/adapter/kafka/da/application/mapping/ScadaMeasurementPublishedEventConverter.java
+++ b/osgp/platform/osgp-adapter-kafka-distributionautomation/src/main/java/org/opensmartgridplatform/adapter/kafka/da/application/mapping/ScadaMeasurementPublishedEventConverter.java
@@ -80,6 +80,9 @@ public class ScadaMeasurementPublishedEventConverter
     if (source.getBayIdentification() != null) {
       names.add(new Name(new NameType("bay identificatie"), source.getBayIdentification()));
     }
+    if (source.getAssetLabel() != null) {
+      names.add(new Name(new NameType("functieplaatslabel"), source.getAssetLabel()));
+    }
     final Voltage voltage = new Voltage(UnitMultiplier.k, UnitSymbol.V, LOW_VOLTAGE_NOMINAL);
     return new ConductingEquipment(new BaseVoltage("LS", voltage), names);
   }

--- a/osgp/platform/osgp-adapter-kafka-distributionautomation/src/main/java/org/opensmartgridplatform/adapter/kafka/da/domain/entities/Feeder.java
+++ b/osgp/platform/osgp-adapter-kafka-distributionautomation/src/main/java/org/opensmartgridplatform/adapter/kafka/da/domain/entities/Feeder.java
@@ -31,4 +31,7 @@ public class Feeder extends AbstractEntity {
 
   @Column(length = 32, nullable = false)
   private String name;
+
+  @Column(length = 255)
+  private String assetLabel;
 }

--- a/osgp/platform/osgp-adapter-kafka-distributionautomation/src/main/java/org/opensmartgridplatform/adapter/kafka/da/infra/mqtt/in/ScadaMeasurementPayload.java
+++ b/osgp/platform/osgp-adapter-kafka-distributionautomation/src/main/java/org/opensmartgridplatform/adapter/kafka/da/infra/mqtt/in/ScadaMeasurementPayload.java
@@ -30,6 +30,7 @@ public class ScadaMeasurementPayload {
   private String substationName;
   private String feeder;
   private String bayIdentification;
+  private String assetLabel;
 
   @JsonProperty("D")
   private String date;

--- a/osgp/platform/osgp-adapter-kafka-distributionautomation/src/main/resources/db/migration/V20210604150958175__Add_asset_label_to_feeder.sql
+++ b/osgp/platform/osgp-adapter-kafka-distributionautomation/src/main/resources/db/migration/V20210604150958175__Add_asset_label_to_feeder.sql
@@ -1,0 +1,14 @@
+DO
+$$
+BEGIN
+
+  IF NOT EXISTS(SELECT 1 FROM information_schema.columns
+                WHERE table_schema = current_schema AND table_name = 'feeder' AND column_name = 'asset_label')
+  THEN
+    ALTER TABLE feeder ADD COLUMN asset_label CHARACTER VARYING(255);
+
+    COMMENT ON COLUMN feeder.asset_label IS 'A label providing asset details with the feeder.';
+  END IF;
+
+END;
+$$

--- a/osgp/platform/osgp-adapter-kafka-distributionautomation/src/test/java/org/opensmartgridplatform/adapter/kafka/da/application/mapping/ScadaMeasurementPublishedEventConverterTest.java
+++ b/osgp/platform/osgp-adapter-kafka-distributionautomation/src/test/java/org/opensmartgridplatform/adapter/kafka/da/application/mapping/ScadaMeasurementPublishedEventConverterTest.java
@@ -27,6 +27,7 @@ class ScadaMeasurementPublishedEventConverterTest {
   private static final String VERSION = "2";
   private static final String SUBSTATION_NAME = "Test location";
   private static final String BAY_IDENTIFICATION = "03FQ03";
+  private static final String ASSET_LABEL = "test asset label";
 
   @Test
   void testConvertScadaMeasurementPublishedEventVersion1() {
@@ -42,6 +43,7 @@ class ScadaMeasurementPublishedEventConverterTest {
             .substationName(SUBSTATION_NAME)
             .feeder(String.valueOf(feeder))
             .bayIdentification(BAY_IDENTIFICATION)
+            .assetLabel(ASSET_LABEL)
             .createdUtcSeconds(utcSeconds)
             .data(data.split(","))
             .build();
@@ -74,6 +76,7 @@ class ScadaMeasurementPublishedEventConverterTest {
             .substationName(SUBSTATION_NAME)
             .feeder(String.valueOf(feeder))
             .bayIdentification(BAY_IDENTIFICATION)
+            .assetLabel(ASSET_LABEL)
             .createdUtcSeconds(utcSeconds)
             .data(data.split(","))
             .build();
@@ -100,6 +103,7 @@ class ScadaMeasurementPublishedEventConverterTest {
     names.add(new Name(new NameType("bay positie"), String.valueOf(feeder)));
     if (feeder != 100) {
       names.add(new Name(new NameType("bay identificatie"), BAY_IDENTIFICATION));
+      names.add(new Name(new NameType("functieplaatslabel"), ASSET_LABEL));
     }
     return names;
   }
@@ -122,7 +126,7 @@ class ScadaMeasurementPublishedEventConverterTest {
         this.mapper.map(payload, ScadaMeasurementPublishedEvent.class);
     final List<Analog> measurements = event.getMeasurements();
 
-    assertThat(event.getCreatedDateTime()).isEqualTo(utcSeconds * 1000l);
+    assertThat(event.getCreatedDateTime()).isEqualTo(utcSeconds * 1000L);
     assertThat(measurements)
         .usingElementComparatorIgnoringFields("mRID")
         .isEqualTo(LovVoltageMessageFactory.expectedMetaMeasurements());


### PR DESCRIPTION
Adds field assetLabel to the Feeder entity. This can contain a label
with identification details for the feeder.
When a ScadaMeasurementPayload is processed and a feeder is found, the
asset label of the feeder is used to enrich the
ScadaMeasurementPublishedEvent with a name of type 'functieplaatslabel'.

[@DistributionAutomation]
