### PR TITLE
SLIM-2065 Clear mbus status xsd implementation

### DIFF
--- a/osgp/shared/osgp-ws-smartmetering/src/main/resources/SmartMeteringManagement.wsdl
+++ b/osgp/shared/osgp-ws-smartmetering/src/main/resources/SmartMeteringManagement.wsdl
@@ -156,7 +156,6 @@
     </wsdl:part>
   </wsdl:message>
 
-
   <wsdl:message name="ClearMbusStatusRequest">
     <wsdl:part element="smman:ClearMbusStatusRequest"
       name="ClearMbusStatusRequest">

--- a/osgp/shared/osgp-ws-smartmetering/src/main/resources/SmartMeteringManagement.wsdl
+++ b/osgp/shared/osgp-ws-smartmetering/src/main/resources/SmartMeteringManagement.wsdl
@@ -157,24 +157,24 @@
   </wsdl:message>
 
 
-  <wsdl:message name="ClearMbusStatusByChannelRequest">
-    <wsdl:part element="smman:ClearMbusStatusByChannelRequest"
-      name="ClearMbusStatusByChannelRequest">
+  <wsdl:message name="ClearMbusStatusRequest">
+    <wsdl:part element="smman:ClearMbusStatusRequest"
+      name="ClearMbusStatusRequest">
     </wsdl:part>
   </wsdl:message>
-  <wsdl:message name="ClearMbusStatusByChannelAsyncResponse">
-    <wsdl:part element="smman:ClearMbusStatusByChannelAsyncResponse"
-      name="ClearMbusStatusByChannelAsyncResponse">
+  <wsdl:message name="ClearMbusStatusAsyncResponse">
+    <wsdl:part element="smman:ClearMbusStatusAsyncResponse"
+      name="ClearMbusStatusAsyncResponse">
     </wsdl:part>
   </wsdl:message>
-  <wsdl:message name="ClearMbusStatusByChannelAsyncRequest">
-    <wsdl:part element="smman:ClearMbusStatusByChannelAsyncRequest"
-      name="ClearMbusStatusByChannelAsyncRequest">
+  <wsdl:message name="ClearMbusStatusAsyncRequest">
+    <wsdl:part element="smman:ClearMbusStatusAsyncRequest"
+      name="ClearMbusStatusAsyncRequest">
     </wsdl:part>
   </wsdl:message>
-  <wsdl:message name="ClearMbusStatusByChannelResponse">
-    <wsdl:part element="smman:ClearMbusStatusByChannelResponse"
-      name="ClearMbusStatusByChannelResponse">
+  <wsdl:message name="ClearMbusStatusResponse">
+    <wsdl:part element="smman:ClearMbusStatusResponse"
+      name="ClearMbusStatusResponse">
     </wsdl:part>
   </wsdl:message>
 
@@ -306,20 +306,20 @@
       </wsdl:output>
     </wsdl:operation>
 
-    <wsdl:operation name="ClearMbusStatusByChannel">
-      <wsdl:input message="tns:ClearMbusStatusByChannelRequest"
-        name="ClearMbusStatusByChannelRequest">
+    <wsdl:operation name="ClearMbusStatus">
+      <wsdl:input message="tns:ClearMbusStatusRequest"
+        name="ClearMbusStatusRequest">
       </wsdl:input>
-      <wsdl:output message="tns:ClearMbusStatusByChannelAsyncResponse"
-        name="ClearMbusStatusByChannelAsyncResponse">
+      <wsdl:output message="tns:ClearMbusStatusAsyncResponse"
+        name="ClearMbusStatusAsyncResponse">
       </wsdl:output>
     </wsdl:operation>
-    <wsdl:operation name="GetClearMbusStatusByChannelResponse">
-      <wsdl:input message="tns:ClearMbusStatusByChannelAsyncRequest"
-        name="ClearMbusStatusByChannelAsyncRequest">
+    <wsdl:operation name="GetClearMbusStatusResponse">
+      <wsdl:input message="tns:ClearMbusStatusAsyncRequest"
+        name="ClearMbusStatusAsyncRequest">
       </wsdl:input>
-      <wsdl:output message="tns:ClearMbusStatusByChannelResponse"
-        name="ClearMbusStatusByChannelResponse">
+      <wsdl:output message="tns:ClearMbusStatusResponse"
+        name="ClearMbusStatusResponse">
       </wsdl:output>
     </wsdl:operation>
 
