### PR TITLE
FDP-113 Remove dependency to domain-logging from ws-core

### DIFF
--- a/osgp/platform/osgp-adapter-ws-core/pom.xml
+++ b/osgp/platform/osgp-adapter-ws-core/pom.xml
@@ -84,10 +84,6 @@
     </dependency>
     <dependency>
       <groupId>org.opensmartgridplatform</groupId>
-      <artifactId>osgp-domain-logging</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.opensmartgridplatform</groupId>
       <artifactId>osgp-adapter-ws-shared</artifactId>
     </dependency>
     <dependency>
@@ -227,7 +223,7 @@
       <groupId>ma.glasnost.orika</groupId>
       <artifactId>orika-core</artifactId>
     </dependency>
-    
+
     <!-- Lombok -->
     <dependency>
       <groupId>org.projectlombok</groupId>

--- a/osgp/platform/osgp-adapter-ws-core/src/main/java/org/opensmartgridplatform/adapter/ws/core/application/config/ApplicationContext.java
+++ b/osgp/platform/osgp-adapter-ws-core/src/main/java/org/opensmartgridplatform/adapter/ws/core/application/config/ApplicationContext.java
@@ -17,7 +17,6 @@ import org.opensmartgridplatform.adapter.ws.shared.db.application.config.Writabl
 import org.opensmartgridplatform.domain.core.specifications.DeviceSpecifications;
 import org.opensmartgridplatform.domain.core.specifications.EventSpecifications;
 import org.opensmartgridplatform.domain.core.valueobjects.FirmwareLocation;
-import org.opensmartgridplatform.logging.domain.config.ReadOnlyLoggingConfig;
 import org.opensmartgridplatform.shared.application.config.AbstractConfig;
 import org.opensmartgridplatform.shared.application.config.PagingSettings;
 import org.opensmartgridplatform.ws.core.config.CoreWebServiceConfig;
@@ -45,7 +44,6 @@ import org.springframework.validation.beanvalidation.MethodValidationPostProcess
 @Import({
   PersistenceConfig.class,
   WritablePersistenceConfig.class,
-  ReadOnlyLoggingConfig.class,
   WebServiceConfig.class,
   CoreWebServiceConfig.class
 })


### PR DESCRIPTION
Removes the dependency to osgp-adapter-domain-logging and the imported
ReadOnlyLoggingConfig from osgp-adapter-ws-core and its
ApplicationContext.

This dependency and imported configuration provided access to the
database with logging information that the web service operations from
WS core do not need access to.