### PR TITLE
SLIM-2987-HSTN-an-uploaded-FW-file-in-SMHE-must-also-be-send-to-GXF

### DIFF
--- a/integration-tests/cucumber-tests-core/src/test/java/org/opensmartgridplatform/cucumber/core/ReadSettingsHelper.java
+++ b/integration-tests/cucumber-tests-core/src/test/java/org/opensmartgridplatform/cucumber/core/ReadSettingsHelper.java
@@ -8,7 +8,10 @@
  */
 package org.opensmartgridplatform.cucumber.core;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
@@ -252,6 +255,9 @@ public class ReadSettingsHelper {
       final Map<String, String> settings, final String key, final String defaultValue) {
     try {
       if (!settings.containsKey(key)) {
+        if (defaultValue == null) {
+          return null;
+        }
         return Hex.decodeHex(defaultValue.toCharArray());
       } else {
         return Hex.decodeHex(settings.get(key).toCharArray());
@@ -284,6 +290,14 @@ public class ReadSettingsHelper {
     }
 
     return Enum.valueOf(enumType, settings.get(key));
+  }
+
+  public static List<String> getStringList(
+      final Map<String, String> settings, final String key, final String separator) {
+    if (!settings.containsKey(key) || StringUtils.isBlank(settings.get(key))) {
+      return new ArrayList<String>(0);
+    }
+    return Arrays.asList(settings.get(key).split(separator));
   }
 
   public static <E extends Enum<E>> E getEnum(

--- a/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/basicosgpfunctions/AuthorizePlatformFunctionsSteps.java
+++ b/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/basicosgpfunctions/AuthorizePlatformFunctionsSteps.java
@@ -341,8 +341,10 @@ public class AuthorizePlatformFunctionsSteps {
     request.setId(PlatformCommonDefaults.FIRMWARE_ID);
     final Firmware firmware = new Firmware();
     firmware.setDescription(PlatformCommonDefaults.FIRMWARE_DESCRIPTION);
-    firmware.setManufacturer(PlatformCommonDefaults.DEFAULT_MANUFACTURER_CODE);
-    firmware.setModelCode(PlatformCommonDefaults.DEVICE_MODEL_MODEL_CODE);
+    final DeviceModel deviceModel = new DeviceModel();
+    deviceModel.setModelCode(PlatformCommonDefaults.DEVICE_MODEL_MODEL_CODE);
+    deviceModel.setManufacturer(PlatformCommonDefaults.DEFAULT_MANUFACTURER_CODE);
+    firmware.getDeviceModels().add(deviceModel);
     firmware.setPushToNewDevices(PlatformCommonDefaults.FIRMWARE_PUSH_TO_NEW_DEVICE);
     request.setFirmware(firmware);
     ScenarioContext.current()
@@ -354,8 +356,10 @@ public class AuthorizePlatformFunctionsSteps {
     final AddFirmwareRequest request = new AddFirmwareRequest();
     final Firmware firmware = new Firmware();
     firmware.setDescription(PlatformCommonDefaults.FIRMWARE_DESCRIPTION);
-    firmware.setManufacturer(PlatformCommonDefaults.DEFAULT_MANUFACTURER_CODE);
-    firmware.setModelCode(PlatformCommonDefaults.DEVICE_MODEL_MODEL_CODE);
+    final DeviceModel deviceModel = new DeviceModel();
+    deviceModel.setModelCode(PlatformCommonDefaults.DEVICE_MODEL_MODEL_CODE);
+    deviceModel.setManufacturer(PlatformCommonDefaults.DEFAULT_MANUFACTURER_CODE);
+    firmware.getDeviceModels().add(deviceModel);
     firmware.setPushToNewDevices(PlatformCommonDefaults.FIRMWARE_PUSH_TO_NEW_DEVICE);
     request.setFirmware(firmware);
     ScenarioContext.current()

--- a/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/core/firmwaremanagement/AddFirmwareSteps.java
+++ b/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/core/firmwaremanagement/AddFirmwareSteps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Smart Society Services B.V.
+ * Copyright 2021 Smart Society Services B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -10,72 +10,66 @@ package org.opensmartgridplatform.cucumber.platform.common.glue.steps.ws.core.fi
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.opensmartgridplatform.cucumber.core.ReadSettingsHelper.getEnum;
+import static org.opensmartgridplatform.cucumber.core.ReadSettingsHelper.getHexDecoded;
 
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import java.util.Map;
 import org.opensmartgridplatform.adapter.ws.schema.core.common.OsgpResultType;
-import org.opensmartgridplatform.adapter.ws.schema.core.firmwaremanagement.ChangeFirmwareRequest;
-import org.opensmartgridplatform.adapter.ws.schema.core.firmwaremanagement.ChangeFirmwareResponse;
+import org.opensmartgridplatform.adapter.ws.schema.core.firmwaremanagement.AddFirmwareRequest;
+import org.opensmartgridplatform.adapter.ws.schema.core.firmwaremanagement.AddFirmwareResponse;
 import org.opensmartgridplatform.adapter.ws.schema.core.firmwaremanagement.Firmware;
 import org.opensmartgridplatform.cucumber.core.ScenarioContext;
 import org.opensmartgridplatform.cucumber.platform.PlatformKeys;
 import org.opensmartgridplatform.cucumber.platform.common.PlatformCommonKeys;
 import org.opensmartgridplatform.cucumber.platform.common.support.ws.core.CoreFirmwareManagementClient;
 import org.opensmartgridplatform.cucumber.platform.glue.steps.ws.GenericResponseSteps;
-import org.opensmartgridplatform.domain.core.repositories.FirmwareFileRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.ws.soap.client.SoapFaultClientException;
 
 /** Class with all the firmware requests steps */
-public class ChangeFirmwareSteps extends FirmwareSteps {
+public class AddFirmwareSteps extends FirmwareSteps {
 
   @Autowired private CoreFirmwareManagementClient client;
 
-  @Autowired private FirmwareFileRepository firmwareFileRepository;
-
   /**
-   * Sends a Change Firmware request to the platform for a given device identification.
+   * Sends a Add Firmware request to the platform.
    *
    * @param requestParameters The table with the request parameters.
    * @throws Throwable
    */
-  @When("^receiving an change firmware request$")
-  public void receivingAnChangeFirmwareRequest(final Map<String, String> requestParameters)
+  @When("^receiving an add firmware request$")
+  public void receivingAnAddFirmwareRequest(final Map<String, String> requestParameters)
       throws Throwable {
 
-    final ChangeFirmwareRequest request = new ChangeFirmwareRequest();
-
-    long firmwareFileId = 0;
-    if (this.firmwareFileRepository.findAll() != null && this.firmwareFileRepository.count() > 0) {
-      firmwareFileId = this.firmwareFileRepository.findAll().get(0).getId();
-    }
-
-    request.setId((int) firmwareFileId);
+    final AddFirmwareRequest request = new AddFirmwareRequest();
 
     final Firmware firmware = this.createAndGetFirmware(requestParameters);
-    firmware.setId((int) firmwareFileId);
+    if (requestParameters.containsKey(PlatformKeys.FIRMWARE_FILE)) {
+      firmware.setFile(getHexDecoded(requestParameters, PlatformKeys.FIRMWARE_FILE, ""));
+    }
+
     request.setFirmware(firmware);
 
     try {
-      ScenarioContext.current().put(PlatformKeys.RESPONSE, this.client.changeFirmware(request));
+      ScenarioContext.current().put(PlatformKeys.RESPONSE, this.client.addFirmware(request));
     } catch (final SoapFaultClientException ex) {
       ScenarioContext.current().put(PlatformKeys.RESPONSE, ex);
     }
   }
 
-  @Then("^the change firmware response contains$")
-  public void theChangeFirmwareResponseContains(final Map<String, String> expectedResponseData)
+  @Then("^the add firmware response contains$")
+  public void theAddFirmwareResponseContains(final Map<String, String> expectedResponseData)
       throws Throwable {
-    final ChangeFirmwareResponse response =
-        (ChangeFirmwareResponse) ScenarioContext.current().get(PlatformCommonKeys.RESPONSE);
+    final AddFirmwareResponse response =
+        (AddFirmwareResponse) ScenarioContext.current().get(PlatformCommonKeys.RESPONSE);
 
     assertThat(response.getResult())
         .isEqualTo(getEnum(expectedResponseData, PlatformKeys.KEY_RESULT, OsgpResultType.class));
   }
 
-  @Then("^the change firmware response contains soap fault$")
-  public void theChangeFirmwareResponseContainsSoapFault(
+  @Then("^the add firmware response contains soap fault$")
+  public void theAddFirmwareResponseContainsSoapFault(
       final Map<String, String> expectedResponseData) throws Throwable {
     GenericResponseSteps.verifySoapFault(expectedResponseData);
   }

--- a/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/core/firmwaremanagement/FirmwareSteps.java
+++ b/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/core/firmwaremanagement/FirmwareSteps.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2021 Smart Society Services B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.opensmartgridplatform.cucumber.platform.common.glue.steps.ws.core.firmwaremanagement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.opensmartgridplatform.cucumber.core.ReadSettingsHelper.getBoolean;
+import static org.opensmartgridplatform.cucumber.core.ReadSettingsHelper.getHexDecoded;
+import static org.opensmartgridplatform.cucumber.core.ReadSettingsHelper.getString;
+import static org.opensmartgridplatform.cucumber.core.ReadSettingsHelper.getStringList;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.SortedSet;
+import java.util.stream.Collectors;
+import org.opensmartgridplatform.adapter.ws.schema.core.firmwaremanagement.DeviceModel;
+import org.opensmartgridplatform.adapter.ws.schema.core.firmwaremanagement.Firmware;
+import org.opensmartgridplatform.adapter.ws.schema.core.firmwaremanagement.FirmwareModuleData;
+import org.opensmartgridplatform.cucumber.platform.PlatformDefaults;
+import org.opensmartgridplatform.cucumber.platform.PlatformKeys;
+import org.opensmartgridplatform.domain.core.entities.FirmwareFile;
+import org.opensmartgridplatform.domain.core.entities.FirmwareModule;
+import org.opensmartgridplatform.domain.core.repositories.FirmwareFileRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class FirmwareSteps {
+
+  public static final String COMMUNICATION_MODULE_ACTIVE_FIRMWARE =
+      "communication_module_active_firmware";
+  public static final String FUNCTIONAL = "functional";
+  public static final String MODULE_ACTIVE_FIRMWARE = "module_active_firmware";
+  public static final String M_BUS = "m_bus";
+  public static final String SECURITY = "security";
+  public static final String ACTIVE_FIRMWARE = "active_firmware";
+  public static final String M_BUS_DRIVER_ACTIVE_FIRMWARE = "m_bus_driver_active_firmware";
+  public static final String SIMPLE_VERSION_INFO = "simple_version_info";
+
+  @Autowired private FirmwareFileRepository firmwareFileRepository;
+
+  protected Firmware createAndGetFirmware(final Map<String, String> requestParameters) {
+    final Firmware firmware = new Firmware();
+    firmware.setIdentification(
+        getString(requestParameters, PlatformKeys.FIRMWARE_FILE_IDENTIFICATION, null));
+    firmware.setFilename(getString(requestParameters, PlatformKeys.FIRMWARE_FILE_FILENAME, null));
+    firmware.setDescription(getString(requestParameters, PlatformKeys.FIRMWARE_DESCRIPTION, null));
+    if (requestParameters.containsKey(PlatformKeys.FIRMWARE_FILE)) {
+      firmware.setFile(getHexDecoded(requestParameters, PlatformKeys.FIRMWARE_FILE, null));
+    }
+    firmware.setPushToNewDevices(
+        getBoolean(
+            requestParameters,
+            PlatformKeys.FIRMWARE_PUSH_TO_NEW_DEVICES,
+            PlatformDefaults.FIRMWARE_PUSH_TO_NEW_DEVICE));
+
+    //    final String manufacturer =
+    //        getString(
+    //            requestParameters,
+    //            PlatformKeys.MANUFACTURER_NAME,
+    //            PlatformDefaults.DEFAULT_MANUFACTURER_NAME);
+    //    firmware.setManufacturer(manufacturer);
+
+    //    final DeviceModel deviceModel = new DeviceModel();
+    //    final String modelCode =
+    //        getString(
+    //            requestParameters,
+    //            PlatformKeys.DEVICEMODEL_MODELCODE,
+    //            PlatformDefaults.DEVICE_MODEL_MODEL_CODE);
+    //    deviceModel.setModelCode(modelCode);
+    //    deviceModel.setManufacturer(manufacturer);
+    //    firmware.getDeviceModels().add(deviceModel);
+
+    firmware.setFirmwareModuleData(new FirmwareModuleData());
+    if (requestParameters.containsKey(PlatformKeys.FIRMWARE_MODULE_VERSION_COMM)) {
+      firmware
+          .getFirmwareModuleData()
+          .setModuleVersionComm(
+              getString(requestParameters, PlatformKeys.FIRMWARE_MODULE_VERSION_COMM, null));
+    }
+    if (requestParameters.containsKey(PlatformKeys.FIRMWARE_MODULE_VERSION_FUNC)) {
+      firmware
+          .getFirmwareModuleData()
+          .setModuleVersionFunc(
+              getString(requestParameters, PlatformKeys.FIRMWARE_MODULE_VERSION_FUNC, null));
+    }
+    if (requestParameters.containsKey(PlatformKeys.FIRMWARE_MODULE_VERSION_MA)) {
+      firmware
+          .getFirmwareModuleData()
+          .setModuleVersionMa(
+              getString(requestParameters, PlatformKeys.FIRMWARE_MODULE_VERSION_MA, null));
+    }
+    if (requestParameters.containsKey(PlatformKeys.FIRMWARE_MODULE_VERSION_MBUS)) {
+      firmware
+          .getFirmwareModuleData()
+          .setModuleVersionMbus(
+              getString(requestParameters, PlatformKeys.FIRMWARE_MODULE_VERSION_MBUS, null));
+    }
+    if (requestParameters.containsKey(PlatformKeys.FIRMWARE_MODULE_VERSION_SEC)) {
+      firmware
+          .getFirmwareModuleData()
+          .setModuleVersionSec(
+              getString(requestParameters, PlatformKeys.FIRMWARE_MODULE_VERSION_SEC, null));
+    }
+    if (requestParameters.containsKey(PlatformKeys.FIRMWARE_MODULE_VERSION_M_BUS_DRIVER_ACTIVE)) {
+      firmware
+          .getFirmwareModuleData()
+          .setModuleVersionMBusDriverActive(
+              getString(
+                  requestParameters,
+                  PlatformKeys.FIRMWARE_MODULE_VERSION_M_BUS_DRIVER_ACTIVE,
+                  null));
+    }
+
+    final List<String> deviceModelCodes =
+        getStringList(requestParameters, PlatformKeys.DEVICEMODEL_MODELCODE, ";");
+    final List<String> deviceModelDescs =
+        getStringList(requestParameters, PlatformKeys.DEVICEMODEL_DESCRIPTION, ";");
+    final List<String> deviceModelManus =
+        getStringList(requestParameters, PlatformKeys.MANUFACTURER_NAME, ";");
+    for (int i = 0; i < deviceModelCodes.size(); i++) {
+      final DeviceModel deviceModel = new DeviceModel();
+      deviceModel.setModelCode(deviceModelCodes.get(i));
+      deviceModel.setDescription(deviceModelDescs.size() >= i + 1 ? deviceModelDescs.get(i) : null);
+      deviceModel.setManufacturer(
+          deviceModelManus.size() >= i + 1
+              ? deviceModelManus.get(i)
+              : PlatformDefaults.DEFAULT_MANUFACTURER_NAME);
+      firmware.getDeviceModels().add(deviceModel);
+    }
+
+    return firmware;
+  }
+
+  protected void assertFirmwareFileExists(
+      final String identification, final Map<String, String> firmwareFileProperties) {
+    final Firmware expectedFirmware = this.createAndGetFirmware(firmwareFileProperties);
+    final FirmwareFile databaseFirmwareFile =
+        this.firmwareFileRepository.findByIdentification(identification);
+
+    assertThat(databaseFirmwareFile)
+        .isNotNull()
+        .as("Firmware File {} should exist", identification);
+
+    assertThat(databaseFirmwareFile.getDescription()).isEqualTo(expectedFirmware.getDescription());
+    assertThat(databaseFirmwareFile.getFile()).isEqualTo(expectedFirmware.getFile());
+    assertThat(databaseFirmwareFile.getFilename()).isEqualTo(expectedFirmware.getFilename());
+  }
+
+  protected void assertFirmwareFileHasModuleVersions(
+      final String identification, final Map<String, String> expectedmoduleVersions) {
+    final Firmware expectedFirmware = this.createAndGetFirmware(expectedmoduleVersions);
+
+    final FirmwareFile databaseFirmwareFile =
+        this.firmwareFileRepository.findByIdentification(identification);
+
+    assertThat(databaseFirmwareFile)
+        .isNotNull()
+        .as("Firmware File {} should exist", identification);
+
+    final Map<FirmwareModule, String> databaseModuleVersions =
+        databaseFirmwareFile.getModuleVersions();
+
+    assertThat(databaseModuleVersions).hasSameSizeAs(expectedmoduleVersions);
+
+    final FirmwareModuleData expectedFirmwareModuleData = expectedFirmware.getFirmwareModuleData();
+
+    for (final Entry<FirmwareModule, String> entry : databaseModuleVersions.entrySet()) {
+
+      final String version = entry.getValue();
+
+      switch (entry.getKey().getDescription()) {
+        case COMMUNICATION_MODULE_ACTIVE_FIRMWARE:
+          assertThat(expectedFirmwareModuleData.getModuleVersionComm()).isEqualTo(version);
+          break;
+        case FUNCTIONAL:
+          assertThat(expectedFirmwareModuleData.getModuleVersionFunc()).isEqualTo(version);
+          break;
+        case M_BUS:
+          assertThat(expectedFirmwareModuleData.getModuleVersionMbus()).isEqualTo(version);
+          break;
+        case M_BUS_DRIVER_ACTIVE_FIRMWARE:
+          assertThat(expectedFirmwareModuleData.getModuleVersionMBusDriverActive())
+              .isEqualTo(version);
+          break;
+        case MODULE_ACTIVE_FIRMWARE:
+          assertThat(expectedFirmwareModuleData.getModuleVersionMa()).isEqualTo(version);
+          break;
+        case SECURITY:
+          assertThat(expectedFirmwareModuleData.getModuleVersionSec()).isEqualTo(version);
+          break;
+        case SIMPLE_VERSION_INFO:
+          assertThat(expectedFirmwareModuleData.getModuleVersionSimple()).isEqualTo(version);
+          break;
+        default:
+      }
+    }
+  }
+
+  protected void assertFirmwareFileHasDeviceModels(
+      final String identification, final Map<String, String> expectedDeviceModels) {
+    final Firmware expectedFirmware = this.createAndGetFirmware(expectedDeviceModels);
+
+    final FirmwareFile databaseFirmwareFile =
+        this.firmwareFileRepository.findByIdentification(identification);
+
+    assertThat(databaseFirmwareFile)
+        .isNotNull()
+        .as("Firmware File {} should exist", identification);
+
+    final SortedSet<org.opensmartgridplatform.domain.core.entities.DeviceModel>
+        databaseDeviceModels = databaseFirmwareFile.getDeviceModels();
+
+    final List<DeviceModel> deviceModels = expectedFirmware.getDeviceModels();
+
+    assertThat(databaseDeviceModels).hasSameSizeAs(deviceModels);
+
+    final List<String> databaseDeviceModelCodes =
+        databaseDeviceModels.stream().map(ddm -> ddm.getModelCode()).collect(Collectors.toList());
+    final List<String> deviceModelCodes =
+        deviceModels.stream().map(dm -> dm.getModelCode()).collect(Collectors.toList());
+
+    assertThat(deviceModelCodes).containsExactlyInAnyOrderElementsOf(databaseDeviceModelCodes);
+  }
+}

--- a/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/core/firmwaremanagement/FirmwareSteps.java
+++ b/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/ws/core/firmwaremanagement/FirmwareSteps.java
@@ -58,23 +58,6 @@ public class FirmwareSteps {
             PlatformKeys.FIRMWARE_PUSH_TO_NEW_DEVICES,
             PlatformDefaults.FIRMWARE_PUSH_TO_NEW_DEVICE));
 
-    //    final String manufacturer =
-    //        getString(
-    //            requestParameters,
-    //            PlatformKeys.MANUFACTURER_NAME,
-    //            PlatformDefaults.DEFAULT_MANUFACTURER_NAME);
-    //    firmware.setManufacturer(manufacturer);
-
-    //    final DeviceModel deviceModel = new DeviceModel();
-    //    final String modelCode =
-    //        getString(
-    //            requestParameters,
-    //            PlatformKeys.DEVICEMODEL_MODELCODE,
-    //            PlatformDefaults.DEVICE_MODEL_MODEL_CODE);
-    //    deviceModel.setModelCode(modelCode);
-    //    deviceModel.setManufacturer(manufacturer);
-    //    firmware.getDeviceModels().add(deviceModel);
-
     firmware.setFirmwareModuleData(new FirmwareModuleData());
     if (requestParameters.containsKey(PlatformKeys.FIRMWARE_MODULE_VERSION_COMM)) {
       firmware

--- a/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/support/ws/core/CoreFirmwareManagementClient.java
+++ b/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/support/ws/core/CoreFirmwareManagementClient.java
@@ -11,6 +11,8 @@ package org.opensmartgridplatform.cucumber.platform.common.support.ws.core;
 import org.opensmartgridplatform.adapter.ws.schema.core.firmwaremanagement.AddDeviceModelRequest;
 import org.opensmartgridplatform.adapter.ws.schema.core.firmwaremanagement.AddFirmwareRequest;
 import org.opensmartgridplatform.adapter.ws.schema.core.firmwaremanagement.AddFirmwareResponse;
+import org.opensmartgridplatform.adapter.ws.schema.core.firmwaremanagement.AddOrChangeFirmwareRequest;
+import org.opensmartgridplatform.adapter.ws.schema.core.firmwaremanagement.AddOrChangeFirmwareResponse;
 import org.opensmartgridplatform.adapter.ws.schema.core.firmwaremanagement.ChangeDeviceModelRequest;
 import org.opensmartgridplatform.adapter.ws.schema.core.firmwaremanagement.ChangeDeviceModelResponse;
 import org.opensmartgridplatform.adapter.ws.schema.core.firmwaremanagement.ChangeFirmwareRequest;
@@ -96,6 +98,14 @@ public class CoreFirmwareManagementClient extends BaseClient {
         this.coreFirmwareManagementWstf.getTemplate(
             this.getOrganizationIdentification(), this.getUserName());
     return (AddFirmwareResponse) wst.marshalSendAndReceive(request);
+  }
+
+  public AddOrChangeFirmwareResponse addOrChangeFirmware(final AddOrChangeFirmwareRequest request)
+      throws WebServiceSecurityException {
+    final WebServiceTemplate wst =
+        this.coreFirmwareManagementWstf.getTemplate(
+            this.getOrganizationIdentification(), this.getUserName());
+    return (AddOrChangeFirmwareResponse) wst.marshalSendAndReceive(request);
   }
 
   public ChangeDeviceModelResponse changeDeviceModel(final ChangeDeviceModelRequest request)

--- a/integration-tests/cucumber-tests-platform-common/src/test/resources/features/common/osgp-adapter-ws-core/FirmwareManagement/AddFirmware.feature
+++ b/integration-tests/cucumber-tests-platform-common/src/test/resources/features/common/osgp-adapter-ws-core/FirmwareManagement/AddFirmware.feature
@@ -16,6 +16,10 @@ Feature: FirmwareManagement add firmware
       | FirmwareDescription      | Firmware is newly created with File Contents but without related FirmwareModules |
     Then the add firmware response contains
       | Result | OK |
+    And the entity firmware exists
+      | ModelCode                 | DeviceModelDBStorageModel_test                                                   |
+      | FirmwareFilename          | NewFirmware_test1                                                                |
+      | FirmwareDescription       | Firmware is newly created with File Contents but without related FirmwareModules |
 
   Scenario: Add firmware without File Content and without related DeviceModel and FirmwareModules
     Given a device model
@@ -30,25 +34,6 @@ Feature: FirmwareManagement add firmware
       | FaultCode    | SOAP-ENV:Server                                             |
       | FaultString  | UNKNOWN_FIRMWARE                                            |
       | InnerMessage | DeviceModel with id "NewFirmware_test2" could not be found. |
-
-  Scenario: Add firmware without File Content (but Firmware File in DB) and without related FirmwareModules
-    Given a device model
-      | ModelCode              | DeviceModelDBStorageModel_test  |
-      | DeviceModelFileStorage | false                           |
-    And a firmware
-      | DeviceIdentification     | TEST1024000000001              |
-      | FirmwareFilename         | NewFirmware_test3              |
-      | FirmwarePushToNewDevices | true                           |
-      | ManufacturerName         | Test                           |
-      | ModelCode                | DeviceModelDBStorageModel_test |
-      | Description              |                                |
-    When receiving an add firmware request
-      | FirmwareFilename          | NewFirmware_test3                                                                                                 |
-      | ManufacturerName          | Test                                                                                                              |
-      | ModelCode                 | DeviceModelDBStorageModel_test                                                                                    |
-      | FirmwareDescription       | Firmware is newly created without File Content (but Firmware File in DB) and without related FirmwareModules      |
-    Then the add firmware response contains
-      | Result | OK |
 
   Scenario: Add firmware with File Contents and with related FirmwareModules
     Given a device model
@@ -68,4 +53,15 @@ Feature: FirmwareManagement add firmware
       | FirmwareModuleVersionMbda | mbda_1.7                                                                      |
     Then the add firmware response contains
       | Result | OK |
+    And the entity firmware exists
+      | FirmwareFile              | 57696520646974206c656573742069732067656b                                      |
+      | FirmwareFilename          | NewFirmware_test4                                                             |
+      | ModelCode                 | DeviceModelDBStorageModel_test                                                |
+      | FirmwareDescription       | Firmware is newly created with File Contents and with related FirmwareModules |
+      | FirmwareModuleVersionComm | comm_1.2                                                                      |
+      | FirmwareModuleVersionFunc | func_1.3                                                                      |
+      | FirmwareModuleVersionMa   | ma_1.4                                                                        |
+      | FirmwareModuleVersionMbus | mbus_1.5                                                                      |
+      | FirmwareModuleVersionSec  | sec_1.6                                                                       |
+      | FirmwareModuleVersionMbda | mbda_1.7                                                                      |
 

--- a/integration-tests/cucumber-tests-platform-common/src/test/resources/features/common/osgp-adapter-ws-core/FirmwareManagement/AddFirmware.feature
+++ b/integration-tests/cucumber-tests-platform-common/src/test/resources/features/common/osgp-adapter-ws-core/FirmwareManagement/AddFirmware.feature
@@ -1,0 +1,71 @@
+@Common @Platform @FirmwareManagement
+Feature: FirmwareManagement add firmware
+  As OSGP 
+  I want to add the firmware of a device
+  In order to ...
+
+  Scenario: Add firmware with File Contents but without related FirmwareModules
+    Given a device model
+      | ModelCode              | DeviceModelDBStorageModel_test |
+      | DeviceModelFileStorage | false                          |
+    When receiving an add firmware request
+      | FirmwareFile             | 57696520646974206c656573742069732067656b                                         |
+      | FirmwareFilename         | NewFirmware_test1                                                                |
+      | ManufacturerName         | Test                                                                             |
+      | ModelCode                | DeviceModelDBStorageModel_test                                                   |
+      | FirmwareDescription      | Firmware is newly created with File Contents but without related FirmwareModules |
+    Then the add firmware response contains
+      | Result | OK |
+
+  Scenario: Add firmware without File Content and without related DeviceModel and FirmwareModules
+    Given a device model
+      | ModelCode              | DeviceModelDBStorageModel_test  |
+      | DeviceModelFileStorage | false                           |
+    When receiving an add firmware request
+      | FirmwareFilename          | NewFirmware_test2                                                                         |
+      | ManufacturerName          | Test                                                                                      |
+      | ModelCode                 | DeviceModelDBStorageModel_test                                                            |
+      | FirmwareDescription       | Firmware is newly created without File Contents and without related FirmwareModules       |
+    Then the add firmware response contains soap fault
+      | FaultCode    | SOAP-ENV:Server                                             |
+      | FaultString  | UNKNOWN_FIRMWARE                                            |
+      | InnerMessage | DeviceModel with id "NewFirmware_test2" could not be found. |
+
+  Scenario: Add firmware without File Content (but Firmware File in DB) and without related FirmwareModules
+    Given a device model
+      | ModelCode              | DeviceModelDBStorageModel_test  |
+      | DeviceModelFileStorage | false                           |
+    And a firmware
+      | DeviceIdentification     | TEST1024000000001              |
+      | FirmwareFilename         | NewFirmware_test3              |
+      | FirmwarePushToNewDevices | true                           |
+      | ManufacturerName         | Test                           |
+      | ModelCode                | DeviceModelDBStorageModel_test |
+      | Description              |                                |
+    When receiving an add firmware request
+      | FirmwareFilename          | NewFirmware_test3                                                                                                 |
+      | ManufacturerName          | Test                                                                                                              |
+      | ModelCode                 | DeviceModelDBStorageModel_test                                                                                    |
+      | FirmwareDescription       | Firmware is newly created without File Content (but Firmware File in DB) and without related FirmwareModules      |
+    Then the add firmware response contains
+      | Result | OK |
+
+  Scenario: Add firmware with File Contents and with related FirmwareModules
+    Given a device model
+      | ModelCode              | DeviceModelDBStorageModel_test |
+      | DeviceModelFileStorage | false                          |
+    When receiving an add firmware request
+      | FirmwareFile              | 57696520646974206c656573742069732067656b                                      |
+      | FirmwareFilename          | NewFirmware_test4                                                             |
+      | ManufacturerName          | Test                                                                          |
+      | ModelCode                 | DeviceModelDBStorageModel_test                                                |
+      | FirmwareDescription       | Firmware is newly created with File Contents and with related FirmwareModules |
+      | FirmwareModuleVersionComm | comm_1.2                                                                      |
+      | FirmwareModuleVersionFunc | func_1.3                                                                      |
+      | FirmwareModuleVersionMa   | ma_1.4                                                                        |
+      | FirmwareModuleVersionMbus | mbus_1.5                                                                      |
+      | FirmwareModuleVersionSec  | sec_1.6                                                                       |
+      | FirmwareModuleVersionMbda | mbda_1.7                                                                      |
+    Then the add firmware response contains
+      | Result | OK |
+

--- a/integration-tests/cucumber-tests-platform-common/src/test/resources/features/common/osgp-adapter-ws-core/FirmwareManagement/AddOrChangeFirmware.feature
+++ b/integration-tests/cucumber-tests-platform-common/src/test/resources/features/common/osgp-adapter-ws-core/FirmwareManagement/AddOrChangeFirmware.feature
@@ -60,7 +60,7 @@ Feature: FirmwareManagement add or change firmware
       | ManufacturerName           | Test                                                           |
     Then the add or change firmware response contains
       | Result | OK |
-   And the firmware file '1234567890ABCBEF' exists
+    And the firmware file '1234567890ABCBEF' exists
       | FirmwareFile               | 57696520646974206c656573742069732067656b                       |
       | FirmwareFilename           | NewFirmware_test3                                              |
       | FirmwareDescription        | Add 3 - Firmware is newly created with related FirmwareModules |

--- a/integration-tests/cucumber-tests-platform-common/src/test/resources/features/common/osgp-adapter-ws-core/FirmwareManagement/AddOrChangeFirmware.feature
+++ b/integration-tests/cucumber-tests-platform-common/src/test/resources/features/common/osgp-adapter-ws-core/FirmwareManagement/AddOrChangeFirmware.feature
@@ -1,0 +1,241 @@
+@Common @Platform @FirmwareManagement
+Feature: FirmwareManagement add or change firmware
+  As OSGP 
+  I want to add a new or change an existing firmware
+  In order to ...
+
+  Scenario: Add firmware with File Contents
+    Given a device model
+      | ModelCode              | DeviceModelDBStorageModel_test |
+      | DeviceModelFileStorage | false                          |
+    When receiving an add or change firmware request
+      | FirmwareFileIdentification | 1234567890ABCBEF                                     |
+      | FirmwareFile               | 57696520646974206c656573742069732067656b             |
+      | FirmwareFilename           | NewFirmware_test1                                    |
+      | ManufacturerName           | Test                                                 |
+      | ModelCode                  | DeviceModelDBStorageModel_test                       |
+      | FirmwareDescription        | Add 1 - Firmware is newly created with File Contents |
+      | FirmwareModuleVersionComm  | comm_1.2                                             |
+    Then the add or change firmware response contains
+      | Result | OK |
+    And the firmware file '1234567890ABCBEF' exists
+      | FirmwareFile               | 57696520646974206c656573742069732067656b             |
+      | FirmwareFilename           | NewFirmware_test1                                    |
+      | FirmwareDescription        | Add 1 - Firmware is newly created with File Contents |
+      | FirmwareModuleVersionComm  | comm_1.2                                             |
+
+  Scenario: Add firmware without File Content
+    Given a device model
+      | ModelCode              | DeviceModelDBStorageModel_test  |
+      | DeviceModelFileStorage | false                           |
+    When receiving an add or change firmware request
+      | FirmwareFileIdentification | 1234567890ABCBEF                                        |
+      | ManufacturerName           | Test                                                    |
+      | ModelCode                  | DeviceModelDBStorageModel_test                          |
+      | FirmwareDescription        | Add 2 - Firmware is newly created without File Contents |
+      | FirmwareModuleVersionComm  | comm_1.2                                                |
+    Then the add or change firmware response contains
+      | Result | OK |
+    And the firmware file '1234567890ABCBEF' exists
+      | FirmwareDescription       | Add 2 - Firmware is newly created without File Contents |
+      | FirmwareModuleVersionComm | comm_1.2                                                |
+
+  Scenario: Add firmware with File Contents and with related FirmwareModules
+    Given a device model
+      | ModelCode              | DeviceModelDBStorageModel_test1 |
+      | DeviceModelFileStorage | false                           |
+    When receiving an add or change firmware request
+      | FirmwareFileIdentification | 1234567890ABCBEF                                               |
+      | FirmwareFile               | 57696520646974206c656573742069732067656b                       |
+      | FirmwareFilename           | NewFirmware_test3                                              |
+      | FirmwareDescription        | Add 3 - Firmware is newly created with related FirmwareModules |
+      | FirmwareModuleVersionComm  | comm_1.2                                                       |
+      | FirmwareModuleVersionFunc  | func_1.3                                                       |
+      | FirmwareModuleVersionMa    | ma_1.4                                                         |
+      | FirmwareModuleVersionMbus  | mbus_1.5                                                       |
+      | FirmwareModuleVersionSec   | sec_1.6                                                        |
+      | FirmwareModuleVersionMbda  | mbda_1.7                                                       |  
+      | ModelCode                  | DeviceModelDBStorageModel_test1                                |
+      | DeviceModelDescription     | DeviceModelDBStorageModel_desc1                                |
+      | ManufacturerName           | Test                                                           |
+    Then the add or change firmware response contains
+      | Result | OK |
+   And the firmware file '1234567890ABCBEF' exists
+      | FirmwareFile               | 57696520646974206c656573742069732067656b                       |
+      | FirmwareFilename           | NewFirmware_test3                                              |
+      | FirmwareDescription        | Add 3 - Firmware is newly created with related FirmwareModules |
+    And the firmware file '1234567890ABCBEF' has module versions
+      | FirmwareModuleVersionComm  | comm_1.2                                                       |
+      | FirmwareModuleVersionFunc  | func_1.3                                                       |
+      | FirmwareModuleVersionMa    | ma_1.4                                                         |
+      | FirmwareModuleVersionMbus  | mbus_1.5                                                       |
+      | FirmwareModuleVersionSec   | sec_1.6                                                        |
+      | FirmwareModuleVersionMbda  | mbda_1.7                                                       |  
+      
+  Scenario: Add firmware with File Contents and with multiple related DeviceModels
+    Given a device model
+      | ModelCode              | DeviceModelDBStorageModel_test1 |
+      | DeviceModelFileStorage | false                           |
+    And a device model
+      | ModelCode              | DeviceModelDBStorageModel_test2 |
+      | DeviceModelFileStorage | false                           |
+    And a device model
+      | ModelCode              | DeviceModelDBStorageModel_test3 |
+      | DeviceModelFileStorage | false                           |
+    When receiving an add or change firmware request
+      | FirmwareFileIdentification | 1234567890ABCBEF                                                                                |
+      | FirmwareFile               | 57696520646974206c656573742069732067656b                                                        |
+      | FirmwareFilename           | NewFirmware_test4                                                                               |
+      | FirmwareDescription        | Add 4 - Firmware is newly created with multiple related DeviceModels                            |
+      | ModelCode                  | DeviceModelDBStorageModel_test1;DeviceModelDBStorageModel_test2;DeviceModelDBStorageModel_test3 |
+      | DeviceModelDescription     | DeviceModelDBStorageModel_desc1;DeviceModelDBStorageModel_desc2;DeviceModelDBStorageModel_desc3 |
+      | ManufacturerName           | Test;Test;Test                                                                                  |
+      | FirmwareModuleVersionComm  | comm_1.2                                                                                        |
+    Then the add or change firmware response contains
+      | Result | OK |    
+    And the firmware file '1234567890ABCBEF' exists
+      | FirmwareFile              | 57696520646974206c656573742069732067656b                                                        |
+      | FirmwareFilename          | NewFirmware_test4                                                                               |
+      | FirmwareDescription       | Add 4 - Firmware is newly created with multiple related DeviceModels                            |
+    And the firmware file '1234567890ABCBEF' has device models
+      | ModelCode                 | DeviceModelDBStorageModel_test1;DeviceModelDBStorageModel_test2;DeviceModelDBStorageModel_test3 |
+      
+  Scenario: Add firmware with File Contents and without related DeviceModel
+    Given a device model
+      | ModelCode              | DeviceModelDBStorageModel_test |
+      | DeviceModelFileStorage | false                          |
+    When receiving an add or change firmware request
+      | FirmwareFileIdentification | 1234567890ABCBEF                                                                     |
+      | FirmwareFile              | 57696520646974206c656573742069732067656b                                              |
+      | FirmwareFilename          | NewFirmware_test5                                                                     |
+      | FirmwareDescription       | Add 5 - Firmware is newly created with File Contents and without related DeviceModels |
+      | FirmwareModuleVersionComm | comm_1.2                                                                              |
+    Then the add or change firmware response contains
+      | Result | OK |    
+    And the firmware file '1234567890ABCBEF' exists
+      | FirmwareFile              | 57696520646974206c656573742069732067656b                                              |
+      | FirmwareFilename          | NewFirmware_test5                                                                     |
+      | FirmwareDescription       | Add 5 - Firmware is newly created with File Contents and without related DeviceModels |
+     
+  Scenario: Change firmware with File Content - Change Description
+    Given a device model
+      | ModelCode              | DeviceModelDBStorageModel_test  |
+      | DeviceModelFileStorage | false                           |
+    And a firmware
+      | FirmwareFileIdentification | 1234567890ABCBEF                         |
+      | FirmwareFile               | 57696520646974206c656573742069732067656b |
+      | FirmwareFilename           | NewFirmware_test6                        |
+      | FirmwarePushToNewDevices   | true                                     |
+      | ManufacturerName           | Test                                     |
+      | ModelCode                  | DeviceModelDBStorageModel_test           |
+      | FirmwareDescription        | This is some description                 |
+    When receiving an add or change firmware request
+      | FirmwareFileIdentification | 1234567890ABCBEF                                      |
+      | FirmwarePushToNewDevices   | true                                                  |
+      | ManufacturerName           | Test                                                  |
+      | ModelCode                  | DeviceModelDBStorageModel_test                        |
+      | FirmwareDescription        | Change 1 - Firmware is changed  - Added Description   |
+      | FirmwareModuleVersionComm  | comm_1.2                                              |
+    Then the add or change firmware response contains
+      | Result | OK |
+    And the firmware file '1234567890ABCBEF' exists
+      | FirmwareFile               | 57696520646974206c656573742069732067656b            |
+      | FirmwareFilename           | NewFirmware_test6                                   |
+      | FirmwarePushToNewDevices   | true                                                |
+      | ManufacturerName           | Test                                                |
+      | ModelCode                  | DeviceModelDBStorageModel_test                      |
+      | FirmwareDescription        | Change 1 - Firmware is changed  - Added Description |
+
+  Scenario: Change firmware without File Content - Add File Content
+    Given a device model
+      | ModelCode              | DeviceModelDBStorageModel_test  |
+      | DeviceModelFileStorage | false                           |
+    And a firmware
+      | FirmwareFileIdentification | 1234567890ABCBEF                         |
+      | FirmwarePushToNewDevices   | true                                     |
+      | ManufacturerName           | Test                                     |
+      | ModelCode                  | DeviceModelDBStorageModel_test           |
+      | FirmwareDescription        | This is some description                 |
+    When receiving an add or change firmware request
+      | FirmwareFileIdentification | 1234567890ABCBEF                                      |
+      | FirmwareFile               | 57696520646974206c656573742069732067656b              |
+      | FirmwareFilename           | NewFirmware_test4                                     |
+      | FirmwarePushToNewDevices   | true                                                  |
+      | ManufacturerName           | Test                                                  |
+      | ModelCode                  | DeviceModelDBStorageModel_test                        |
+      | FirmwareDescription        | Change 2 - Firmware is changed  - Added File Content  |
+      | FirmwareModuleVersionComm  | comm_1.2                                              |
+    Then the add or change firmware response contains
+      | Result | OK |
+    And the firmware file '1234567890ABCBEF' exists
+      | FirmwareFile               | 57696520646974206c656573742069732067656b              |
+      | FirmwareFilename           | NewFirmware_test4                                     |
+      | FirmwarePushToNewDevices   | true                                                  |
+      | FirmwareDescription        | Change 2 - Firmware is changed  - Added File Content  |
+
+  Scenario: Change firmware without related DeviceModels- Add related DeviceModels
+    Given a device model
+      | ModelCode              | DeviceModelDBStorageModel_test1 |
+      | DeviceModelFileStorage | false                           |
+    And a device model
+      | ModelCode              | DeviceModelDBStorageModel_test2 |
+      | DeviceModelFileStorage | false                           |
+    And a device model
+      | ModelCode              | DeviceModelDBStorageModel_test3 |
+      | DeviceModelFileStorage | false                           |
+    And a firmware
+      | FirmwareFileIdentification | 1234567890ABCBEF                         |
+      | FirmwarePushToNewDevices   | true                                     |
+      | FirmwareDescription        | This is some description                 |
+      | ModelCode                  | DeviceModelDBStorageModel_test1          |
+    When receiving an add or change firmware request
+      | FirmwareFileIdentification | 1234567890ABCBEF                                             |
+      | FirmwarePushToNewDevices   | true                                                         |
+      | FirmwareDescription        | Change 3 - Firmware is changed  - Added related DeviceModels |
+      | ModelCode                  | DeviceModelDBStorageModel_test1;DeviceModelDBStorageModel_test2;DeviceModelDBStorageModel_test3 |
+      | DeviceModelDescription     | DeviceModelDBStorageModel_desc1;DeviceModelDBStorageModel_desc2;DeviceModelDBStorageModel_desc3 |
+      | ManufacturerName           | Test;Test;Test                                                                                  |
+      | FirmwareModuleVersionComm  | comm_1.2                                                                                        |
+    Then the add or change firmware response contains
+      | Result | OK |
+    And the firmware file '1234567890ABCBEF' exists
+      | FirmwarePushToNewDevices   | true                                                         |
+      | FirmwareDescription        | Change 3 - Firmware is changed  - Added related DeviceModels |
+ 
+  Scenario: Change firmware without related DeviceModels- Add related DeviceModels
+    Given a device model
+      | ModelCode              | DeviceModelDBStorageModel_test1 |
+      | DeviceModelFileStorage | false                           |
+    And a firmware
+      | FirmwareFileIdentification | 1234567890ABCBEF                         |
+      | FirmwarePushToNewDevices   | true                                     |
+      | FirmwareDescription        | This is some description                 |
+      | ModelCode                  | DeviceModelDBStorageModel_test1          |
+      | FirmwareModuleVersionComm  | comm_1.2                                 |
+      | FirmwareModuleVersionFunc  | func_1.3                                 |
+      | FirmwareModuleVersionMa    | ma_1.4                                   |
+      | FirmwareModuleVersionMbus  | mbus_1.5                                 |
+      | FirmwareModuleVersionSec   | sec_1.6                                  |
+      | FirmwareModuleVersionMbda  | mbda_1.7                                 |  
+    When receiving an add or change firmware request
+      | FirmwareFileIdentification | 1234567890ABCBEF                                          |
+      | FirmwarePushToNewDevices   | true                                                      |
+      | FirmwareDescription        | Change 4 - Firmware is changed  - Changed Module Versions |
+      | FirmwareModuleVersionComm  | comm_2.2                                                  |
+      | FirmwareModuleVersionFunc  | func_2.3                                                  |
+      | FirmwareModuleVersionMa    | ma_2.4                                                    |
+      | FirmwareModuleVersionMbus  | mbus_2.5                                                  |
+      | FirmwareModuleVersionSec   | sec_2.6                                                   |
+      | FirmwareModuleVersionMbda  | mbda_2.7                                                  |     
+    Then the add or change firmware response contains
+      | Result | OK |
+    And the firmware file '1234567890ABCBEF' exists
+      | FirmwarePushToNewDevices   | true                                                      |
+      | FirmwareDescription        | Change 4 - Firmware is changed  - Changed Module Versions |
+    And the firmware file '1234567890ABCBEF' has module versions
+      | FirmwareModuleVersionComm  | comm_2.2                                                  |
+      | FirmwareModuleVersionFunc  | func_2.3                                                  |
+      | FirmwareModuleVersionMa    | ma_2.4                                                    |
+      | FirmwareModuleVersionMbus  | mbus_2.5                                                  |
+      | FirmwareModuleVersionSec   | sec_2.6                                                   |
+      | FirmwareModuleVersionMbda  | mbda_2.7                                                  |

--- a/integration-tests/cucumber-tests-platform-common/src/test/resources/features/common/osgp-adapter-ws-core/FirmwareManagement/ChangeFirmware.feature
+++ b/integration-tests/cucumber-tests-platform-common/src/test/resources/features/common/osgp-adapter-ws-core/FirmwareManagement/ChangeFirmware.feature
@@ -22,6 +22,10 @@ Feature: FirmwareManagement change firmware
       | FirmwareDescription      | Firmware is changed! |
     Then the change firmware response contains
       | Result | OK |
+    And the entity firmware exists
+      | ModelCode                 | TestModel            |
+      | FirmwareFilename          | NewFirmware          |
+      | FirmwareDescription       | Firmware is changed! |
 
   Scenario Outline: Change firmware with an unknown or empty devicemodel
     Given a device

--- a/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/database/core/FirmwareFileSteps.java
+++ b/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/database/core/FirmwareFileSteps.java
@@ -253,41 +253,20 @@ public class FirmwareFileSteps {
           final DeviceModel deviceModel = firmwareFile.getDeviceModels().iterator().next();
 
           assertThat(firmwareFile.getDescription())
-              .isEqualTo(
-                  getString(
-                      expectedEntity,
-                      PlatformKeys.FIRMWARE_DESCRIPTION,
-                      PlatformDefaults.FIRMWARE_DESCRIPTION));
+              .isEqualTo(getString(expectedEntity, PlatformKeys.FIRMWARE_DESCRIPTION, null));
           assertThat(firmwareFile.getModuleVersionComm())
               .isEqualTo(
-                  getString(
-                      expectedEntity,
-                      PlatformKeys.FIRMWARE_MODULE_VERSION_COMM,
-                      PlatformDefaults.FIRMWARE_MODULE_VERSION_COMM));
+                  getString(expectedEntity, PlatformKeys.FIRMWARE_MODULE_VERSION_COMM, null));
           assertThat(firmwareFile.getModuleVersionFunc())
               .isEqualTo(
-                  getString(
-                      expectedEntity,
-                      PlatformKeys.FIRMWARE_MODULE_VERSION_FUNC,
-                      PlatformDefaults.FIRMWARE_MODULE_VERSION_FUNC));
+                  getString(expectedEntity, PlatformKeys.FIRMWARE_MODULE_VERSION_FUNC, null));
           assertThat(firmwareFile.getModuleVersionMa())
-              .isEqualTo(
-                  getString(
-                      expectedEntity,
-                      PlatformKeys.FIRMWARE_MODULE_VERSION_MA,
-                      PlatformDefaults.FIRMWARE_MODULE_VERSION_MA));
+              .isEqualTo(getString(expectedEntity, PlatformKeys.FIRMWARE_MODULE_VERSION_MA, null));
           assertThat(firmwareFile.getModuleVersionMbus())
               .isEqualTo(
-                  getString(
-                      expectedEntity,
-                      PlatformKeys.FIRMWARE_MODULE_VERSION_MBUS,
-                      PlatformDefaults.FIRMWARE_MODULE_VERSION_MBUS));
+                  getString(expectedEntity, PlatformKeys.FIRMWARE_MODULE_VERSION_MBUS, null));
           assertThat(firmwareFile.getModuleVersionSec())
-              .isEqualTo(
-                  getString(
-                      expectedEntity,
-                      PlatformKeys.FIRMWARE_MODULE_VERSION_SEC,
-                      PlatformDefaults.FIRMWARE_MODULE_VERSION_SEC));
+              .isEqualTo(getString(expectedEntity, PlatformKeys.FIRMWARE_MODULE_VERSION_SEC, null));
 
           assertThat(deviceModel.getModelCode())
               .isEqualTo(

--- a/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/database/core/FirmwareFileSteps.java
+++ b/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/database/core/FirmwareFileSteps.java
@@ -11,6 +11,7 @@ package org.opensmartgridplatform.cucumber.platform.glue.steps.database.core;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.opensmartgridplatform.cucumber.core.ReadSettingsHelper.getBoolean;
 import static org.opensmartgridplatform.cucumber.core.ReadSettingsHelper.getEnum;
+import static org.opensmartgridplatform.cucumber.core.ReadSettingsHelper.getHexDecoded;
 import static org.opensmartgridplatform.cucumber.core.ReadSettingsHelper.getString;
 
 import com.google.common.io.Files;
@@ -109,21 +110,36 @@ public class FirmwareFileSteps {
      * identification then no longer needs to be added to the constructor
      * used to create the firmware.)
      */
-    final String identification =
+    String identification =
         getString(
             settings,
             PlatformKeys.FIRMWARE_FILE_FILENAME,
             UUID.randomUUID().toString().replace("-", ""));
+    /*
+     * To enable tests for Firmware File upload the FirmwareFileIdentification
+     * as actually used to uniquely identify the Firmware File. In these scenario's
+     * the FirmwareFileIdentification is added and will overrule the filename as identification.
+     */
+    identification = getString(settings, PlatformKeys.FIRMWARE_FILE_IDENTIFICATION, identification);
+
+    /*
+     * The File contents can either be present in the Scenario parameters under label FirmwareFile
+     * The File Content is than provided in hexadecimal
+     * or the File contents can be read into a byte array using Firmware File's Filename
+     */
     final String filename = getString(settings, PlatformKeys.FIRMWARE_FILE_FILENAME, "");
-    final boolean fileExists =
-        getBoolean(
-            settings, PlatformKeys.FIRMWARE_FILE_EXISTS, PlatformDefaults.FIRMWARE_FILE_EXISTS);
-    final byte[] file;
-    if (fileExists) {
-      file = this.readFile(deviceModel, filename, isForSmartMeters);
+    byte[] file = null;
+    if (settings.containsKey(PlatformKeys.FIRMWARE_FILE)) {
+      file = getHexDecoded(settings, PlatformKeys.FIRMWARE_FILE, null);
     } else {
-      file = null;
+      final boolean fileExists =
+          getBoolean(
+              settings, PlatformKeys.FIRMWARE_FILE_EXISTS, PlatformDefaults.FIRMWARE_FILE_EXISTS);
+      if (fileExists) {
+        file = this.readFile(deviceModel, filename, isForSmartMeters);
+      }
     }
+
     FirmwareFile firmwareFile =
         new FirmwareFile.Builder()
             .withIdentification(identification)

--- a/osgp/platform/osgp-adapter-ws-core/src/main/java/org/opensmartgridplatform/adapter/ws/core/application/mapping/FirmwareConverter.java
+++ b/osgp/platform/osgp-adapter-ws-core/src/main/java/org/opensmartgridplatform/adapter/ws/core/application/mapping/FirmwareConverter.java
@@ -95,6 +95,7 @@ class FirmwareConverter
             .MODULE_DESCRIPTION_SIMPLE_VERSION_INFO:
           firmwareModuleData.setModuleVersionSimple(moduleVersion.getValue());
           break;
+        default:
       }
     }
     output.setFirmwareModuleData(firmwareModuleData);

--- a/osgp/platform/osgp-adapter-ws-core/src/main/java/org/opensmartgridplatform/adapter/ws/core/application/mapping/FirmwareConverter.java
+++ b/osgp/platform/osgp-adapter-ws-core/src/main/java/org/opensmartgridplatform/adapter/ws/core/application/mapping/FirmwareConverter.java
@@ -9,6 +9,8 @@
 package org.opensmartgridplatform.adapter.ws.core.application.mapping;
 
 import java.util.GregorianCalendar;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
@@ -18,6 +20,7 @@ import ma.glasnost.orika.metadata.Type;
 import org.opensmartgridplatform.adapter.ws.schema.core.firmwaremanagement.Firmware;
 import org.opensmartgridplatform.adapter.ws.schema.core.firmwaremanagement.FirmwareModuleData;
 import org.opensmartgridplatform.domain.core.entities.DeviceModel;
+import org.opensmartgridplatform.domain.core.entities.FirmwareModule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,39 +40,63 @@ class FirmwareConverter
 
     final Firmware output = new Firmware();
 
-    /*
-     * A firmware file has been changed to be related to (possibly) multiple
-     * device models to be usable across different value streams for all
-     * kinds of devices.
-     *
-     * If this code gets used in a scenario where multiple device models are
-     * actually related to the firmware file it may need to be updated to
-     * deal with this.
-     */
     final Set<DeviceModel> deviceModels = source.getDeviceModels();
-    if (deviceModels.size() != 1) {
-      LOGGER.warn(
-          "Conversion to WS Firmware assumes a single DeviceModel, FirmwareFile (id={}) has {}: {}",
-          source.getId(),
-          deviceModels.size(),
-          deviceModels);
+    for (final DeviceModel deviceModel : deviceModels) {
+      final org.opensmartgridplatform.adapter.ws.schema.core.firmwaremanagement.DeviceModel
+          wsDeviceModel =
+              new org.opensmartgridplatform.adapter.ws.schema.core.firmwaremanagement.DeviceModel();
+      wsDeviceModel.setModelCode(deviceModel.getModelCode());
+      wsDeviceModel.setDescription(deviceModel.getDescription());
+      wsDeviceModel.setManufacturer(deviceModel.getManufacturer().getCode());
+      output.getDeviceModels().add(wsDeviceModel);
     }
-    final DeviceModel deviceModel = deviceModels.iterator().next();
 
     output.setDescription(source.getDescription());
     output.setFilename(source.getFilename());
     output.setId(source.getId().intValue());
-    output.setModelCode(deviceModel.getModelCode());
+    output.setIdentification(source.getIdentification());
     output.setPushToNewDevices(source.getPushToNewDevices());
-    output.setManufacturer(deviceModel.getManufacturer().getCode());
     output.setActive(source.isActive());
 
     final FirmwareModuleData firmwareModuleData = new FirmwareModuleData();
-    firmwareModuleData.setModuleVersionComm(source.getModuleVersionComm());
-    firmwareModuleData.setModuleVersionFunc(source.getModuleVersionFunc());
-    firmwareModuleData.setModuleVersionMa(source.getModuleVersionMa());
-    firmwareModuleData.setModuleVersionMbus(source.getModuleVersionMbus());
-    firmwareModuleData.setModuleVersionSec(source.getModuleVersionSec());
+    final Map<FirmwareModule, String> moduleVersions = source.getModuleVersions();
+    for (final Entry<FirmwareModule, String> moduleVersion : moduleVersions.entrySet()) {
+      final FirmwareModule firmwareModule = moduleVersion.getKey();
+      switch (firmwareModule.getDescription()) {
+        case org.opensmartgridplatform.domain.core.valueobjects.FirmwareModuleData
+            .MODULE_DESCRIPTION_COMM:
+          firmwareModuleData.setModuleVersionComm(moduleVersion.getValue());
+          break;
+        case org.opensmartgridplatform.domain.core.valueobjects.FirmwareModuleData
+            .MODULE_DESCRIPTION_FUNC:
+          firmwareModuleData.setModuleVersionFunc(moduleVersion.getValue());
+          break;
+        case org.opensmartgridplatform.domain.core.valueobjects.FirmwareModuleData
+            .MODULE_DESCRIPTION_FUNC_SMART_METERING:
+          firmwareModuleData.setModuleVersionFunc(moduleVersion.getValue());
+          break;
+        case org.opensmartgridplatform.domain.core.valueobjects.FirmwareModuleData
+            .MODULE_DESCRIPTION_MA:
+          firmwareModuleData.setModuleVersionMa(moduleVersion.getValue());
+          break;
+        case org.opensmartgridplatform.domain.core.valueobjects.FirmwareModuleData
+            .MODULE_DESCRIPTION_MBUS:
+          firmwareModuleData.setModuleVersionMbus(moduleVersion.getValue());
+          break;
+        case org.opensmartgridplatform.domain.core.valueobjects.FirmwareModuleData
+            .MODULE_DESCRIPTION_MBUS_DRIVER_ACTIVE:
+          firmwareModuleData.setModuleVersionMBusDriverActive(moduleVersion.getValue());
+          break;
+        case org.opensmartgridplatform.domain.core.valueobjects.FirmwareModuleData
+            .MODULE_DESCRIPTION_SEC:
+          firmwareModuleData.setModuleVersionSec(moduleVersion.getValue());
+          break;
+        case org.opensmartgridplatform.domain.core.valueobjects.FirmwareModuleData
+            .MODULE_DESCRIPTION_SIMPLE_VERSION_INFO:
+          firmwareModuleData.setModuleVersionSimple(moduleVersion.getValue());
+          break;
+      }
+    }
     output.setFirmwareModuleData(firmwareModuleData);
 
     final GregorianCalendar gCalendar = new GregorianCalendar();

--- a/osgp/platform/osgp-adapter-ws-core/src/main/java/org/opensmartgridplatform/adapter/ws/core/application/services/FirmwareFileRequest.java
+++ b/osgp/platform/osgp-adapter-ws-core/src/main/java/org/opensmartgridplatform/adapter/ws/core/application/services/FirmwareFileRequest.java
@@ -8,36 +8,26 @@
  */
 package org.opensmartgridplatform.adapter.ws.core.application.services;
 
+import lombok.Getter;
+
+@Getter
 public class FirmwareFileRequest {
+  private final String identification;
   private final String description;
   private final String fileName;
   private final boolean pushToNewDevices;
   private final boolean active;
 
   public FirmwareFileRequest(
+      final String identification,
       final String description,
       final String fileName,
       final boolean pushToNewDevices,
       final boolean active) {
+    this.identification = identification;
     this.description = description;
     this.fileName = fileName;
     this.pushToNewDevices = pushToNewDevices;
     this.active = active;
-  }
-
-  public String getDescription() {
-    return this.description;
-  }
-
-  public String getFileName() {
-    return this.fileName;
-  }
-
-  public boolean isPushToNewDevices() {
-    return this.pushToNewDevices;
-  }
-
-  public boolean isActive() {
-    return this.active;
   }
 }

--- a/osgp/platform/osgp-adapter-ws-core/src/main/java/org/opensmartgridplatform/adapter/ws/core/application/services/FirmwareManagementService.java
+++ b/osgp/platform/osgp-adapter-ws-core/src/main/java/org/opensmartgridplatform/adapter/ws/core/application/services/FirmwareManagementService.java
@@ -650,7 +650,7 @@ public class FirmwareManagementService {
       } else {
         // Storing the file in the database
         savedFirmwareFile =
-            this.savedToDatabase(firmwareFileRequest, databaseFirmwareFiles.get(0).getFile());
+            this.createNewFirmwareFile(firmwareFileRequest, databaseFirmwareFiles.get(0).getFile());
       }
     } else if (databaseDeviceModel.isFileStorage()) {
       // Saving the file to the file system
@@ -658,7 +658,7 @@ public class FirmwareManagementService {
       savedFirmwareFile = this.firmwareFileFrom(firmwareFileRequest);
     } else {
       // Storing the file in the database
-      savedFirmwareFile = this.savedToDatabase(firmwareFileRequest, file);
+      savedFirmwareFile = this.createNewFirmwareFile(firmwareFileRequest, file);
     }
 
     if (firmwareFileRequest.isPushToNewDevices()) {
@@ -678,6 +678,69 @@ public class FirmwareManagementService {
     this.firmwareFileRepository.save(savedFirmwareFile);
   }
 
+  @Transactional(value = "writableTransactionManager")
+  public void addOrChangeFirmware(
+      @Identification final String organisationIdentification,
+      final FirmwareFileRequest firmwareFileRequest,
+      final byte[] file,
+      final List<org.opensmartgridplatform.domain.core.valueobjects.DeviceModel> deviceModels,
+      final FirmwareModuleData firmwareModuleData)
+      throws OsgpException {
+
+    final Organisation organisation =
+        this.domainHelperService.findOrganisation(organisationIdentification);
+    this.domainHelperService.isAllowed(organisation, PlatformFunction.CREATE_FIRMWARE);
+
+    // find for each DeviceModel from the WebServcies the corresponding entities
+    // There should be at least one DeviceModel. If none found a FunctionalException should be
+    // raised
+    // Each DeviceModel can have it's own Manufacturer (at least a theory)
+    // if a Manufacturer entity related to the DeviceModel can not be found a FunctionalException
+    // should be raised
+    // if one of the DeviceModel entities can not be found a FunctionalException should be raised
+    final List<DeviceModel> databaseDeviceModels = new ArrayList<>();
+    for (final org.opensmartgridplatform.domain.core.valueobjects.DeviceModel deviceModel :
+        deviceModels) {
+      final Manufacturer databaseManufacturer =
+          this.manufacturerRepository.findByCode(deviceModel.getManufacturer());
+
+      if (databaseManufacturer == null) {
+        LOGGER.info("Manufacturer doesn't exist.");
+        throw new FunctionalException(
+            FunctionalExceptionType.UNKNOWN_MANUFACTURER,
+            ComponentType.WS_CORE,
+            new UnknownEntityException(Manufacturer.class, deviceModel.getManufacturer()));
+      }
+      final DeviceModel databaseDeviceModel =
+          this.deviceModelRepository.findByManufacturerAndModelCode(
+              databaseManufacturer, deviceModel.getModelCode());
+
+      if (databaseDeviceModel == null) {
+        LOGGER.info("DeviceModel doesn't exist.");
+        throw new FunctionalException(
+            FunctionalExceptionType.UNKNOWN_DEVICEMODEL,
+            ComponentType.WS_CORE,
+            new UnknownEntityException(DeviceModel.class, deviceModel.getModelCode()));
+      }
+      databaseDeviceModels.add(databaseDeviceModel);
+    }
+    if (!deviceModels.isEmpty() && databaseDeviceModels.isEmpty()) {
+      LOGGER.info("No DeviceModels found.");
+      throw new FunctionalException(
+          FunctionalExceptionType.UNKNOWN_DEVICEMODEL, ComponentType.WS_CORE);
+    }
+
+    final Map<FirmwareModule, String> firmwareVersionsByModule =
+        firmwareModuleData.getVersionsByModule(this.firmwareModuleRepository, false);
+
+    final FirmwareFile firmwareFile = this.insertOrUdateDatabase(firmwareFileRequest, file);
+
+    firmwareFile.updateFirmwareDeviceModels(databaseDeviceModels);
+    firmwareFile.updateFirmwareModuleData(firmwareVersionsByModule);
+
+    this.firmwareFileRepository.save(firmwareFile);
+  }
+
   private FirmwareFile firmwareFileFrom(final FirmwareFileRequest firmwareFileRequest) {
     return new FirmwareFile.Builder()
         .withFilename(firmwareFileRequest.getFileName())
@@ -687,9 +750,48 @@ public class FirmwareManagementService {
         .build();
   }
 
-  private FirmwareFile savedToDatabase(
+  private FirmwareFile insertOrUdateDatabase(
+      final FirmwareFileRequest firmwareFileRequest, final byte[] file) {
+    final String identification = firmwareFileRequest.getIdentification();
+    final FirmwareFile existingFirmwareFile =
+        this.firmwareFileRepository.findByIdentification(identification);
+    FirmwareFile savedFirmwareFile;
+    if (existingFirmwareFile == null) {
+      final FirmwareFile newFirmwareFile = this.createNewFirmwareFile(firmwareFileRequest, file);
+      savedFirmwareFile = this.firmwareFileRepository.save(newFirmwareFile);
+    } else {
+      this.updateExistingFirmwareFile(existingFirmwareFile, firmwareFileRequest, file);
+      savedFirmwareFile = this.firmwareFileRepository.save(existingFirmwareFile);
+    }
+    return savedFirmwareFile;
+  }
+
+  private FirmwareFile updateExistingFirmwareFile(
+      final FirmwareFile existingFirmwareFile,
+      final FirmwareFileRequest firmwareFileRequest,
+      final byte[] file) {
+    existingFirmwareFile.setDescription(firmwareFileRequest.getDescription());
+    // A file can only be uploaded once
+    // - directly at creation of the FirmwareFile record
+    // - or as is processed here in a update action of the FirmwareFile record
+    // Removing the File Content is not allowed. Null or empty value for file therefore will be
+    // ignored.
+    // Getting and directly setting of file(name) attributes of the existing FW file record seems
+    // not necessary but asppearently a new record is created in the process
+    if (existingFirmwareFile.getFile() == null || existingFirmwareFile.getFile().length == 0) {
+      existingFirmwareFile.setFilename(firmwareFileRequest.getFileName());
+      existingFirmwareFile.setFile(file);
+    } else {
+      existingFirmwareFile.setFilename(existingFirmwareFile.getFilename());
+      existingFirmwareFile.setFile(existingFirmwareFile.getFile());
+    }
+    return existingFirmwareFile;
+  }
+
+  private FirmwareFile createNewFirmwareFile(
       final FirmwareFileRequest firmwareFileRequest, final byte[] file) {
     return new FirmwareFile.Builder()
+        .withIdentification(firmwareFileRequest.getIdentification())
         .withFilename(firmwareFileRequest.getFileName())
         .withDescription(firmwareFileRequest.getDescription())
         .withPushToNewDevices(firmwareFileRequest.isPushToNewDevices())
@@ -720,6 +822,12 @@ public class FirmwareManagementService {
         this.domainHelperService.findOrganisation(organisationIdentification);
     this.domainHelperService.isAllowed(organisation, PlatformFunction.CHANGE_FIRMWARE);
 
+    FirmwareFile changedFirmwareFile =
+        this.firmwareFileRepository
+            .findById((long) id)
+            .orElseThrow(
+                supplyFirmwareFileNotFoundException(id, firmwareFileRequest.getFileName()));
+
     final Manufacturer databaseManufacturer = this.manufacturerRepository.findByCode(manufacturer);
 
     if (databaseManufacturer == null) {
@@ -742,12 +850,6 @@ public class FirmwareManagementService {
           new UnknownEntityException(DeviceModel.class, modelCode));
     }
 
-    FirmwareFile changedFirmwareFile =
-        this.firmwareFileRepository
-            .findById((long) id)
-            .orElseThrow(
-                supplyFirmwareFileNotFoundException(id, firmwareFileRequest.getFileName()));
-
     changedFirmwareFile.setDescription(firmwareFileRequest.getDescription());
     /*
      * A firmware file has been changed to be related to (possibly) multiple
@@ -760,6 +862,9 @@ public class FirmwareManagementService {
      * If multiple device models are related, it is not clear what to do,
      * and which if the device models (if any) should be removed. In such
      * case the device model will be added for now.
+     *
+     * 2021-06-02: In case of multiple DeviceModels all existing must be deleted
+     * and all new DeviceModels in the request must be added
      */
     final Set<DeviceModel> existingDeviceModels = changedFirmwareFile.getDeviceModels();
     if (existingDeviceModels.size() > 1) {
@@ -774,8 +879,9 @@ public class FirmwareManagementService {
           changedFirmwareFile.getId(),
           existingDeviceModels.size(),
           databaseDeviceModel);
-      existingDeviceModels.clear();
     }
+    existingDeviceModels.clear();
+
     changedFirmwareFile.addDeviceModel(databaseDeviceModel);
     changedFirmwareFile.setFilename(firmwareFileRequest.getFileName());
     changedFirmwareFile.updateFirmwareModuleData(

--- a/osgp/platform/osgp-adapter-ws-core/src/main/java/org/opensmartgridplatform/adapter/ws/core/endpoints/FirmwareManagementEndpoint.java
+++ b/osgp/platform/osgp-adapter-ws-core/src/main/java/org/opensmartgridplatform/adapter/ws/core/endpoints/FirmwareManagementEndpoint.java
@@ -1130,14 +1130,18 @@ public class FirmwareManagementEndpoint {
 
   private String getManufacturerFromFirmware(final Firmware firmware) {
     return firmware.getDeviceModels().stream()
-        .map(dm -> dm.getManufacturer())
+        .map(
+            org.opensmartgridplatform.adapter.ws.schema.core.firmwaremanagement.DeviceModel
+                ::getManufacturer)
         .findFirst()
         .orElse(null);
   }
 
   private String getModelCodeFromFirmware(final Firmware firmware) {
     return firmware.getDeviceModels().stream()
-        .map(dm -> dm.getModelCode())
+        .map(
+            org.opensmartgridplatform.adapter.ws.schema.core.firmwaremanagement.DeviceModel
+                ::getModelCode)
         .findFirst()
         .orElse(null);
   }

--- a/osgp/platform/osgp-adapter-ws-core/src/main/java/org/opensmartgridplatform/adapter/ws/core/endpoints/FirmwareManagementEndpoint.java
+++ b/osgp/platform/osgp-adapter-ws-core/src/main/java/org/opensmartgridplatform/adapter/ws/core/endpoints/FirmwareManagementEndpoint.java
@@ -873,14 +873,8 @@ public class FirmwareManagementEndpoint {
 
       // The AddFirmwareRequest accepts multiple DeviceModels to be related to a Firmware.
       // This FirmwareManagementService only accepts ONE for now
-      final List<org.opensmartgridplatform.adapter.ws.schema.core.firmwaremanagement.DeviceModel>
-          wsDeviceModels = request.getFirmware().getDeviceModels();
-      String modelCode = null;
-      String manufacturer = null;
-      if (!wsDeviceModels.isEmpty()) {
-        modelCode = wsDeviceModels.get(0).getModelCode();
-        manufacturer = wsDeviceModels.get(0).getManufacturer();
-      }
+      final String manufacturer = this.getManufacturerFromFirmware(request.getFirmware());
+      final String modelCode = this.getModelCodeFromFirmware(request.getFirmware());
 
       this.firmwareManagementService.addFirmware(
           organisationIdentification,
@@ -939,14 +933,8 @@ public class FirmwareManagementEndpoint {
 
     // The ChangeFirmwareRequest accepts multiple DeviceModels to be related to a Firmware.
     // This FirmwareManagementService only accepts ONE for now
-    final List<org.opensmartgridplatform.adapter.ws.schema.core.firmwaremanagement.DeviceModel>
-        wsDeviceModels = request.getFirmware().getDeviceModels();
-    String modelCode = null;
-    String manufacturer = null;
-    if (!wsDeviceModels.isEmpty()) {
-      modelCode = wsDeviceModels.get(0).getModelCode();
-      manufacturer = wsDeviceModels.get(0).getManufacturer();
-    }
+    final String manufacturer = this.getManufacturerFromFirmware(request.getFirmware());
+    final String modelCode = this.getModelCodeFromFirmware(request.getFirmware());
 
     try {
       this.firmwareManagementService.changeFirmware(
@@ -1138,6 +1126,20 @@ public class FirmwareManagementEndpoint {
     }
 
     return response;
+  }
+
+  private String getManufacturerFromFirmware(final Firmware firmware) {
+    return firmware.getDeviceModels().stream()
+        .map(dm -> dm.getManufacturer())
+        .findFirst()
+        .orElse(null);
+  }
+
+  private String getModelCodeFromFirmware(final Firmware firmware) {
+    return firmware.getDeviceModels().stream()
+        .map(dm -> dm.getModelCode())
+        .findFirst()
+        .orElse(null);
   }
 
   private void handleException(final Exception e) throws OsgpException {

--- a/osgp/platform/osgp-adapter-ws-core/src/main/java/org/opensmartgridplatform/adapter/ws/core/endpoints/FirmwareManagementEndpoint.java
+++ b/osgp/platform/osgp-adapter-ws-core/src/main/java/org/opensmartgridplatform/adapter/ws/core/endpoints/FirmwareManagementEndpoint.java
@@ -871,13 +871,13 @@ public class FirmwareManagementEndpoint {
           this.firmwareManagementMapper.map(
               request.getFirmware().getFirmwareModuleData(), FirmwareModuleData.class);
 
-      // TODO The AddFirmwareRequest accepts multiple DeviceModels to be related to a Firmware.
+      // The AddFirmwareRequest accepts multiple DeviceModels to be related to a Firmware.
       // This FirmwareManagementService only accepts ONE for now
       final List<org.opensmartgridplatform.adapter.ws.schema.core.firmwaremanagement.DeviceModel>
           wsDeviceModels = request.getFirmware().getDeviceModels();
       String modelCode = null;
       String manufacturer = null;
-      if (wsDeviceModels.size() > 0) {
+      if (!wsDeviceModels.isEmpty()) {
         modelCode = wsDeviceModels.get(0).getModelCode();
         manufacturer = wsDeviceModels.get(0).getManufacturer();
       }
@@ -937,13 +937,13 @@ public class FirmwareManagementEndpoint {
         this.firmwareManagementMapper.map(
             request.getFirmware().getFirmwareModuleData(), FirmwareModuleData.class);
 
-    // TODO The ChangeFirmwareRequest accepts multiple DeviceModels to be related to a Firmware.
+    // The ChangeFirmwareRequest accepts multiple DeviceModels to be related to a Firmware.
     // This FirmwareManagementService only accepts ONE for now
     final List<org.opensmartgridplatform.adapter.ws.schema.core.firmwaremanagement.DeviceModel>
         wsDeviceModels = request.getFirmware().getDeviceModels();
     String modelCode = null;
     String manufacturer = null;
-    if (wsDeviceModels.size() > 0) {
+    if (!wsDeviceModels.isEmpty()) {
       modelCode = wsDeviceModels.get(0).getModelCode();
       manufacturer = wsDeviceModels.get(0).getManufacturer();
     }

--- a/osgp/platform/osgp-adapter-ws-shared-db/src/main/java/org/opensmartgridplatform/adapter/ws/shared/db/domain/repositories/writable/WritableFirmwareFileRepository.java
+++ b/osgp/platform/osgp-adapter-ws-shared-db/src/main/java/org/opensmartgridplatform/adapter/ws/shared/db/domain/repositories/writable/WritableFirmwareFileRepository.java
@@ -21,6 +21,9 @@ import org.springframework.stereotype.Repository;
 public interface WritableFirmwareFileRepository
     extends JpaRepository<FirmwareFile, Long>, JpaSpecificationExecutor<FirmwareFile> {
 
+  @Query("SELECT ff FROM FirmwareFile ff WHERE ff.identification = :identification ")
+  FirmwareFile findByIdentification(@Param("identification") String identification);
+
   @Query("SELECT ff FROM FirmwareFile ff WHERE :deviceModel MEMBER OF ff.deviceModels")
   List<FirmwareFile> findByDeviceModel(@Param("deviceModel") DeviceModel deviceModel);
 

--- a/osgp/platform/osgp-domain-core/src/main/java/org/opensmartgridplatform/domain/core/entities/FirmwareFile.java
+++ b/osgp/platform/osgp-domain-core/src/main/java/org/opensmartgridplatform/domain/core/entities/FirmwareFile.java
@@ -12,6 +12,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -100,6 +101,11 @@ public class FirmwareFile extends AbstractEntity {
   public void updateFirmwareModuleData(final Map<FirmwareModule, String> versionsByModule) {
     this.firmwareModules.clear();
     versionsByModule.forEach(this::addFirmwareModule);
+  }
+
+  public void updateFirmwareDeviceModels(final List<DeviceModel> deviceModels) {
+    this.deviceModels.clear();
+    deviceModels.forEach(this::addDeviceModel);
   }
 
   public String getIdentification() {
@@ -356,7 +362,9 @@ public class FirmwareFile extends AbstractEntity {
     private boolean active;
 
     public Builder withIdentification(final String identification) {
-      this.identification = identification;
+      if (identification != null) {
+        this.identification = identification;
+      }
       return this;
     }
 

--- a/osgp/shared/osgp-ws-core/src/main/resources/FirmwareManagement.wsdl
+++ b/osgp/shared/osgp-ws-core/src/main/resources/FirmwareManagement.wsdl
@@ -251,6 +251,21 @@
     </wsdl:part>
   </wsdl:message>
 
+  <wsdl:message name="AddOrChangeFirmwareHeader">
+    <wsdl:part element="common:OrganisationIdentification"
+      name="OrganisationIdentification" />
+    <wsdl:part element="common:UserName" name="UserName" />
+    <wsdl:part element="common:ApplicationName" name="ApplicationName" />
+  </wsdl:message>
+  <wsdl:message name="AddOrChangeFirmwareRequest">
+    <wsdl:part element="fman:AddOrChangeFirmwareRequest" name="AddOrChangeFirmwareRequest">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="AddOrChangeFirmwareResponse">
+    <wsdl:part element="fman:AddOrChangeFirmwareResponse" name="AddOrChangeFirmwareResponse">
+    </wsdl:part>
+  </wsdl:message>
+
   <wsdl:message name="GetDeviceFirmwareHistoryHeader">
     <wsdl:part element="common:OrganisationIdentification"
       name="OrganisationIdentification" />
@@ -531,6 +546,14 @@
       </wsdl:output>
     </wsdl:operation>
 
+    <wsdl:operation name="AddOrChangeFirmware">
+      <wsdl:input message="tns:AddOrChangeFirmwareRequest" name="AddOrChangeFirmwareRequest">
+      </wsdl:input>
+      <wsdl:output message="tns:AddOrChangeFirmwareResponse"
+        name="AddOrChangeFirmwareResponse">
+      </wsdl:output>
+    </wsdl:operation>
+
     <wsdl:operation name="RemoveFirmware">
       <wsdl:input message="tns:RemoveFirmwareRequest" name="RemoveFirmwareRequest">
       </wsdl:input>
@@ -804,6 +827,22 @@
         <soap:body use="literal" />
       </wsdl:input>
       <wsdl:output name="ChangeFirmwareResponse">
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+
+    <wsdl:operation name="AddOrChangeFirmware">
+      <soap:operation soapAction="" />
+      <wsdl:input name="AddOrChangeFirmwareRequest">
+        <soap:header message="tns:AddOrChangeFirmwareHeader"
+          part="OrganisationIdentification" use="literal" />
+        <soap:header message="tns:AddOrChangeFirmwareHeader"
+          part="UserName" use="literal" />
+        <soap:header message="tns:AddOrChangeFirmwareHeader"
+          part="ApplicationName" use="literal" />
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output name="AddOrChangeFirmwareResponse">
         <soap:body use="literal" />
       </wsdl:output>
     </wsdl:operation>

--- a/osgp/shared/osgp-ws-core/src/main/resources/schemas/firmwaremanagement.xsd
+++ b/osgp/shared/osgp-ws-core/src/main/resources/schemas/firmwaremanagement.xsd
@@ -487,7 +487,7 @@
       <xsd:element name="Id" type="xsd:int" />
       <xsd:element name="Filename" type="xsd:string" minOccurs="0" />
       <xsd:element name="CreationTime" type="xsd:dateTime" minOccurs="0" />
-       <xsd:element minOccurs="0" maxOccurs="unbounded" name="DeviceModels" type="tns:DeviceModel" />
+      <xsd:element minOccurs="0" maxOccurs="unbounded" name="DeviceModels" type="tns:DeviceModel" />
       <xsd:element name="Description" minOccurs="0">
         <xsd:simpleType>
           <xsd:restriction base="xsd:string">

--- a/osgp/shared/osgp-ws-core/src/main/resources/schemas/firmwaremanagement.xsd
+++ b/osgp/shared/osgp-ws-core/src/main/resources/schemas/firmwaremanagement.xsd
@@ -369,6 +369,24 @@
     </xsd:complexType>
   </xsd:element>
 
+  <xsd:element name="AddOrChangeFirmwareRequest">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="Firmware" type="tns:Firmware" />
+        <xsd:element name="Id" type="xsd:int" />
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="AddOrChangeFirmwareResponse">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="Result" type="common:OsgpResultType" />
+        <xsd:element name="Description" type="xsd:string" minOccurs="0" />
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+
   <xsd:element name="SwitchFirmwareRequest">
     <xsd:complexType>
       <xsd:sequence>
@@ -465,23 +483,11 @@
 
   <xsd:complexType name="Firmware">
     <xsd:sequence>
+      <xsd:element name="Identification" type="xsd:string" minOccurs="0" />
       <xsd:element name="Id" type="xsd:int" />
       <xsd:element name="Filename" type="xsd:string" minOccurs="0" />
       <xsd:element name="CreationTime" type="xsd:dateTime" minOccurs="0" />
-      <xsd:element name="Manufacturer" minOccurs="0">
-        <xsd:simpleType>
-          <xsd:restriction base="xsd:string">
-            <xsd:maxLength value="4" />
-          </xsd:restriction>
-        </xsd:simpleType>
-      </xsd:element>
-      <xsd:element name="ModelCode" minOccurs="0">
-        <xsd:simpleType>
-          <xsd:restriction base="xsd:string">
-            <xsd:maxLength value="255" />
-          </xsd:restriction>
-        </xsd:simpleType>
-      </xsd:element>
+       <xsd:element minOccurs="0" maxOccurs="unbounded" name="DeviceModels" type="tns:DeviceModel" />
       <xsd:element name="Description" minOccurs="0">
         <xsd:simpleType>
           <xsd:restriction base="xsd:string">


### PR DESCRIPTION
The existing implementation of two endpoints in FirmwareManagement are not compliant with the datamodel of the Core database. These endpoints (AddFirmwareRequest and ChangeFirmwareRequest) differ from this datamodel on two major points

- The Identification column was added as mandatory, unique and user-defined column. 
The current implementation uses either the Id column (internal database key) or a combination of Firmware's filename and related devicemodel's code to uniquely identifythe Firmware

- The current implementation assumes an one-on-one relationbetween Firmware and DeviceModel. The datamodel in the Core database has a many-to-many relation between Firmware and DeviceModel.

SMHE needs an endpoint to synchronize between it's own database and the database on the GXF platform.

- Therefor and extra endpoint was implemented: AddorChangeFirmware.
- This new endpoint consumes this new AddorChangeFirmwareRequest containing the existing Firmware class. This class originally had one ModelCode and one Manufacturer. This was replaced by a list of DeviceModels (an already existing object) containig both ModelCode and Manufacturer).
- The Firmware class now also has an Identification
- To be compliant with this modified Firmware class the AddFirmwareRequest and ChangeFirmwareRequest handling was slightly modified assuming the list of DeviceModels always contains exactly one DeviceModel.
- The Firmware class in AddFirmwareRequest and ChangeFirmwareRequest has no value for Identification but generates one serverside in case of a new Firmware.