@@ -554,9 +554,9 @@
     </wsdl:operation>
 
 
-    <wsdl:operation name="ClearMbusStatusByChannel">
+    <wsdl:operation name="ClearMbusStatus">
       <soap:operation soapAction="" />
-      <wsdl:input name="ClearMbusStatusByChannelRequest">
+      <wsdl:input name="ClearMbusStatusRequest">
         <soap:header message="tns:ActionHeader" part="OrganisationIdentification"
           use="literal" />
         <soap:header message="tns:ActionHeader" part="UserName"
@@ -565,14 +565,14 @@
           use="literal" />
         <soap:body use="literal" />
       </wsdl:input>
-      <wsdl:output name="ClearMbusStatusByChannelAsyncResponse">
+      <wsdl:output name="ClearMbusStatusAsyncResponse">
         <soap:body use="literal" />
       </wsdl:output>
     </wsdl:operation>
 
-    <wsdl:operation name="GetClearMbusStatusByChannelResponse">
+    <wsdl:operation name="GetClearMbusStatusResponse">
       <soap:operation soapAction="" />
-      <wsdl:input name="ClearMbusStatusByChannelAsyncRequest">
+      <wsdl:input name="ClearMbusStatusAsyncRequest">
         <soap:header message="tns:ActionHeader" part="OrganisationIdentification"
           use="literal" />
         <soap:header message="tns:ActionHeader" part="UserName"
@@ -581,7 +581,7 @@
           use="literal" />
         <soap:body use="literal" />
       </wsdl:input>
-      <wsdl:output name="ClearMbusStatusByChannelResponse">
+      <wsdl:output name="ClearMbusStatusResponse">
         <soap:body use="literal" />
       </wsdl:output>
     </wsdl:operation>

--- a/osgp/shared/osgp-ws-smartmetering/src/main/resources/SmartMeteringManagement.wsdl
+++ b/osgp/shared/osgp-ws-smartmetering/src/main/resources/SmartMeteringManagement.wsdl
@@ -156,6 +156,28 @@
     </wsdl:part>
   </wsdl:message>
 
+
+  <wsdl:message name="ClearMbusStatusByChannelRequest">
+    <wsdl:part element="smman:ClearMbusStatusByChannelRequest"
+      name="ClearMbusStatusByChannelRequest">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="ClearMbusStatusByChannelAsyncResponse">
+    <wsdl:part element="smman:ClearMbusStatusByChannelAsyncResponse"
+      name="ClearMbusStatusByChannelAsyncResponse">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="ClearMbusStatusByChannelAsyncRequest">
+    <wsdl:part element="smman:ClearMbusStatusByChannelAsyncRequest"
+      name="ClearMbusStatusByChannelAsyncRequest">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="ClearMbusStatusByChannelResponse">
+    <wsdl:part element="smman:ClearMbusStatusByChannelResponse"
+      name="ClearMbusStatusByChannelResponse">
+    </wsdl:part>
+  </wsdl:message>
+
   <wsdl:message name="GetGsmDiagnosticRequest">
     <wsdl:part element="smman:GetGsmDiagnosticRequest" name="GetGsmDiagnosticRequest">
     </wsdl:part>
@@ -281,6 +303,23 @@
       </wsdl:input>
       <wsdl:output message="tns:SetDeviceLifecycleStatusByChannelResponse"
         name="SetDeviceLifecycleStatusByChannelResponse">
+      </wsdl:output>
+    </wsdl:operation>
+
+    <wsdl:operation name="ClearMbusStatusByChannel">
+      <wsdl:input message="tns:ClearMbusStatusByChannelRequest"
+        name="ClearMbusStatusByChannelRequest">
+      </wsdl:input>
+      <wsdl:output message="tns:ClearMbusStatusByChannelAsyncResponse"
+        name="ClearMbusStatusByChannelAsyncResponse">
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="GetClearMbusStatusByChannelResponse">
+      <wsdl:input message="tns:ClearMbusStatusByChannelAsyncRequest"
+        name="ClearMbusStatusByChannelAsyncRequest">
+      </wsdl:input>
+      <wsdl:output message="tns:ClearMbusStatusByChannelResponse"
+        name="ClearMbusStatusByChannelResponse">
       </wsdl:output>
     </wsdl:operation>
 
