### PR TITLE
Make IEC61850 client port configurable

### DIFF
--- a/osgp/protocol-adapter-iec61850/osgp-protocol-adapter-iec61850/src/main/java/org/opensmartgridplatform/adapter/protocol/iec61850/application/config/Iec61850Config.java
+++ b/osgp/protocol-adapter-iec61850/osgp-protocol-adapter-iec61850/src/main/java/org/opensmartgridplatform/adapter/protocol/iec61850/application/config/Iec61850Config.java
@@ -27,7 +27,6 @@ import org.opensmartgridplatform.shared.application.config.AbstractConfig;
 import org.opensmartgridplatform.shared.infra.networking.DisposableNioEventLoopGroup;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
@@ -71,14 +70,6 @@ public class Iec61850Config extends AbstractConfig {
 
   private static final String PROPERTY_NAME_OSLP_DEFAULT_LATITUDE = "iec61850.default.latitude";
   private static final String PROPERTY_NAME_OSLP_DEFAULT_LONGITUDE = "iec61850.default.longitude";
-
-  @Value("${iec61850.default.port:102}")
-  private int defaultPort;
-
-  @Bean
-  public int iec61850DefaultPort() {
-    return this.defaultPort;
-  }
 
   @Bean
   public int connectionTimeout() {

--- a/osgp/protocol-adapter-iec61850/osgp-protocol-adapter-iec61850/src/main/java/org/opensmartgridplatform/adapter/protocol/iec61850/infra/networking/services/Iec61850DeviceConnectionService.java
+++ b/osgp/protocol-adapter-iec61850/osgp-protocol-adapter-iec61850/src/main/java/org/opensmartgridplatform/adapter/protocol/iec61850/infra/networking/services/Iec61850DeviceConnectionService.java
@@ -45,6 +45,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @DependsOn({
+  "iec61850PortClient",
   "iec61850SsldPortServer",
   "iec61850RtuPortServer",
   "responseTimeout",
@@ -67,7 +68,7 @@ public class Iec61850DeviceConnectionService {
 
   @Autowired private Iec61850Client iec61850Client;
 
-  @Autowired private int iec61850DefaultPort;
+  @Autowired private int iec61850PortClient;
 
   @Autowired private int iec61850SsldPortServer;
 
@@ -220,7 +221,7 @@ public class Iec61850DeviceConnectionService {
     } else if (IED.ZOWN_RTU.equals(ied) || IED.DA_RTU.equals(ied)) {
       port = this.iec61850RtuPortServer;
     } else {
-      port = this.iec61850DefaultPort;
+      port = this.iec61850PortClient;
     }
     return port;
   }


### PR DESCRIPTION
Correction for https://github.com/OSGP/Documentation/issues/250
iec61850.default.port property has be removed, because it is not used.
iec61850.port.client property from osgp-adapter-protocol-iec61850.properties is used instead.