### PR TITLE
Save retrieved IC, dont retrieve IC during connection postprocessing

### DIFF
--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/factories/DlmsConnectionHelper.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/factories/DlmsConnectionHelper.java
@@ -63,7 +63,6 @@ public class DlmsConnectionHelper {
         this.devicePingConfig.pingingEnabled() && StringUtils.hasText(device.getIpAddress());
     final boolean initializeInvocationCounter =
         device.needsInvocationCounter() && !device.isInvocationCounterInitialized();
-    final Duration waitBeforeInitializingInvocationCounter = NO_DELAY;
     final Duration waitBeforeCreatingTheConnection =
         initializeInvocationCounter ? this.delayBetweenDlmsConnections : NO_DELAY;
 
@@ -72,7 +71,7 @@ public class DlmsConnectionHelper {
         messageListener,
         pingDevice,
         initializeInvocationCounter,
-        waitBeforeInitializingInvocationCounter,
+        NO_DELAY,
         waitBeforeCreatingTheConnection);
   }
 

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/factories/InvocationCounterManager.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/factories/InvocationCounterManager.java
@@ -13,6 +13,7 @@ import org.openmuc.jdlms.AttributeAddress;
 import org.openmuc.jdlms.ObisCode;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.utils.DlmsHelper;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.entities.DlmsDevice;
+import org.opensmartgridplatform.adapter.protocol.dlms.domain.repositories.DlmsDeviceRepository;
 import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.exceptionhandling.OsgpException;
 import org.slf4j.Logger;