@@ -482,7 +521,7 @@
       </wsdl:output>
     </wsdl:operation>
 
-      <wsdl:operation name="SetDeviceLifecycleStatusByChannel">
+    <wsdl:operation name="SetDeviceLifecycleStatusByChannel">
       <soap:operation soapAction="" />
       <wsdl:input name="SetDeviceLifecycleStatusByChannelRequest">
         <soap:header message="tns:ActionHeader" part="OrganisationIdentification"
@@ -510,6 +549,39 @@
         <soap:body use="literal" />
       </wsdl:input>
       <wsdl:output name="SetDeviceLifecycleStatusByChannelResponse">
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+
+
+    <wsdl:operation name="ClearMbusStatusByChannel">
+      <soap:operation soapAction="" />
+      <wsdl:input name="ClearMbusStatusByChannelRequest">
+        <soap:header message="tns:ActionHeader" part="OrganisationIdentification"
+          use="literal" />
+        <soap:header message="tns:ActionHeader" part="UserName"
+          use="literal" />
+        <soap:header message="tns:ActionHeader" part="ApplicationName"
+          use="literal" />
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output name="ClearMbusStatusByChannelAsyncResponse">
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+
+    <wsdl:operation name="GetClearMbusStatusByChannelResponse">
+      <soap:operation soapAction="" />
+      <wsdl:input name="ClearMbusStatusByChannelAsyncRequest">
+        <soap:header message="tns:ActionHeader" part="OrganisationIdentification"
+          use="literal" />
+        <soap:header message="tns:ActionHeader" part="UserName"
+          use="literal" />
+        <soap:header message="tns:ActionHeader" part="ApplicationName"
+          use="literal" />
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output name="ClearMbusStatusByChannelResponse">
         <soap:body use="literal" />
       </wsdl:output>
     </wsdl:operation>

--- a/osgp/shared/osgp-ws-smartmetering/src/main/resources/schemas/bundle-ws-smartmetering.xsd
+++ b/osgp/shared/osgp-ws-smartmetering/src/main/resources/schemas/bundle-ws-smartmetering.xsd
@@ -323,11 +323,11 @@
     </xsd:complexType>
   </xsd:element>
   <xsd:element
-    name="ClearMbusStatusByChannelRequest">
+    name="ClearMbusStatusRequest">
     <xsd:complexType>
       <xsd:complexContent>
         <xsd:extension
-          base="smman:ClearMbusStatusByChannelRequestData" />
+          base="smman:ClearMbusStatusRequestData" />
       </xsd:complexContent>
     </xsd:complexType>
   </xsd:element>
@@ -410,7 +410,7 @@
         <xsd:element
           ref="tns:SetDeviceLifecycleStatusByChannelRequest" />
         <xsd:element
-          ref="tns:ClearMbusStatusByChannelRequest" />
+          ref="tns:ClearMbusStatusRequest" />
         <xsd:element ref="tns:ScanMbusChannelsRequest" />
         <xsd:element
           ref="tns:SetRandomisationSettingsRequest" />
@@ -629,11 +629,11 @@
     </xsd:complexType>
   </xsd:element>
   <xsd:element
-    name="ClearMbusStatusByChannelResponse">
+    name="ClearMbusStatusResponse">
     <xsd:complexType>
       <xsd:complexContent>
         <xsd:extension
-          base="smman:ClearMbusStatusByChannelResponseData" />
+          base="smman:ClearMbusStatusResponseData" />
       </xsd:complexContent>
     </xsd:complexType>
   </xsd:element>
@@ -699,7 +699,7 @@
         <xsd:element
           ref="tns:SetDeviceLifecycleStatusByChannelResponse" />
         <xsd:element
-          ref="tns:ClearMbusStatusByChannelResponse" />
+          ref="tns:ClearMbusStatusResponse" />
         <xsd:element ref="tns:ScanMbusChannelsResponse" />
         <xsd:element ref="tns:GetOutagesResponse" />
         <xsd:element ref="tns:GetGsmDiagnosticResponse" />

--- a/osgp/shared/osgp-ws-smartmetering/src/main/resources/schemas/bundle-ws-smartmetering.xsd
+++ b/osgp/shared/osgp-ws-smartmetering/src/main/resources/schemas/bundle-ws-smartmetering.xsd
@@ -322,6 +322,15 @@
       </xsd:complexContent>
     </xsd:complexType>
   </xsd:element>
