### PR TITLE
Remove CDMA specific protocol from GXF

### DIFF
--- a/osgp/platform/osgp-core/src/main/resources/db/migration/V20211007131424000__deletes_CDMA_specific_protocol_info.sql
+++ b/osgp/platform/osgp-core/src/main/resources/db/migration/V20211007131424000__deletes_CDMA_specific_protocol_info.sql
@@ -2,6 +2,12 @@ DO
 $$
 begin
 
+/*
+ * There are 3 records created in previous flyway scripts SMR_CDMA (5.1), SMR_CDMA (5.0.0) and DSMR_CDMA (4.2.2)
+ * These records are CDMA specific, and should not be added by the flyway scripts.
+ * In production there could be other specific protocols already created by hand (for example: SMR_GPRS and SMR_LTE_M),
+ * when exist in the database, then we do not want to delete the 3 protocol specific records.
+ */
 if ((select count(*)
      from   protocol_info
      where  protocol like '%SMR_%') = 3) then

--- a/osgp/platform/osgp-core/src/main/resources/db/migration/V20211007131424000__deletes_CDMA_specific_protocol_info.sql
+++ b/osgp/platform/osgp-core/src/main/resources/db/migration/V20211007131424000__deletes_CDMA_specific_protocol_info.sql
@@ -4,7 +4,7 @@ begin
 
 if ((select count(*)
      from   protocol_info
-     where  protocol like '%SMR_CDMA') = 3) then
+     where  protocol like '%SMR_%') = 3) then
 
 delete from protocol_info WHERE protocol = 'SMR_CDMA' AND protocol_version  = '5.1';
 delete from protocol_info WHERE protocol = 'SMR_CDMA' AND protocol_version  = '5.0.0';

--- a/osgp/platform/osgp-core/src/main/resources/db/migration/V20211007131424000__deletes_CDMA_specific_protocol_info.sql
+++ b/osgp/platform/osgp-core/src/main/resources/db/migration/V20211007131424000__deletes_CDMA_specific_protocol_info.sql
@@ -4,7 +4,7 @@ begin
 
 if ((select count(*)
      from   protocol_info
-     where  protocol like '%_CDMA') = 3) then
+     where  protocol like '%SMR_CDMA') = 3) then
 
 delete from protocol_info WHERE protocol = 'SMR_CDMA' AND protocol_version  = '5.1';
 delete from protocol_info WHERE protocol = 'SMR_CDMA' AND protocol_version  = '5.0.0';

--- a/osgp/platform/osgp-core/src/main/resources/db/migration/V20211007131424000__deletes_CDMA_specific_protocol_info.sql
+++ b/osgp/platform/osgp-core/src/main/resources/db/migration/V20211007131424000__deletes_CDMA_specific_protocol_info.sql
@@ -1,0 +1,16 @@
+DO
+$$
+begin
+
+if ((select count(*)
+     from   protocol_info
+     where  protocol like '%_CDMA') = 3) then
+
+delete from protocol_info WHERE protocol = 'SMR_CDMA' AND protocol_version  = '5.1';
+delete from protocol_info WHERE protocol = 'SMR_CDMA' AND protocol_version  = '5.0.0';
+delete from protocol_info WHERE protocol = 'DSMR_CDMA' AND protocol_version  = '4.2.2';
+
+end if;
+
+end;
+$$


### PR DESCRIPTION
There are 3 records SMR_CDMA (5.1) SMR_CDMA (5.0.0) en DSMR_CDMA (4.2.2) created by flyway. By SMHE are there a number of protocols created SMR_GPRS en SMR_LTE_M by hand, if they exist the records created by SMHE will should not be removed by this flyway script