@@ -32,12 +33,16 @@ public class InvocationCounterManager {
 
   private final DlmsConnectionFactory connectionFactory;
   private final DlmsHelper dlmsHelper;
+  private final DlmsDeviceRepository deviceRepository;
 
   @Autowired
   public InvocationCounterManager(
-      final DlmsConnectionFactory connectionFactory, final DlmsHelper dlmsHelper) {
+      final DlmsConnectionFactory connectionFactory,
+      final DlmsHelper dlmsHelper,
+      final DlmsDeviceRepository deviceRepository) {
     this.connectionFactory = connectionFactory;
     this.dlmsHelper = dlmsHelper;
+    this.deviceRepository = deviceRepository;
   }
 
   /**
@@ -46,6 +51,7 @@ public class InvocationCounterManager {
    */
   public void initializeInvocationCounter(final DlmsDevice device) throws OsgpException {
     this.initializeWithInvocationCounterStoredOnDevice(device);
+    this.deviceRepository.save(device);
   }
 
   private void initializeWithInvocationCounterStoredOnDevice(final DlmsDevice device)

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/DlmsConnectionMessageProcessor.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/DlmsConnectionMessageProcessor.java
@@ -95,10 +95,6 @@ public abstract class DlmsConnectionMessageProcessor {
     this.closeDlmsConnection(device, conn);
 
     this.throttlingService.closeConnection();
-
-    if (device.needsInvocationCounter()) {
-      this.updateInvocationCounterForDevice(device, conn);
-    }
   }
 
   protected void closeDlmsConnection(final DlmsDevice device, final DlmsConnectionManager conn) {
@@ -110,28 +106,6 @@ public abstract class DlmsConnectionMessageProcessor {
     } catch (final Exception e) {
       LOGGER.error("Error while closing connection", e);
     }
-  }
-
-  /* package private */
-  void updateInvocationCounterForDevice(final DlmsDevice device, final DlmsConnectionManager conn) {
-    if (!(conn.getDlmsMessageListener() instanceof InvocationCountingDlmsMessageListener)) {
-      LOGGER.error(
-          "updateInvocationCounterForDevice should only be called for devices with HLS 5 "
-              + "communication with an InvocationCountingDlmsMessageListener - device: {}, hls5: {}, "
-              + "listener: {}",
-          device.getDeviceIdentification(),
-          device.isHls5Active(),
-          conn.getDlmsMessageListener() == null
-              ? "null"
-              : conn.getDlmsMessageListener().getClass().getName());
-      return;
-    }
-
-    final InvocationCountingDlmsMessageListener dlmsMessageListener =
-        (InvocationCountingDlmsMessageListener) conn.getDlmsMessageListener();
-    final int numberOfSentMessages = dlmsMessageListener.getNumberOfSentMessages();
-    device.incrementInvocationCounter(numberOfSentMessages);
-    this.deviceRepository.save(device);
   }
 
   /**

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/factories/InvocationCounterManagerTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/factories/InvocationCounterManagerTest.java
@@ -70,6 +70,11 @@ class InvocationCounterManagerTest {
     this.manager.initializeInvocationCounter(device);
 
     assertThat(device.getInvocationCounter()).isEqualTo(invocationCounterValueOnDevice);
+
+    assertThat(device.getInvocationCounter())
+        .isEqualTo(Long.valueOf(dataObject.getValue().toString()));
+    verify(this.deviceRepository).save(device);
+
     verify(connectionManager).close();
   }
 }

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/factories/InvocationCounterManagerTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/factories/InvocationCounterManagerTest.java
@@ -26,6 +26,7 @@ import org.openmuc.jdlms.datatypes.DataObject;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.utils.DlmsHelper;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.entities.DlmsDevice;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.entities.DlmsDeviceBuilder;
+import org.opensmartgridplatform.adapter.protocol.dlms.domain.repositories.DlmsDeviceRepository;
 
 @ExtendWith(MockitoExtension.class)
 class InvocationCounterManagerTest {
@@ -38,9 +39,13 @@ class InvocationCounterManagerTest {
 
   @Mock private DlmsHelper dlmsHelper;
 
+  @Mock private DlmsDeviceRepository deviceRepository;
+
   @BeforeEach
   public void setUp() {
-    this.manager = new InvocationCounterManager(this.connectionFactory, this.dlmsHelper);
+    this.manager =
+        new InvocationCounterManager(
+            this.connectionFactory, this.dlmsHelper, this.deviceRepository);
   }
 
   @Test

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/MessagingTestConfiguration.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/MessagingTestConfiguration.java
@@ -23,6 +23,7 @@ import org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.utils.Dlm
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.factories.DlmsConnectionFactory;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.factories.DlmsConnectionHelper;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.factories.InvocationCounterManager;
+import org.opensmartgridplatform.adapter.protocol.dlms.domain.repositories.DlmsDeviceRepository;
 import org.opensmartgridplatform.adapter.protocol.dlms.exceptions.OsgpExceptionConverter;
 import org.opensmartgridplatform.adapter.protocol.dlms.infra.messaging.processors.GetPowerQualityProfileRequestMessageProcessor;
 import org.opensmartgridplatform.shared.application.config.AbstractConfig;
@@ -94,12 +95,15 @@ public class MessagingTestConfiguration extends AbstractConfig {
   }
 
   @Bean
-  public InvocationCounterManager invocationCounterManager() {
-    return new InvocationCounterManager(this.dlmsConnectionFactory(), this.dlmsHelper());
+  public InvocationCounterManager invocationCounterManager(
+      final DlmsDeviceRepository dlmsDeviceRepository) {
+    return new InvocationCounterManager(
+        this.dlmsConnectionFactory(), this.dlmsHelper(), dlmsDeviceRepository);
   }
 
   @Bean
-  public DlmsConnectionHelper dlmsConnectionHelper() {
+  public DlmsConnectionHelper dlmsConnectionHelper(
+      final DlmsDeviceRepository dlmsDeviceRepository) {
     final DevicePingConfig devicePingConfig =
         new DevicePingConfig() {
           @Override
@@ -113,7 +117,10 @@ public class MessagingTestConfiguration extends AbstractConfig {
           }
         };
     return new DlmsConnectionHelper(
-        this.invocationCounterManager(), this.dlmsConnectionFactory(), devicePingConfig, 0);
+        this.invocationCounterManager(dlmsDeviceRepository),
+        this.dlmsConnectionFactory(),
+        devicePingConfig,
+        0);
   }
 
   @Bean


### PR DESCRIPTION
This PR fixes a major bug: since the merge of https://github.com/OSGP/open-smart-grid-platform/pull/652
no connection is possible with smart meters using the IC. 

The retrieved IC is never saved to the dlms_device table which leads to always failing connections since the stored IC always has the incorrect value '0'. 

The IC is saved after retrieving. Within the connection post processing, the init IC is removed since this is already in place in DlmsConnectionHelper.createConnectionForDevice().