### PR TITLE
SMHE-227 change recover key process

### DIFF
--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/database/device/DlmsDeviceSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/database/device/DlmsDeviceSteps.java
@@ -764,9 +764,11 @@ public class DlmsDeviceSteps {
     }
   }
 
-  @Then("after {int} seconds, the new keys are recovered")
+  @Then("after {int} seconds, the new {} key is recovered")
   public void newKeysAreRecovered(
-      final int maxSecondsToWait, final Map<String, String> inputSettings) {
+      final int maxSecondsToWait,
+      final SecretType keyType,
+      final Map<String, String> inputSettings) {
     if (!inputSettings.containsKey(PlatformSmartmeteringKeys.DEVICE_IDENTIFICATION)) {
       throw new IllegalArgumentException("No device identification provided");
     }
@@ -776,8 +778,7 @@ public class DlmsDeviceSteps {
         && !inputSettings.containsKey(KEY_DEVICE_ENCRYPTIONKEY)) {
       throw new IllegalArgumentException("No authentication or encryption key provided");
     }
-    final List<SecretType> keyTypesToCheck =
-        Arrays.asList(E_METER_AUTHENTICATION_KEY, E_METER_ENCRYPTION_KEY_UNICAST);
+    final List<SecretType> keyTypesToCheck = Arrays.asList(keyType);
     final Map<SecretStatus, Integer> expectedNrOfKeysByStatus = new HashMap<>();
     expectedNrOfKeysByStatus.put(SecretStatus.NEW, 0);
     expectedNrOfKeysByStatus.put(SecretStatus.ACTIVE, 1);

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/configuration/ReplaceKeys.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/configuration/ReplaceKeys.feature
@@ -1,4 +1,4 @@
-@SmartMetering @Platform @SmartMeteringConfiguration
+@SmartMetering @Platform @SmartMeteringConfiguration @NightlyBuildOnly
 Feature: SmartMetering Configuration - Replace Keys
   As a grid operator
   I want to be able to replace the keys on a device
@@ -31,7 +31,7 @@ Feature: SmartMetering Configuration - Replace Keys
       | Result               | OK                |
     And the new keys are stored in the secret management database encrypted_secret table
 
-  @RecoverKeys @test
+  @RecoverKeys
   Scenario: Recover keys after a (simulated) failed key change (incorrect E key)
     #Try to connect using incorrect E-key and then try to recover the correct new key
     Given a dlms device

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/configuration/ReplaceKeys.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/configuration/ReplaceKeys.feature
@@ -1,4 +1,4 @@
-@SmartMetering @Platform @SmartMeteringConfiguration @NightlyBuildOnly
+@SmartMetering @Platform @SmartMeteringConfiguration
 Feature: SmartMetering Configuration - Replace Keys
   As a grid operator
   I want to be able to replace the keys on a device
@@ -31,21 +31,19 @@ Feature: SmartMetering Configuration - Replace Keys
       | Result               | OK                |
     And the new keys are stored in the secret management database encrypted_secret table
 
-  @RecoverKeys
-  Scenario: Recover keys after a (simulated) failed key change
-    #Try to connect using incorrect (swapped) keys and then try to recover the correct new keys
+  @RecoverKeys @test
+  Scenario: Recover keys after a (simulated) failed key change (incorrect E key)
+    #Try to connect using incorrect E-key and then try to recover the correct new key
     Given a dlms device
       | DeviceIdentification | TEST1024000000001 |
       | DeviceType           | SMART_METER_E     |
-      | Authentication_key   | 867424ac75b6d53c89276d304608321f0a1f6e401f453f84adf3477c7ee1623c |
+      | Authentication_key   | c19fe80a22a0f6c5cdaad0826c4d204f23694ded08d811b66e9b845d9f2157d2 |
       | Encryption_key       | c19fe80a22a0f6c5cdaad0826c4d204f23694ded08d811b66e9b845d9f2157d2 |
     And new keys are registered in the secret management database
       | DeviceIdentification | TEST1024000000001 |
-      | Authentication_key   | c19fe80a22a0f6c5cdaad0826c4d204f23694ded08d811b66e9b845d9f2157d2 |
       | Encryption_key       | 867424ac75b6d53c89276d304608321f0a1f6e401f453f84adf3477c7ee1623c |
     When the get actual meter reads request is received
       | DeviceIdentification | TEST1024000000001 |
-    Then after 15 seconds, the new keys are recovered
+    Then after 15 seconds, the new E_METER_ENCRYPTION_KEY_UNICAST key is recovered
       | DeviceIdentification | TEST1024000000001 |
-      | Authentication_key   | c19fe80a22a0f6c5cdaad0826c4d204f23694ded08d811b66e9b845d9f2157d2 |
       | Encryption_key       | 867424ac75b6d53c89276d304608321f0a1f6e401f453f84adf3477c7ee1623c |

--- a/osgp/platform/osgp-secret-management/src/integration-test/java/org/opensmartgridplatform/secretmanagement/application/SoapServiceSecretManagementIT.java
+++ b/osgp/platform/osgp-secret-management/src/integration-test/java/org/opensmartgridplatform/secretmanagement/application/SoapServiceSecretManagementIT.java
@@ -249,9 +249,7 @@ public class SoapServiceSecretManagementIT {
     // Store secrets
     this.mockWebServiceClient
         .sendRequest(withSoapEnvelope(activateRequest))
-        .andExpect(
-            ResponseMatchers.serverOrReceiverFault(
-                "Expected 1 new secrets of type E_METER_AUTHENTICATION_KEY for device E0000000000000000, but 0 new secret(s) present"));
+        .andExpect(ResponseMatchers.noFault());
   }
 
   @Test

--- a/osgp/platform/osgp-secret-management/src/main/java/org/opensmartgridplatform/secretmanagement/application/services/SecretManagementService.java
+++ b/osgp/platform/osgp-secret-management/src/main/java/org/opensmartgridplatform/secretmanagement/application/services/SecretManagementService.java
@@ -297,11 +297,10 @@ public class SecretManagementService {
         final DbEncryptedSecret currentSecret = activeSecretOptional.get();
         currentSecret.setSecretStatus(SecretStatus.EXPIRED);
         updatedSecrets.add(currentSecret);
-
-        final DbEncryptedSecret newSecret = newSecretOptional.get();
-        newSecret.setSecretStatus(SecretStatus.ACTIVE);
-        updatedSecrets.add(newSecret);
       }
+      final DbEncryptedSecret newSecret = newSecretOptional.get();
+      newSecret.setSecretStatus(SecretStatus.ACTIVE);
+      updatedSecrets.add(newSecret);
     } else {
       log.info("No new secret of secret type {} present for activation.", secretType);
     }

