### PR TITLE
SLIM-3056 Add validity period to the Jasper API call for wake-up by SMS

### DIFF
--- a/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/main/java/org/opensmartgridplatform/adapter/protocol/jasper/config/JasperWirelessConfig.java
+++ b/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/main/java/org/opensmartgridplatform/adapter/protocol/jasper/config/JasperWirelessConfig.java
@@ -63,6 +63,9 @@ public class JasperWirelessConfig extends AbstractConfig {
   @Value("${jwcc.api_version}")
   private String apiVersion;
 
+  @Value("${jwcc.validity_period:0}")
+  private String validityPeriod;
+
   @Bean
   public Jaxb2Marshaller marshaller() {
     final Jaxb2Marshaller marshaller = new Jaxb2Marshaller();
@@ -72,7 +75,7 @@ public class JasperWirelessConfig extends AbstractConfig {
 
   @Bean
   SaajSoapMessageFactory messageFactory() throws OsgpJasperException {
-    SaajSoapMessageFactory saajSoapMessageFactory;
+    final SaajSoapMessageFactory saajSoapMessageFactory;
     try {
       saajSoapMessageFactory = new SaajSoapMessageFactory(MessageFactory.newInstance());
       saajSoapMessageFactory.setSoapVersion(SoapVersion.SOAP_11);
@@ -135,6 +138,11 @@ public class JasperWirelessConfig extends AbstractConfig {
   @Bean
   public int jasperGetSessionRetries() {
     return Integer.parseInt(this.retries);
+  }
+
+  @Bean
+  public short jasperGetValidityPeriod() {
+    return Short.parseShort(this.validityPeriod);
   }
 
   @Bean

--- a/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/main/java/org/opensmartgridplatform/adapter/protocol/jasper/infra/ws/JasperWirelessSmsClient.java
+++ b/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/main/java/org/opensmartgridplatform/adapter/protocol/jasper/infra/ws/JasperWirelessSmsClient.java
@@ -38,6 +38,8 @@ public class JasperWirelessSmsClient {
 
   @Autowired private JasperWirelessAccess jasperWirelessAccess;
 
+  @Autowired private short jasperGetValidityPeriod;
+
   public SendSMSResponse sendWakeUpSMS(final String iccId) {
 
     final SendSMSRequest sendSMSRequest = WS_CLIENT_FACTORY.createSendSMSRequest();
@@ -48,6 +50,7 @@ public class JasperWirelessSmsClient {
     sendSMSRequest.setMessageTextEncoding("");
     sendSMSRequest.setSentToIccid(iccId);
     sendSMSRequest.setVersion(this.jasperWirelessAccess.getApiVersion());
+    sendSMSRequest.setTpvp(this.jasperGetValidityPeriod);
 
     this.setInterceptorUsernameTokens();
 

--- a/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/main/resources/jasper-interface.properties
+++ b/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/main/resources/jasper-interface.properties
@@ -9,5 +9,7 @@ jwcc.username=TestUser
 jwcc.password=1234
 jwcc.getsession.retries=30
 jwcc.getsession.sleep.between.retries=10000
+# validityPeriod (0, 143) -> validityPeriod x 5 minutes = 5, 10, 15 minutes
+jwcc.validity_period=0
 # =========================================================
 

--- a/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/main/resources/jasper-interface.properties
+++ b/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/main/resources/jasper-interface.properties
@@ -9,7 +9,7 @@ jwcc.username=TestUser
 jwcc.password=1234
 jwcc.getsession.retries=30
 jwcc.getsession.sleep.between.retries=10000
-# validityPeriod (0, 143) -> validityPeriod x 5 minutes = 5, 10, 15 minutes
+# validityPeriod (0, 143) -> (validityPeriod + 1) x 5 minutes = 5, 10, 15 minutes
 jwcc.validity_period=0
 # =========================================================
 

--- a/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/test/java/org/opensmartgridplatform/adapter/protocol/jasper/infra/ws/JasperWirelessSmsClientTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/test/java/org/opensmartgridplatform/adapter/protocol/jasper/infra/ws/JasperWirelessSmsClientTest.java
@@ -51,6 +51,7 @@ class JasperWirelessSmsClientTest {
   private static final String JWCC_STATUS = "Delivered";
   private static final String MODEM_STATUS = "DeliverAckReceivedStatusSuccessful";
   private static final String API_VERSION = "1234";
+  private static final String VALIDITY_PERIOD = "6";
 
   static class PropertyMockingApplicationContextInitializer
       implements ApplicationContextInitializer<ConfigurableApplicationContext> {
@@ -63,6 +64,7 @@ class JasperWirelessSmsClientTest {
       mockEnvironment.setProperty("jwcc.api_version", API_VERSION);
       mockEnvironment.setProperty("jwcc.username", "JohnDoe");
       mockEnvironment.setProperty("jwcc.password", "Whatever");
+      mockEnvironment.setProperty("jwcc.validity_period", VALIDITY_PERIOD);
 
       applicationContext.setEnvironment(mockEnvironment);
     }
@@ -101,6 +103,9 @@ class JasperWirelessSmsClientTest {
                 + "<ns2:sentToIccid>"
                 + ICC_ID
                 + "</ns2:sentToIccid>"
+                + "<ns2:tpvp>"
+                + VALIDITY_PERIOD
+                + "</ns2:tpvp>"
                 + "<ns2:messageText/>"
                 + "</ns2:SendSMSRequest>");
 

--- a/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/test/java/org/opensmartgridplatform/adapter/protocol/jasper/infra/ws/JasperWirelessTestConfig.java
+++ b/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/test/java/org/opensmartgridplatform/adapter/protocol/jasper/infra/ws/JasperWirelessTestConfig.java
@@ -36,6 +36,7 @@ public class JasperWirelessTestConfig {
   private static final String PROPERTY_NAME_CONTROLCENTER_USERNAME = "jwcc.username";
   private static final String PROPERTY_NAME_CONTROLCENTER_PASSWORD = "jwcc.password";
   private static final String PROPERTY_NAME_CONTROLCENTER_API_VERSION = "jwcc.api_version";
+  private static final String PROPERTY_NAME_CONTROLCENTER_VALIDITY_PERIOD = "jwcc.validity_period";
 
   @Resource private Environment environment;
 
@@ -89,5 +90,11 @@ public class JasperWirelessTestConfig {
   @Bean
   public CorrelationIdProviderService correlationIdProviderService() {
     return new CorrelationIdProviderService();
+  }
+
+  @Bean
+  public short jasperGetValidityPeriod() {
+    return Short.parseShort(
+        this.environment.getRequiredProperty(PROPERTY_NAME_CONTROLCENTER_VALIDITY_PERIOD));
   }
 }


### PR DESCRIPTION
This PR adds a validity period (tpvp) value to the jasper wireless API, default value should be 0 = 5 minutes
The formula is: (validityPeriod + 1) * 5 minutes
Signed-off-by: Gerben Kroes <gerben@kroesctrl.nl>