### PR TITLE
SMHE-340 - Database unavailability robustness

### DIFF
--- a/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/AbstractPersistenceConfig.java
+++ b/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/AbstractPersistenceConfig.java
@@ -57,7 +57,7 @@ public abstract class AbstractPersistenceConfig extends AbstractConfig {
   @Value("${db.max_pool_size:5}")
   private int maxPoolSize;
 
-  @Value("${db.initialization_fail_timeout:1}")
+  @Value("${db.initialization_fail_timeout:300000}")
   private long initializationFailTimeout;
 
   @Value("${db.validation_timeout:5000}")


### PR DESCRIPTION
Make applications more robust against database unavailability on startup. Especially useful for CI-tests where the application could be initializing (e.g. applying/checking flyway scripts before the database is available. This can cause the application to reach a not functioning state, which requires manual intervention.

After 5 minutes of database unavailability on startup of the application it will throw an exception.
Ideally there is a health check in place that restarts the application before the 'initialization fail exception' is thrown (e.g. when the database is - for whatever reason - not initialized within 5 minutes). This is health check not yet implemented in GXF.