--- a/osgp/platform/osgp-secret-management/src/main/java/org/opensmartgridplatform/secretmanagement/application/services/SecretManagementService.java
+++ b/osgp/platform/osgp-secret-management/src/main/java/org/opensmartgridplatform/secretmanagement/application/services/SecretManagementService.java
@@ -271,17 +271,17 @@ public class SecretManagementService {
         .collect(collectingAndThen(toList(), this.secretRepository::saveAll));
   }
 
+  public boolean hasNewSecret(final String deviceIdentification, final SecretType secretType) {
+    return this.secretRepository.getSecretCount(deviceIdentification, secretType, SecretStatus.NEW)
+        > 0;
+  }
+
   public synchronized void activateNewSecrets(
       final String deviceIdentification, final List<SecretType> secretTypes) {
     secretTypes.stream()
         .map(t -> this.getUpdatedSecretsForActivation(deviceIdentification, t))
         .flatMap(Collection::stream)
         .collect(collectingAndThen(toList(), this.secretRepository::saveAll));
-  }
-
-  public boolean hasNewSecret(final String deviceIdentification, final SecretType secretType) {
-    return this.secretRepository.getSecretCount(deviceIdentification, secretType, SecretStatus.NEW)
-        > 0;
   }
 
   private List<DbEncryptedSecret> getUpdatedSecretsForActivation(
@@ -303,7 +303,7 @@ public class SecretManagementService {
         updatedSecrets.add(newSecret);
       }
     } else {
-      log.info("No new secret present for activation of type {}", secretType);
+      log.info("No new secret of secret type {} present for activation.", secretType);
     }
     return updatedSecrets;
   }