+  <xsd:element
+    name="ClearMbusStatusByChannelRequest">
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension
+          base="smman:ClearMbusStatusByChannelRequestData" />
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
   <xsd:element name="ScanMbusChannelsRequest">
     <xsd:complexType>
       <xsd:complexContent>
@@ -400,6 +409,8 @@
           ref="tns:GetMbusEncryptionKeyStatusByChannelRequest" />
         <xsd:element
           ref="tns:SetDeviceLifecycleStatusByChannelRequest" />
+        <xsd:element
+          ref="tns:ClearMbusStatusByChannelRequest" />
         <xsd:element ref="tns:ScanMbusChannelsRequest" />
         <xsd:element
           ref="tns:SetRandomisationSettingsRequest" />
@@ -617,6 +628,15 @@
       </xsd:complexContent>
     </xsd:complexType>
   </xsd:element>
+  <xsd:element
+    name="ClearMbusStatusByChannelResponse">
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension
+          base="smman:ClearMbusStatusByChannelResponseData" />
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
   <xsd:element name="ScanMbusChannelsResponse">
     <xsd:complexType>
       <xsd:complexContent>
@@ -678,6 +698,8 @@
           ref="tns:GetMbusEncryptionKeyStatusByChannelResponse" />
         <xsd:element
           ref="tns:SetDeviceLifecycleStatusByChannelResponse" />
+        <xsd:element
+          ref="tns:ClearMbusStatusByChannelResponse" />
         <xsd:element ref="tns:ScanMbusChannelsResponse" />
         <xsd:element ref="tns:GetOutagesResponse" />
         <xsd:element ref="tns:GetGsmDiagnosticResponse" />

--- a/osgp/shared/osgp-ws-smartmetering/src/main/resources/schemas/management-ws-smartmetering.xsd
+++ b/osgp/shared/osgp-ws-smartmetering/src/main/resources/schemas/management-ws-smartmetering.xsd
@@ -270,7 +270,6 @@
     </xsd:complexType>
   </xsd:element>
 
-
   <xsd:element name="ClearMbusStatusRequest">
     <xsd:complexType>
       <xsd:sequence>
@@ -688,7 +687,6 @@
       </xsd:extension>
     </xsd:complexContent>
   </xsd:complexType>
-
 
   <xsd:complexType name="ClearMbusStatusRequestData">
     <xsd:complexContent>

--- a/osgp/shared/osgp-ws-smartmetering/src/main/resources/schemas/management-ws-smartmetering.xsd
+++ b/osgp/shared/osgp-ws-smartmetering/src/main/resources/schemas/management-ws-smartmetering.xsd
@@ -271,36 +271,34 @@
   </xsd:element>
 
 
-  <xsd:element name="ClearMbusStatusByChannelRequest">
+  <xsd:element name="ClearMbusStatusRequest">
     <xsd:complexType>
       <xsd:sequence>
-        <xsd:element name="GatewayDeviceIdentification"
-          type="common:Identification"/>
-        <xsd:element name="ClearMbusStatusByChannelRequestData"
-          type="tns:ClearMbusStatusByChannelRequestData"/>
+        <xsd:element name="ClearMbusStatusRequestData"
+          type="tns:ClearMbusStatusRequestData"/>
       </xsd:sequence>
     </xsd:complexType>
   </xsd:element>
-  <xsd:element name="ClearMbusStatusByChannelAsyncResponse">
+  <xsd:element name="ClearMbusStatusAsyncResponse">
     <xsd:complexType>
       <xsd:complexContent>
         <xsd:extension base="common:AsyncResponse"/>
       </xsd:complexContent>
     </xsd:complexType>
   </xsd:element>
-  <xsd:element name="ClearMbusStatusByChannelAsyncRequest">
+  <xsd:element name="ClearMbusStatusAsyncRequest">
     <xsd:complexType>
       <xsd:complexContent>
         <xsd:extension base="common:AsyncRequest"/>
       </xsd:complexContent>
     </xsd:complexType>
   </xsd:element>
-  <xsd:element name="ClearMbusStatusByChannelResponse">
+  <xsd:element name="ClearMbusStatusResponse">
     <xsd:complexType>
       <xsd:sequence>
         <xsd:element name="Result" type="common:OsgpResultType"/>
