### PR TITLE
Slim 2987 Added ModuleVersionActive as one of moduleVersiontypes in ModuleVersionData

### DIFF
--- a/osgp/platform/osgp-adapter-ws-core/src/main/java/org/opensmartgridplatform/adapter/ws/core/application/mapping/FirmwareConverter.java
+++ b/osgp/platform/osgp-adapter-ws-core/src/main/java/org/opensmartgridplatform/adapter/ws/core/application/mapping/FirmwareConverter.java
@@ -73,7 +73,7 @@ class FirmwareConverter
           break;
         case org.opensmartgridplatform.domain.core.valueobjects.FirmwareModuleData
             .MODULE_DESCRIPTION_FUNC_SMART_METERING:
-          firmwareModuleData.setModuleVersionActive(moduleVersion.getValue());
+          firmwareModuleData.setModuleVersionFunc(moduleVersion.getValue());
           break;
         case org.opensmartgridplatform.domain.core.valueobjects.FirmwareModuleData
             .MODULE_DESCRIPTION_MA:

--- a/osgp/platform/osgp-adapter-ws-core/src/main/java/org/opensmartgridplatform/adapter/ws/core/application/mapping/FirmwareConverter.java
+++ b/osgp/platform/osgp-adapter-ws-core/src/main/java/org/opensmartgridplatform/adapter/ws/core/application/mapping/FirmwareConverter.java
@@ -73,7 +73,7 @@ class FirmwareConverter
           break;
         case org.opensmartgridplatform.domain.core.valueobjects.FirmwareModuleData
             .MODULE_DESCRIPTION_FUNC_SMART_METERING:
-          firmwareModuleData.setModuleVersionFunc(moduleVersion.getValue());
+          firmwareModuleData.setModuleVersionActive(moduleVersion.getValue());
           break;
         case org.opensmartgridplatform.domain.core.valueobjects.FirmwareModuleData
             .MODULE_DESCRIPTION_MA:

--- a/osgp/platform/osgp-adapter-ws-core/src/main/java/org/opensmartgridplatform/adapter/ws/core/application/mapping/FirmwareManagementMapper.java
+++ b/osgp/platform/osgp-adapter-ws-core/src/main/java/org/opensmartgridplatform/adapter/ws/core/application/mapping/FirmwareManagementMapper.java
@@ -39,6 +39,7 @@ public class FirmwareManagementMapper extends ConfigurableMapper {
   public void configure(final MapperFactory mapperFactory) {
 
     mapperFactory.getConverterFactory().registerConverter(new FirmwareConverter());
+    mapperFactory.getConverterFactory().registerConverter(new FirmwareModuleDataConverter());
 
     mapperFactory
         .getConverterFactory()

--- a/osgp/platform/osgp-adapter-ws-core/src/main/java/org/opensmartgridplatform/adapter/ws/core/application/mapping/FirmwareModuleDataConverter.java
+++ b/osgp/platform/osgp-adapter-ws-core/src/main/java/org/opensmartgridplatform/adapter/ws/core/application/mapping/FirmwareModuleDataConverter.java
@@ -1,0 +1,43 @@
+package org.opensmartgridplatform.adapter.ws.core.application.mapping;
+
+import ma.glasnost.orika.CustomConverter;
+import ma.glasnost.orika.MappingContext;
+import ma.glasnost.orika.metadata.Type;
+import org.opensmartgridplatform.domain.core.valueobjects.FirmwareModuleData;
+
+public class FirmwareModuleDataConverter
+    extends CustomConverter<
+        org.opensmartgridplatform.adapter.ws.schema.core.firmwaremanagement.FirmwareModuleData,
+        FirmwareModuleData> {
+
+  private boolean isForSmartMeter = true;
+
+  @Override
+  public FirmwareModuleData convert(
+      final org.opensmartgridplatform.adapter.ws.schema.core.firmwaremanagement.FirmwareModuleData
+          source,
+      final Type<? extends FirmwareModuleData> destinationType,
+      final MappingContext mappingContext) {
+
+    String moduleVersionFunc = source.getModuleVersionFunc();
+    if (this.isForSmartMeter) {
+      moduleVersionFunc = source.getModuleVersionActive();
+    }
+
+    final FirmwareModuleData output =
+        new FirmwareModuleData(
+            source.getModuleVersionComm(),
+            moduleVersionFunc,
+            source.getModuleVersionMa(),
+            source.getModuleVersionMbus(),
+            source.getModuleVersionSec(),
+            source.getModuleVersionMBusDriverActive(),
+            source.getModuleVersionSimple());
+
+    return output;
+  }
+
+  public void setForSmartMeter(final boolean isForSmartMeter) {
+    this.isForSmartMeter = isForSmartMeter;
+  }
+}

--- a/osgp/platform/osgp-adapter-ws-core/src/main/java/org/opensmartgridplatform/adapter/ws/core/application/mapping/FirmwareModuleDataConverter.java
+++ b/osgp/platform/osgp-adapter-ws-core/src/main/java/org/opensmartgridplatform/adapter/ws/core/application/mapping/FirmwareModuleDataConverter.java
@@ -10,8 +10,6 @@ public class FirmwareModuleDataConverter
         org.opensmartgridplatform.adapter.ws.schema.core.firmwaremanagement.FirmwareModuleData,
         FirmwareModuleData> {
 
-  private boolean isForSmartMeter = true;
-
   @Override
   public FirmwareModuleData convert(
       final org.opensmartgridplatform.adapter.ws.schema.core.firmwaremanagement.FirmwareModuleData
@@ -19,8 +17,10 @@ public class FirmwareModuleDataConverter
       final Type<? extends FirmwareModuleData> destinationType,
       final MappingContext mappingContext) {
 
+    // The Func(tional) ModuleVersionType is reused for the Active ModuleVersionType in use with
+    // SmartMetering. SmartMetering is not using the Func type so they will not coexist.
     String moduleVersionFunc = source.getModuleVersionFunc();
-    if (this.isForSmartMeter) {
+    if (source.getModuleVersionActive() != null) {
       moduleVersionFunc = source.getModuleVersionActive();
     }
 
@@ -35,9 +35,5 @@ public class FirmwareModuleDataConverter
             source.getModuleVersionSimple());
 
     return output;
-  }
-
-  public void setForSmartMeter(final boolean isForSmartMeter) {
-    this.isForSmartMeter = isForSmartMeter;
   }
 }

--- a/osgp/platform/osgp-adapter-ws-core/src/main/java/org/opensmartgridplatform/adapter/ws/core/application/mapping/FirmwareModuleDataConverter.java
+++ b/osgp/platform/osgp-adapter-ws-core/src/main/java/org/opensmartgridplatform/adapter/ws/core/application/mapping/FirmwareModuleDataConverter.java
@@ -24,16 +24,13 @@ public class FirmwareModuleDataConverter
       moduleVersionFunc = source.getModuleVersionActive();
     }
 
-    final FirmwareModuleData output =
-        new FirmwareModuleData(
-            source.getModuleVersionComm(),
-            moduleVersionFunc,
-            source.getModuleVersionMa(),
-            source.getModuleVersionMbus(),
-            source.getModuleVersionSec(),
-            source.getModuleVersionMBusDriverActive(),
-            source.getModuleVersionSimple());
-
-    return output;
+    return new FirmwareModuleData(
+        source.getModuleVersionComm(),
+        moduleVersionFunc,
+        source.getModuleVersionMa(),
+        source.getModuleVersionMbus(),
+        source.getModuleVersionSec(),
+        source.getModuleVersionMBusDriverActive(),
+        source.getModuleVersionSimple());
   }
 }