--- a/osgp/platform/osgp-secret-management/src/test/java/org/opensmartgridplatform/secretmanagement/application/services/SecretManagementServiceTest.java
+++ b/osgp/platform/osgp-secret-management/src/test/java/org/opensmartgridplatform/secretmanagement/application/services/SecretManagementServiceTest.java
@@ -342,10 +342,6 @@ public class SecretManagementServiceTest {
 
   @Test
   public void activateSecretsNoNewSecret() {
-    // GIVEN
-    final DbEncryptedSecret newSecret = new DbEncryptedSecret();
-    newSecret.setId(1L);
-    newSecret.setSecretStatus(SecretStatus.ACTIVE);
     // WHEN
     this.service.activateNewSecrets("SOME_DEVICE", Arrays.asList(SecretType.E_METER_MASTER_KEY));
     // THEN

--- a/osgp/platform/osgp-secret-management/src/test/java/org/opensmartgridplatform/secretmanagement/application/services/SecretManagementServiceTest.java
+++ b/osgp/platform/osgp-secret-management/src/test/java/org/opensmartgridplatform/secretmanagement/application/services/SecretManagementServiceTest.java
@@ -342,7 +342,7 @@ public class SecretManagementServiceTest {
 
   @Test
   public void activateSecretsNoNewSecret() {
-    //     GIVEN
+    // GIVEN
     final DbEncryptedSecret newSecret = new DbEncryptedSecret();
     newSecret.setId(1L);
     newSecret.setSecretStatus(SecretStatus.ACTIVE);

--- a/osgp/platform/osgp-secret-management/src/test/java/org/opensmartgridplatform/secretmanagement/application/services/SecretManagementServiceTest.java
+++ b/osgp/platform/osgp-secret-management/src/test/java/org/opensmartgridplatform/secretmanagement/application/services/SecretManagementServiceTest.java
@@ -323,9 +323,6 @@ public class SecretManagementServiceTest {
     newSecret.setId(2L);
     newSecret.setSecretStatus(SecretStatus.ACTIVE);
     // WHEN
-    when(this.secretRepository.getSecretCount(
-            SOME_DEVICE, SecretType.E_METER_MASTER_KEY, SecretStatus.NEW))
-        .thenReturn(1);
     when(this.secretRepository.findSecrets(
             SOME_DEVICE, SecretType.E_METER_MASTER_KEY, SecretStatus.ACTIVE))
         .thenReturn(Arrays.asList(activeSecret));

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/services/SecretManagementService.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/services/SecretManagementService.java
@@ -293,13 +293,10 @@ public class SecretManagementService {
     this.secretManagementClient.activateSecretsRequest(messageMetadata, request);
   }
 
-  public boolean hasNewSecretOfType(
-      final MessageMetadata messageMetadata,
-      final String deviceIdentification,
-      final SecurityKeyType keyType) {
+  public boolean hasNewSecret(
+      final MessageMetadata messageMetadata, final String deviceIdentification) {
     final HasNewSecretRequest request = new HasNewSecretRequest();
     request.setDeviceId(deviceIdentification);
-    request.setSecretType(keyType.toSecretType());
     final HasNewSecretResponse response =
         this.secretManagementClient.hasNewSecretRequest(messageMetadata, request);
     return response.isHasNewSecret();

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/services/SecretManagementService.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/services/SecretManagementService.java
@@ -113,46 +113,52 @@ public class SecretManagementService {
     if (LOGGER.isInfoEnabled()) {
       LOGGER.info("Retrieving new {} for device {}", keyType.name(), deviceIdentification);
     }
-    return this.getNewKeys(messageMetadata, deviceIdentification, Arrays.asList(keyType))
+    return this.getNewKeyPairForConnection(
+            messageMetadata, deviceIdentification, Arrays.asList(keyType))
         .get(keyType);
   }
 
   /**
-   * Retrieves the new (not yet activated) keys of requested types for a specified device
+   * Requests the New key for a specific device identification. Depending on the New key type
+   * (Authentication or Encryption) that will be retrieved, the other Active key type
+   * (Authentication or Encryption) will be requested. Once both key types are retrieved, this new
+   * keypair can be returned for connection with this device.
    *
    * @param messageMetadata the metadata of the request message
    * @param deviceIdentification the device identification string of the device
    * @param keyTypes the requested key types
    * @return the requested keys in a map by key type, with value NULL if not present
    */
-  public Map<SecurityKeyType, byte[]> getNewKeys(
+  public Map<SecurityKeyType, byte[]> getNewKeyPairForConnection(
       final MessageMetadata messageMetadata,
       final String deviceIdentification,
       final List<SecurityKeyType> keyTypes) {
+    final List<TypedSecret> newKeyPairForConnection = new ArrayList<>();
+    final List<SecurityKeyType> keyTypeActiveKey = new ArrayList<>();
+
     final GetNewSecretsRequest getNewSecretsRequest =
         this.createGetNewSecretsRequest(deviceIdentification, keyTypes);
     final GetNewSecretsResponse getNewSecretsResponse =
         this.secretManagementClient.getNewSecretsRequest(messageMetadata, getNewSecretsRequest);
     this.validateGetNewResponse(keyTypes, getNewSecretsResponse);
 
-    final List<SecurityKeyType> activeKeyType = new ArrayList<>();
-    final List<TypedSecret> newKeyPair = new ArrayList<>();
-    for (final TypedSecret secretType : getNewSecretsResponse.getTypedSecrets().getTypedSecret()) {
-      if (secretType.getSecret() != null && secretType.getSecret().length() > 0) {
-        newKeyPair.add(secretType);
+    for (final TypedSecret secretTypeNewKey :
+        getNewSecretsResponse.getTypedSecrets().getTypedSecret()) {
+      if (secretTypeNewKey.getSecret() != null && secretTypeNewKey.getSecret().length() > 0) {
+        newKeyPairForConnection.add(secretTypeNewKey);
       } else {
-        activeKeyType.add(SecurityKeyType.fromSecretType(secretType.getType()));
+        keyTypeActiveKey.add(SecurityKeyType.fromSecretType(secretTypeNewKey.getType()));
       }
     }
 
     final GetSecretsRequest getSecretsRequest =
-        this.createGetSecretsRequest(deviceIdentification, activeKeyType);
+        this.createGetSecretsRequest(deviceIdentification, keyTypeActiveKey);
     final GetSecretsResponse getSecretsResponse =
         this.secretManagementClient.getSecretsRequest(messageMetadata, getSecretsRequest);
-    this.validateGetResponse(activeKeyType, getSecretsResponse);
-    newKeyPair.add(getSecretsResponse.getTypedSecrets().getTypedSecret().get(0));
+    this.validateGetResponse(keyTypeActiveKey, getSecretsResponse);
+    newKeyPairForConnection.add(getSecretsResponse.getTypedSecrets().getTypedSecret().get(0));
 
-    return this.convertSoapSecretsToSecretMapByType(newKeyPair);
+    return this.convertSoapSecretsToSecretMapByType(newKeyPairForConnection);
   }
 
   private void validateGetResponse(

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/services/SecretManagementService.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/services/SecretManagementService.java
@@ -295,11 +295,17 @@ public class SecretManagementService {
 
   public boolean hasNewSecret(
       final MessageMetadata messageMetadata, final String deviceIdentification) {
-    final HasNewSecretRequest request = new HasNewSecretRequest();
-    request.setDeviceId(deviceIdentification);
-    final HasNewSecretResponse response =
-        this.secretManagementClient.hasNewSecretRequest(messageMetadata, request);
-    return response.isHasNewSecret();
+    final HasNewSecretRequest requestAKey = new HasNewSecretRequest();
+    final HasNewSecretRequest requestEKey = new HasNewSecretRequest();
+    requestAKey.setDeviceId(deviceIdentification);
+    requestAKey.setSecretType(SecretType.E_METER_AUTHENTICATION_KEY);
+    final HasNewSecretResponse responseAKey =
+        this.secretManagementClient.hasNewSecretRequest(messageMetadata, requestAKey);
+    requestEKey.setDeviceId(deviceIdentification);
+    requestEKey.setSecretType(SecretType.E_METER_ENCRYPTION_KEY_UNICAST);
+    final HasNewSecretResponse responseEKey =
+        this.secretManagementClient.hasNewSecretRequest(messageMetadata, requestEKey);
+    return responseAKey.isHasNewSecret() || responseEKey.isHasNewSecret();
   }
 
   public byte[] generate128BitsKeyAndStoreAsNewKey(

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/threads/RecoverKeyProcess.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/threads/RecoverKeyProcess.java
@@ -69,17 +69,11 @@ public class RecoverKeyProcess implements Runnable {
 
     final DlmsDevice device = this.findDevice();
 
-    if (!this.secretManagementService.hasNewSecretOfType(
-        this.messageMetadata, this.deviceIdentification, E_METER_AUTHENTICATION)) {
-      log.warn(
-          "[{}] Could not recover keys: device has no new authorisation key registered in secret-mgmt module",
-          this.messageMetadata.getCorrelationUid());
-      return;
-    }
     if (!this.canConnectUsingNewKeys(device)) {
       log.warn(
-          "[{}] Could not recover keys: could not connect to device using new keys",
-          this.messageMetadata.getCorrelationUid());
+          "[{}] Could not recover keys: could not connect to device {} using New keys",
+          this.messageMetadata.getCorrelationUid(),
+          this.deviceIdentification);
       return;
     }
 
@@ -89,6 +83,8 @@ public class RecoverKeyProcess implements Runnable {
           this.deviceIdentification,
           Arrays.asList(E_METER_ENCRYPTION, E_METER_AUTHENTICATION));
     } catch (final Exception e) {
+      //      throw new FunctionalException(
+      //          FunctionalExceptionType.DECRYPTION_EXCEPTION, ComponentType.PROTOCOL_DLMS, e);
       throw new RecoverKeyException(e);
     }
   }
@@ -128,7 +124,11 @@ public class RecoverKeyProcess implements Runnable {
               this.secretManagementService::getNewKeys);
       return connection != null;
     } catch (final Exception e) {
-      log.warn("Connection exception: {}", e.getMessage(), e);
+      log.warn(
+          "Connection exception during key recovery process for device: {} {}",
+          /*device.getDeviceIdentification()*/ "TODO replace",
+          e.getMessage(),
+          e);
       return false;
     } finally {
       if (connection != null) {

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/threads/RecoverKeyProcess.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/threads/RecoverKeyProcess.java
@@ -154,7 +154,7 @@ public class RecoverKeyProcess implements Runnable {
               this.messageMetadata,
               device,
               dlmsMessageListener,
-              this.secretManagementService::getNewKeys);
+              this.secretManagementService::getNewKeyPairForConnection);
       return connection != null;
     } catch (final ThrottlingPermitDeniedException e) {
       throw e;

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/threads/RecoverKeyProcess.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/threads/RecoverKeyProcess.java
@@ -79,26 +79,26 @@ public class RecoverKeyProcess implements Runnable {
     final DlmsDevice device = this.findDevice();
 
     try {
-    if (!this.canConnectUsingNewKeys(device)) {
+      if (!this.canConnectUsingNewKeys(device)) {
+        log.warn(
+            "[{}] Could not recover keys: could not connect to device {} using New keys",
+            this.messageMetadata.getCorrelationUid(),
+            this.deviceIdentification);
+        return;
+      }
+    } catch (final ThrottlingPermitDeniedException e) {
       log.warn(
-          "[{}] Could not recover keys: could not connect to device {} using New keys",
-          this.messageMetadata.getCorrelationUid(),
-          this.deviceIdentification);
-      return;
-    }
-  } catch (final ThrottlingPermitDeniedException e) {
-    log.warn(
-        "RecoverKeyProcess could not connect to the device due to throttling constraints", e);
+          "RecoverKeyProcess could not connect to the device due to throttling constraints", e);
 
-    new Timer()
-        .schedule(
-            new TimerTask() {
-              @Override
-              public void run() {
-                RecoverKeyProcess.this.run();
-              }
-            },
-            this.throttlingClientConfig.delay().toMillis());
+      new Timer()
+          .schedule(
+              new TimerTask() {
+                @Override
+                public void run() {
+                  RecoverKeyProcess.this.run();
+                }
+              },
+              this.throttlingClientConfig.delay().toMillis());
       return;
     }
 

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/threads/RecoverKeyProcess.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/threads/RecoverKeyProcess.java
@@ -83,8 +83,6 @@ public class RecoverKeyProcess implements Runnable {
           this.deviceIdentification,
           Arrays.asList(E_METER_ENCRYPTION, E_METER_AUTHENTICATION));
     } catch (final Exception e) {
-      //      throw new FunctionalException(
-      //          FunctionalExceptionType.DECRYPTION_EXCEPTION, ComponentType.PROTOCOL_DLMS, e);
       throw new RecoverKeyException(e);
     }
   }

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/threads/RecoverKeyProcess.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/threads/RecoverKeyProcess.java
@@ -126,7 +126,7 @@ public class RecoverKeyProcess implements Runnable {
     } catch (final Exception e) {
       log.warn(
           "Connection exception during key recovery process for device: {} {}",
-          /*device.getDeviceIdentification()*/ "TODO replace",
+          device.getDeviceIdentification(),
           e.getMessage(),
           e);
       return false;

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/factories/Hls5Connector.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/factories/Hls5Connector.java
@@ -79,8 +79,8 @@ public class Hls5Connector extends SecureDlmsConnector {
       throw new TechnicalException(
           ComponentType.PROTOCOL_DLMS, "The IP address is not found: " + device.getIpAddress());
     } catch (final IOException e) { // Queue key recovery process
-      if (this.secretManagementService.hasNewSecretOfType(
-          messageMetadata, device.getDeviceIdentification(), E_METER_ENCRYPTION)) {
+      if (this.secretManagementService.hasNewSecret(
+          messageMetadata, device.getDeviceIdentification())) {
         this.recoverKeyProcessInitiator.initiate(
             messageMetadata, device.getDeviceIdentification(), device.getIpAddress());
       }

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/application/services/SecretManagementServiceTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/application/services/SecretManagementServiceTest.java
@@ -10,7 +10,6 @@ package org.opensmartgridplatform.adapter.protocol.dlms.application.services;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -143,16 +142,50 @@ public class SecretManagementServiceTest {
   }
 
   @Test
-  public void testHasNewKey() {
-    final HasNewSecretResponse response = new HasNewSecretResponse();
-    response.setHasNewSecret(true);
+  public void testHasNewSecretAuthenticationKey() {
+    final HasNewSecretResponse responseTrue = new HasNewSecretResponse();
+    responseTrue.setHasNewSecret(true);
+    final HasNewSecretResponse responseFalse = new HasNewSecretResponse();
+    responseFalse.setHasNewSecret(false);
 
-    final HasNewSecretRequest requestAKey = new HasNewSecretRequest();
-    requestAKey.setDeviceId(DEVICE_IDENTIFICATION);
-    requestAKey.setSecretType(SecretType.E_METER_AUTHENTICATION_KEY);
+    when(this.secretManagementClient.hasNewSecretRequest(same(messageMetadata), any()))
+        .thenAnswer(
+            invocationOnMock -> {
+              if (((HasNewSecretRequest) invocationOnMock.getArgument(1))
+                  .getSecretType()
+                  .equals(SecretType.E_METER_AUTHENTICATION_KEY)) {
+                return responseTrue;
+              } else {
+                return responseFalse;
+              }
+            });
 
-    when(this.secretManagementClient.hasNewSecretRequest(same(messageMetadata), eq(requestAKey)))
-        .thenReturn(response);
+    // EXECUTE
+    final boolean result =
+        this.secretManagementTestService.hasNewSecret(messageMetadata, DEVICE_IDENTIFICATION);
+    // ASSERT
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  public void testHasNewSecretEncryptionKey() {
+    final HasNewSecretResponse responseTrue = new HasNewSecretResponse();
+    responseTrue.setHasNewSecret(true);
+    final HasNewSecretResponse responseFalse = new HasNewSecretResponse();
+    responseFalse.setHasNewSecret(false);
+
+    when(this.secretManagementClient.hasNewSecretRequest(same(messageMetadata), any()))
+        .thenAnswer(
+            invocationOnMock -> {
+              if (((HasNewSecretRequest) invocationOnMock.getArgument(1))
+                  .getSecretType()
+                  .equals(SecretType.E_METER_ENCRYPTION_KEY_UNICAST)) {
+                return responseTrue;
+              } else {
+                return responseFalse;
+              }
+            });
+
     // EXECUTE
     final boolean result =
         this.secretManagementTestService.hasNewSecret(messageMetadata, DEVICE_IDENTIFICATION);

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/application/services/SecretManagementServiceTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/application/services/SecretManagementServiceTest.java
@@ -145,8 +145,7 @@ public class SecretManagementServiceTest {
     when(this.secretManagementClient.hasNewSecretRequest(same(messageMetadata), any()))
         .thenReturn(response);
     // EXECUTE
-    final boolean result =
-        this.testService.hasNewSecretOfType(messageMetadata, DEVICE_IDENTIFICATION, KEY_TYPE);
+    final boolean result = this.testService.hasNewSecret(messageMetadata, DEVICE_IDENTIFICATION);
     // ASSERT
     assertThat(result).isTrue();
   }

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/application/threads/RecoverKeyProcessTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/application/threads/RecoverKeyProcessTest.java
@@ -45,23 +45,17 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 @ExtendWith(MockitoExtension.class)
 public class RecoverKeyProcessTest {
 
-  @InjectMocks
-  RecoverKeyProcess recoverKeyProcess;
+  @InjectMocks RecoverKeyProcess recoverKeyProcess;
 
-  @Mock
-  DomainHelperService domainHelperService;
+  @Mock DomainHelperService domainHelperService;
 
-  @Mock
-  Hls5Connector hls5Connector;
+  @Mock Hls5Connector hls5Connector;
 
-  @Mock
-  SecretManagementService secretManagementService;
+  @Mock SecretManagementService secretManagementService;
 
-  @Mock
-  ThrottlingService throttlingService;
+  @Mock ThrottlingService throttlingService;
 
-  @Mock
-  DlmsDeviceRepository dlmsDeviceRepository;
+  @Mock DlmsDeviceRepository dlmsDeviceRepository;
 
   private static final String DEVICE_IDENTIFICATION = "E000123456789";
 
@@ -99,8 +93,8 @@ public class RecoverKeyProcessTest {
   public void testWhenNoNewKeysThenNoActivate() throws OsgpException {
 
     // GIVEN
-    lenient().when(
-            this.secretManagementService.hasNewSecret(MESSAGE_METADATA, DEVICE_IDENTIFICATION))
+    lenient()
+        .when(this.secretManagementService.hasNewSecret(MESSAGE_METADATA, DEVICE_IDENTIFICATION))
         .thenReturn(false);
 
     // WHEN
@@ -117,8 +111,8 @@ public class RecoverKeyProcessTest {
     // GIVEN
     when(this.domainHelperService.findDlmsDevice(DEVICE_IDENTIFICATION, IP_ADDRESS))
         .thenReturn(DEVICE);
-    lenient().when(
-            this.secretManagementService.hasNewSecret(MESSAGE_METADATA, DEVICE_IDENTIFICATION))
+    lenient()
+        .when(this.secretManagementService.hasNewSecret(MESSAGE_METADATA, DEVICE_IDENTIFICATION))
         .thenReturn(true);
     when(this.hls5Connector.connectUnchecked(eq(MESSAGE_METADATA), eq(DEVICE), any(), any()))
         .thenReturn(mock(DlmsConnection.class));
@@ -149,8 +143,8 @@ public class RecoverKeyProcessTest {
     // GIVEN
     when(this.domainHelperService.findDlmsDevice(DEVICE_IDENTIFICATION, IP_ADDRESS))
         .thenReturn(DEVICE);
-    lenient().when(
-            this.secretManagementService.hasNewSecret(MESSAGE_METADATA, DEVICE_IDENTIFICATION))
+    lenient()
+        .when(this.secretManagementService.hasNewSecret(MESSAGE_METADATA, DEVICE_IDENTIFICATION))
         .thenReturn(true);
     when(this.hls5Connector.connectUnchecked(any(), any(), any(), any())).thenReturn(null);
 

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/application/threads/RecoverKeyProcessTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/application/threads/RecoverKeyProcessTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.when;
 import static org.opensmartgridplatform.adapter.protocol.dlms.domain.entities.SecurityKeyType.E_METER_AUTHENTICATION;
 import static org.opensmartgridplatform.adapter.protocol.dlms.domain.entities.SecurityKeyType.E_METER_ENCRYPTION;
 
+import java.io.IOException;
 import java.util.Arrays;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -89,11 +90,13 @@ public class RecoverKeyProcessTest {
   }
 
   @Test
-  public void testWhenNoNewKeysThenNoActivate() throws OsgpException {
+  public void testWhenNotAbleToConnectWithNewKeys() throws OsgpException, IOException {
 
     // GIVEN
     when(this.domainHelperService.findDlmsDevice(DEVICE_IDENTIFICATION, IP_ADDRESS))
         .thenReturn(DEVICE);
+    when(this.hls5Connector.connectUnchecked(eq(MESSAGE_METADATA), eq(DEVICE), any(), any()))
+        .thenReturn(null);
 
     // WHEN
     this.recoverKeyProcess.run();
@@ -146,8 +149,7 @@ public class RecoverKeyProcessTest {
     this.recoverKeyProcess.run();
 
     // THEN
-    final InOrder inOrder =
-        inOrder(this.throttlingService, this.hls5Connector, this.secretManagementService);
+    final InOrder inOrder = inOrder(this.throttlingService, this.hls5Connector);
 
     inOrder.verify(this.throttlingService).openConnection();
     inOrder.verify(this.hls5Connector).connectUnchecked(any(), any(), any(), any());

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/application/threads/RecoverKeyProcessTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/application/threads/RecoverKeyProcessTest.java
@@ -12,7 +12,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -93,14 +92,15 @@ public class RecoverKeyProcessTest {
   public void testWhenNoNewKeysThenNoActivate() throws OsgpException {
 
     // GIVEN
-    lenient()
-        .when(this.secretManagementService.hasNewSecret(MESSAGE_METADATA, DEVICE_IDENTIFICATION))
-        .thenReturn(false);
+    when(this.domainHelperService.findDlmsDevice(DEVICE_IDENTIFICATION, IP_ADDRESS))
+        .thenReturn(DEVICE);
 
     // WHEN
     this.recoverKeyProcess.run();
 
     // THEN
+    verify(this.secretManagementService, never())
+        .hasNewSecret(MESSAGE_METADATA, DEVICE_IDENTIFICATION);
     verify(this.domainHelperService).findDlmsDevice(DEVICE_IDENTIFICATION, IP_ADDRESS);
     verify(this.secretManagementService, never()).activateNewKeys(any(), any(), any());
   }
@@ -111,9 +111,6 @@ public class RecoverKeyProcessTest {
     // GIVEN
     when(this.domainHelperService.findDlmsDevice(DEVICE_IDENTIFICATION, IP_ADDRESS))
         .thenReturn(DEVICE);
-    lenient()
-        .when(this.secretManagementService.hasNewSecret(MESSAGE_METADATA, DEVICE_IDENTIFICATION))
-        .thenReturn(true);
     when(this.hls5Connector.connectUnchecked(eq(MESSAGE_METADATA), eq(DEVICE), any(), any()))
         .thenReturn(mock(DlmsConnection.class));
 
@@ -143,9 +140,6 @@ public class RecoverKeyProcessTest {
     // GIVEN
     when(this.domainHelperService.findDlmsDevice(DEVICE_IDENTIFICATION, IP_ADDRESS))
         .thenReturn(DEVICE);
-    lenient()
-        .when(this.secretManagementService.hasNewSecret(MESSAGE_METADATA, DEVICE_IDENTIFICATION))
-        .thenReturn(true);
     when(this.hls5Connector.connectUnchecked(any(), any(), any(), any())).thenReturn(null);
 
     // WHEN

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/application/threads/RecoverKeyProcessTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/application/threads/RecoverKeyProcessTest.java
@@ -12,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -44,17 +45,30 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 @ExtendWith(MockitoExtension.class)
 public class RecoverKeyProcessTest {
 
-  @InjectMocks RecoverKeyProcess recoverKeyProcess;
+  @InjectMocks
+  RecoverKeyProcess recoverKeyProcess;
 
-  @Mock DomainHelperService domainHelperService;
-  @Mock Hls5Connector hls5Connector;
-  @Mock SecretManagementService secretManagementService;
-  @Mock ThrottlingService throttlingService;
-  @Mock DlmsDeviceRepository dlmsDeviceRepository;
+  @Mock
+  DomainHelperService domainHelperService;
+
+  @Mock
+  Hls5Connector hls5Connector;
+
+  @Mock
+  SecretManagementService secretManagementService;
+
+  @Mock
+  ThrottlingService throttlingService;
+
+  @Mock
+  DlmsDeviceRepository dlmsDeviceRepository;
 
   private static final String DEVICE_IDENTIFICATION = "E000123456789";
+
   private static final String IP_ADDRESS = "1.1.1.1";
+
   private static final DlmsDevice DEVICE = mock(DlmsDevice.class);
+
   private static final MessageMetadata MESSAGE_METADATA = mock(MessageMetadata.class);
 
   @BeforeEach
@@ -85,8 +99,8 @@ public class RecoverKeyProcessTest {
   public void testWhenNoNewKeysThenNoActivate() throws OsgpException {
 
     // GIVEN
-    when(this.secretManagementService.hasNewSecretOfType(
-            MESSAGE_METADATA, DEVICE_IDENTIFICATION, E_METER_AUTHENTICATION))
+    lenient().when(
+            this.secretManagementService.hasNewSecret(MESSAGE_METADATA, DEVICE_IDENTIFICATION))
         .thenReturn(false);
 
     // WHEN
@@ -103,8 +117,8 @@ public class RecoverKeyProcessTest {
     // GIVEN
     when(this.domainHelperService.findDlmsDevice(DEVICE_IDENTIFICATION, IP_ADDRESS))
         .thenReturn(DEVICE);
-    when(this.secretManagementService.hasNewSecretOfType(
-            MESSAGE_METADATA, DEVICE_IDENTIFICATION, E_METER_AUTHENTICATION))
+    lenient().when(
+            this.secretManagementService.hasNewSecret(MESSAGE_METADATA, DEVICE_IDENTIFICATION))
         .thenReturn(true);
     when(this.hls5Connector.connectUnchecked(eq(MESSAGE_METADATA), eq(DEVICE), any(), any()))
         .thenReturn(mock(DlmsConnection.class));
@@ -135,8 +149,8 @@ public class RecoverKeyProcessTest {
     // GIVEN
     when(this.domainHelperService.findDlmsDevice(DEVICE_IDENTIFICATION, IP_ADDRESS))
         .thenReturn(DEVICE);
-    when(this.secretManagementService.hasNewSecretOfType(
-            MESSAGE_METADATA, DEVICE_IDENTIFICATION, E_METER_AUTHENTICATION))
+    lenient().when(
+            this.secretManagementService.hasNewSecret(MESSAGE_METADATA, DEVICE_IDENTIFICATION))
         .thenReturn(true);
     when(this.hls5Connector.connectUnchecked(any(), any(), any(), any())).thenReturn(null);
 


### PR DESCRIPTION
The recover key process is changed to match the situations it will occur. At this moment the code always expect two new keys, however this is never the case since keys are replaced one by one.

The implementation is done based on the design: https://alliander.atlassian.net/wiki/spaces/HOUS/pages/2956266827/Replace+Key+process

Nightly: https://ci.opensmartgridplatform.org/view/Nightly/job/OSGP_open-smart-grid-platform_nightly/1468/cucumber-html-reports/overview-features.html