### PR TITLE
FDP-109 Improve test robustness notifications

### DIFF
--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringmonitoring/SystemEventSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringmonitoring/SystemEventSteps.java
@@ -28,7 +28,7 @@ public class SystemEventSteps {
       responseClient;
 
   @Then("^a system event should be returned$")
-  public void aSystemEventShouldBeRetuned(final Map<String, String> settings) throws Throwable {
+  public void aSystemEventShouldBeReturned(final Map<String, String> settings) throws Throwable {
 
     final GetSystemEventAsyncRequest asyncRequest = SystemEventRequestFactory.fromScenarioContext();
     final GetSystemEventResponse response =
@@ -47,7 +47,7 @@ public class SystemEventSteps {
   }
 
   @Then("^no system event should be returned$")
-  public void noSystemEventShouldBeRetuned() throws Throwable {
+  public void noSystemEventShouldBeReturned() throws Throwable {
 
     final boolean hasMoreResponses =
         this.responseClient.hasMoreResponses(NotificationType.SYSTEM_EVENT);

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/support/ws/smartmetering/configuration/SmartMeteringConfigurationClient.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/support/ws/smartmetering/configuration/SmartMeteringConfigurationClient.java
@@ -40,6 +40,8 @@ import org.opensmartgridplatform.adapter.ws.schema.smartmetering.configuration.G
 import org.opensmartgridplatform.adapter.ws.schema.smartmetering.configuration.GetMbusEncryptionKeyStatusByChannelResponse;
 import org.opensmartgridplatform.adapter.ws.schema.smartmetering.configuration.GetMbusEncryptionKeyStatusRequest;
 import org.opensmartgridplatform.adapter.ws.schema.smartmetering.configuration.GetMbusEncryptionKeyStatusResponse;
+import org.opensmartgridplatform.adapter.ws.schema.smartmetering.configuration.GetPushNotificationAlarmAsyncRequest;
+import org.opensmartgridplatform.adapter.ws.schema.smartmetering.configuration.GetPushNotificationAlarmResponse;
 import org.opensmartgridplatform.adapter.ws.schema.smartmetering.configuration.ReplaceKeysAsyncRequest;
 import org.opensmartgridplatform.adapter.ws.schema.smartmetering.configuration.ReplaceKeysAsyncResponse;
 import org.opensmartgridplatform.adapter.ws.schema.smartmetering.configuration.ReplaceKeysRequest;
@@ -88,6 +90,8 @@ import org.opensmartgridplatform.adapter.ws.schema.smartmetering.configuration.U
 import org.opensmartgridplatform.adapter.ws.schema.smartmetering.configuration.UpdateFirmwareAsyncResponse;
 import org.opensmartgridplatform.adapter.ws.schema.smartmetering.configuration.UpdateFirmwareRequest;
 import org.opensmartgridplatform.adapter.ws.schema.smartmetering.configuration.UpdateFirmwareResponse;
+import org.opensmartgridplatform.adapter.ws.schema.smartmetering.notification.Notification;
+import org.opensmartgridplatform.adapter.ws.schema.smartmetering.notification.NotificationType;
 import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smartmetering.SmartMeteringBaseClient;
 import org.opensmartgridplatform.shared.exceptionhandling.WebServiceSecurityException;
 import org.opensmartgridplatform.shared.infra.ws.DefaultWebServiceTemplateFactory;
@@ -454,5 +458,16 @@ public class SmartMeteringConfigurationClient extends SmartMeteringBaseClient {
     this.waitForNotification(correlationUid);
 
     return (GetKeysResponse) this.getTemplate().marshalSendAndReceive(asyncRequest);
+  }
+
+  public GetPushNotificationAlarmResponse getPushNotificationAlarm()
+      throws WebServiceSecurityException {
+
+    final Notification notification =
+        this.waitForNotification(NotificationType.PUSH_NOTIFICATION_ALARM);
+    final GetPushNotificationAlarmAsyncRequest request = new GetPushNotificationAlarmAsyncRequest();
+    request.setCorrelationUid(notification.getCorrelationUid());
+    request.setDeviceIdentification(notification.getDeviceIdentification());
+    return (GetPushNotificationAlarmResponse) this.getTemplate().marshalSendAndReceive(request);
   }
 }

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/ReceiveAlarmNotifications.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/ReceiveAlarmNotifications.feature
@@ -4,7 +4,7 @@ Feature: SmartMetering - Receive Alarm Notifications
   I want to be able to receive alarm notifications from a device
   So I get notified about certain events soon after they occur
 
-  Background: 
+  Background:
     Given a dlms device
       | DeviceIdentification | TEST1024000000001 |
       | DeviceType           | SMART_METER_E     |
@@ -14,9 +14,11 @@ Feature: SmartMetering - Receive Alarm Notifications
       | DeviceIdentification | TEST1024000000001 |
     Then the alarm should be pushed to the osgp_logging database device_log_item table
       | DeviceIdentification | TEST1024000000001 |
+    And a push notification alarm should be received
   @NightlyBuildOnly
   Scenario: Handle a received alarm notification from an unknown device
     When an alarm notification is received from an unknown device
       | DeviceIdentification | UNKNOWN0000000001 |
     Then the alarm should be pushed to the osgp_logging database device_log_item table
       | DeviceIdentification | UNKNOWN0000000001 |
+    And a push notification alarm should be received


### PR DESCRIPTION
An earlier improvement filtered the notifications by type to make sure a
system event was handled. Before filtering it turned out a push
notification alarm could make the test fail.

This updates the Cucumber test dealing with push notification alarms to
not only check if the pushed alarm ends up in the logging database, but
also check a notification was sent and the push notification alarm
response can be retrieved.
By including retrieval of the pushed alarm message, its notification
should no longer be able to break other test cases.

Processing of the pushed alarms still had some notification check issues
due to the way pushed alarms are treated in the
PushNotificationAlarmMessageProcessor from core. When two alarms by the
same devices arrive in the queues at about the same time, processing can
be done in multiple concurrent listener threads, trying to update the
same device data from the same original version. The manner in which the
resulting StaleObjectStateException is handled appears to lead to more
notifications for the same alarm, which in turn leads to test assertion
failures regarding these notifications.
The changes to the test code are not a real fix, but treat the symptoms
by adding a few seconds between simulated alarms from the same device,
which should prevent the concurrent processing of multiple alarms for a
single device.