--- a/osgp/platform/osgp-adapter-ws-core/src/main/java/org/opensmartgridplatform/adapter/ws/core/application/services/FirmwareManagementService.java
+++ b/osgp/platform/osgp-adapter-ws-core/src/main/java/org/opensmartgridplatform/adapter/ws/core/application/services/FirmwareManagementService.java
@@ -723,7 +723,7 @@ public class FirmwareManagementService {
     }
 
     final Map<FirmwareModule, String> firmwareVersionsByModule =
-        firmwareModuleData.getVersionsByModule(this.firmwareModuleRepository, false);
+        firmwareModuleData.getVersionsByModule(this.firmwareModuleRepository, true);
 
     final FirmwareFile firmwareFile = this.insertOrUdateDatabase(firmwareFileRequest, file);
 

--- a/osgp/shared/osgp-ws-core/src/main/resources/schemas/firmwaremanagement.xsd
+++ b/osgp/shared/osgp-ws-core/src/main/resources/schemas/firmwaremanagement.xsd
@@ -531,6 +531,7 @@
     <xsd:sequence>
       <xsd:element name="ModuleVersionComm" type="xsd:string" minOccurs="0" />
       <xsd:element name="ModuleVersionFunc" type="xsd:string" minOccurs="0" />
+      <xsd:element name="ModuleVersionActive" type="xsd:string" minOccurs="0" />
       <xsd:element name="ModuleVersionMa" type="xsd:string" minOccurs="0" />
       <xsd:element name="ModuleVersionMbus" type="xsd:string" minOccurs="0" />
       <xsd:element name="ModuleVersionSec" type="xsd:string" minOccurs="0" />


### PR DESCRIPTION
Added ModuleVersionActive as one of moduleVersiontypes in ModuleVersionData for use with SmartMetering.
This additional versiontype needed some adeption in convertors since they reused the Func(tional) moduleVersiontype for Active moduleVersiontype in use with SmartMetering. A follow-up story will be defined to tackle this.