-        <xsd:element name="ClearMbusStatusByChannelResponseData"
-          type="tns:ClearMbusStatusByChannelResponseData"/>
+        <xsd:element name="ClearMbusStatusResponseData"
+          type="tns:ClearMbusStatusResponseData"/>
       </xsd:sequence>
     </xsd:complexType>
   </xsd:element>
@@ -692,25 +690,16 @@
   </xsd:complexType>
 
 
-  <xsd:complexType name="ClearMbusStatusByChannelRequestData">
+  <xsd:complexType name="ClearMbusStatusRequestData">
     <xsd:complexContent>
       <xsd:extension base="common:Query">
-        <xsd:sequence>
-          <xsd:element name="Channel" type="common:Channel"/>
-        </xsd:sequence>
       </xsd:extension>
     </xsd:complexContent>
   </xsd:complexType>
 
-  <xsd:complexType name="ClearMbusStatusByChannelResponseData">
+  <xsd:complexType name="ClearMbusStatusResponseData">
     <xsd:complexContent>
       <xsd:extension base="common:Response">
-        <xsd:sequence>
-          <xsd:element name="GatewayDeviceIdentification"
-            type="common:Identification"/>
-          <xsd:element name="MbusDeviceIdentification" type="common:Identification"/>
-          <xsd:element name="Channel" type="common:Channel"/>
-        </xsd:sequence>
       </xsd:extension>
     </xsd:complexContent>
   </xsd:complexType>

--- a/osgp/shared/osgp-ws-smartmetering/src/main/resources/schemas/management-ws-smartmetering.xsd
+++ b/osgp/shared/osgp-ws-smartmetering/src/main/resources/schemas/management-ws-smartmetering.xsd
@@ -270,6 +270,41 @@
     </xsd:complexType>
   </xsd:element>
 
+
+  <xsd:element name="ClearMbusStatusByChannelRequest">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="GatewayDeviceIdentification"
+          type="common:Identification"/>
+        <xsd:element name="ClearMbusStatusByChannelRequestData"
+          type="tns:ClearMbusStatusByChannelRequestData"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="ClearMbusStatusByChannelAsyncResponse">
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="common:AsyncResponse"/>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="ClearMbusStatusByChannelAsyncRequest">
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="common:AsyncRequest"/>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="ClearMbusStatusByChannelResponse">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="Result" type="common:OsgpResultType"/>
+        <xsd:element name="ClearMbusStatusByChannelResponseData"
+          type="tns:ClearMbusStatusByChannelResponseData"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+
   <!-- Data Types -->
 
   <!-- Query for FindEventsRequest -->
@@ -647,9 +682,33 @@
       <xsd:extension base="common:Response">
         <xsd:sequence>
           <xsd:element name="GatewayDeviceIdentification"
-                       type="common:Identification"/>
+            type="common:Identification"/>
           <xsd:element name="MbusDeviceIdentification" type="common:Identification"/>
           <xsd:element name="DeviceLifecycleStatus" type="common:DeviceLifecycleStatus"/>
+          <xsd:element name="Channel" type="common:Channel"/>
+        </xsd:sequence>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+
+
+  <xsd:complexType name="ClearMbusStatusByChannelRequestData">
+    <xsd:complexContent>
+      <xsd:extension base="common:Query">
+        <xsd:sequence>
+          <xsd:element name="Channel" type="common:Channel"/>
+        </xsd:sequence>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="ClearMbusStatusByChannelResponseData">
+    <xsd:complexContent>
+      <xsd:extension base="common:Response">
+        <xsd:sequence>
+          <xsd:element name="GatewayDeviceIdentification"
+            type="common:Identification"/>
+          <xsd:element name="MbusDeviceIdentification" type="common:Identification"/>
           <xsd:element name="Channel" type="common:Channel"/>
         </xsd:sequence>
       </xsd:extension>


### PR DESCRIPTION
As a PO i want smhe to clear the mbus status, so the alarms are cleared via the E-meter to the G-meter.

After this the 5.1 G-meter is ready to raise new alarms.

5.0 E-meters clears the status by itself, in production we found out that sometimes the alarms/event where already cleared before the headend started an event readout.

The clear action works with a mask, the headend first has to read out the bits. Make a mask to clear only the raised bits, and send this to the E-meter. After this the reset alarm method can be started.