### PR TITLE
feature/slim-1928-fw-update-G-meter-firmware-image-identifier-fix

### DIFF
--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/firmware/firmwarefile/FirmwareFile.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/firmware/firmwarefile/FirmwareFile.java
@@ -210,15 +210,18 @@ public class FirmwareFile {
    *   <li>MAN (3 bytes) Manufacturer code according to FLAG
    *       (https://www.dlms.com/flag-id/flag-id-list)
    *   <li>DEV (4 bytes) M-Bus DEV code (letters "MBUS" (utf-8))
-   *   <li>M-Bus Short ID
+   *   <li>M-Bus Short ID*
    *       <ul>
-   *         <li>Identification Number (3 bytes)
-   *         <li>Manufacturer ID (3 bytes)
+   *         <li>Identification Number (4 bytes)
+   *         <li>Manufacturer ID (2 bytes)
    *         <li>Version (1 bytes)
    *         <li>DeviceType (1 bytes)
    *       </ul>
    *   <li>M-Bus FW ID (4 bytes)
    * </ul>
+   *
+   * * Definition of Short-ID is described in Smart Meter Requirements 5.2 Supplement 5, P2
+   * Companion Standard paragraph 9.2. Short Equipment Identifier
    *
    * @return byte[] image identifier
    */

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/firmware/firmwarefile/FirmwareFile.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/firmware/firmwarefile/FirmwareFile.java
@@ -201,7 +201,10 @@ public class FirmwareFile {
   }
 
   /**
-   * The Identifier for firmware image of M-Bus device has the following content
+   * Smart Meter Requirements 5.1, Supplement 5, P3 Companion Standard, Section 5.13.1 Firmware
+   * upgrade M-Bus devices
+   *
+   * <p>The Identifier for firmware image of M-Bus device has the following content
    *
    * <ul>
    *   <li>MAN (3 bytes) Manufacturer code according to FLAG
@@ -213,8 +216,8 @@ public class FirmwareFile {
    *         <li>Manufacturer ID (3 bytes)
    *         <li>Version (1 bytes)
    *         <li>DeviceType (1 bytes)
-   *         <li>M-Bus FW ID (4 bytes)
    *       </ul>
+   *   <li>M-Bus FW ID (4 bytes)
    * </ul>
    *
    * @return byte[] image identifier
@@ -230,7 +233,8 @@ public class FirmwareFile {
 
     final FirmwareFileHeaderAddressField addressField = header.getFirmwareFileHeaderAddressField();
     final ByteBuffer imageIdentifier = ByteBuffer.allocate(imageIdentifierSize);
-    imageIdentifier.put(addressField.getMbusManufacturerId());
+    imageIdentifier.put(
+        header.getMbusManufacturerId().getIdentification().getBytes(StandardCharsets.UTF_8));
     imageIdentifier.put("MBUS".getBytes(StandardCharsets.UTF_8));
     imageIdentifier.put(addressField.getMbusDeviceIdentificationNumber());
     imageIdentifier.put(addressField.getMbusManufacturerId());
@@ -245,8 +249,13 @@ public class FirmwareFile {
       final FirmwareFileHeader header, final int imageIdentifierSize) {
     final FirmwareFileHeaderAddressField addressField = header.getFirmwareFileHeaderAddressField();
     log.debug("creating image identifier for M-Bus device from firmware file header information");
-    log.debug("MbusManufacturerId " + Arrays.toString(addressField.getMbusManufacturerId()));
-    log.debug("MBUS " + Arrays.toString("MBUS".getBytes(StandardCharsets.UTF_8)));
+    final String manufacturerIdentification = header.getMbusManufacturerId().getIdentification();
+    log.debug(
+        "ManufacturerIdentification ('"
+            + manufacturerIdentification
+            + "') "
+            + Arrays.toString(manufacturerIdentification.getBytes(StandardCharsets.UTF_8)));
+    log.debug("'MBUS' " + Arrays.toString("MBUS".getBytes(StandardCharsets.UTF_8)));
     log.debug(
         "MbusDeviceIdentificationNumber "
             + Arrays.toString(addressField.getMbusDeviceIdentificationNumber()));

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/firmware/firmwarefile/FirmwareFileHeader.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/firmware/firmwarefile/FirmwareFileHeader.java
@@ -42,7 +42,7 @@ public class FirmwareFileHeader {
     return this.toInt(this.getFirmwareFileHeaderAddressField().getMbusVersion());
   }
 
-  ManufacturerId getMbusManufacturerId() {
+  public ManufacturerId getMbusManufacturerId() {
     return ManufacturerId.fromId(
         this.toInt(this.getFirmwareFileHeaderAddressField().getMbusManufacturerId()));
   }

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/firmware/firmwarefile/FirmwareFileTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/firmware/firmwarefile/FirmwareFileTest.java
@@ -26,6 +26,7 @@ import org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.firmware.
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.firmware.firmwarefile.enums.AddressType;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.firmware.firmwarefile.enums.DeviceType;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.firmware.firmwarefile.enums.SecurityType;
+import org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.mbus.IdentificationNumber;
 import org.opensmartgridplatform.adapter.protocol.dlms.exceptions.ProtocolAdapterException;
 import org.springframework.core.io.ClassPathResource;
 
@@ -165,5 +166,18 @@ public class FirmwareFileTest {
                 .getFirmwareFileHeaderAddressField()
                 .getMbusDeviceIdentificationNumber())
         .isEqualTo(mbusDeviceIdentificationNumberByteArrayOutput);
+  }
+
+  @Test
+  public void testImageIdentifierForMbusDevice() throws ProtocolAdapterException {
+    final FirmwareFile firmwareFile = new FirmwareFile(byteArray);
+    firmwareFile.setMbusDeviceIdentificationNumber(
+        new IdentificationNumber("16019864").getIdentificationNumber().intValue());
+
+    assertThat(firmwareFile.createImageIdentifierForMbusDevice())
+        .isEqualTo(
+            new byte[] {
+              71, 87, 73, 77, 66, 85, 83, 100, -104, 1, 22, -23, 30, 80, 3, 17, 0, 64, 0
+            });
   }
 }


### PR DESCRIPTION
Use manufacturer ID accourding to FLAG in ImageIdentifier

Signed-off-by: Harry Middelburg <harry.middelburg@alliander.com>