### PR TITLE
Fixed 2 connection issues in the protocol adapter.

### DIFF
--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/services/DomainHelperService.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/services/DomainHelperService.java
@@ -72,7 +72,12 @@ public class DomainHelperService {
   }
 
   public DlmsDevice findDlmsDevice(final MessageMetadata messageMetadata) throws OsgpException {
-    final String deviceIdentification = messageMetadata.getDeviceIdentification();
+    return this.findDlmsDevice(
+        messageMetadata.getDeviceIdentification(), messageMetadata.getIpAddress());
+  }
+
+  public DlmsDevice findDlmsDevice(final String deviceIdentification, final String ipAddress)
+      throws OsgpException {
     final DlmsDevice dlmsDevice =
         this.dlmsDeviceRepository.findByDeviceIdentification(deviceIdentification);
     if (dlmsDevice == null) {
@@ -83,14 +88,14 @@ public class DomainHelperService {
           FunctionalExceptionType.UNKNOWN_DEVICE, ComponentType.PROTOCOL_DLMS);
     }
 
-    final String ipAddress;
-    if (dlmsDevice.isIpAddressIsStatic()) {
-      ipAddress = messageMetadata.getIpAddress();
-    } else {
-      ipAddress = this.getDeviceIpAddressFromSessionProvider(dlmsDevice);
-    }
     /* Ip Address is a transient attribute for DlmsDevice, so save is not required */
-    dlmsDevice.setIpAddress(ipAddress);
+    if (dlmsDevice.isIpAddressIsStatic()) {
+      dlmsDevice.setIpAddress(ipAddress);
+    } else {
+      final String ipAddressFromSessionProvider =
+          this.getDeviceIpAddressFromSessionProvider(dlmsDevice);
+      dlmsDevice.setIpAddress(ipAddressFromSessionProvider);
+    }
     return dlmsDevice;
   }
 

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/services/DomainHelperService.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/services/DomainHelperService.java
@@ -89,8 +89,8 @@ public class DomainHelperService {
     } else {
       ipAddress = this.getDeviceIpAddressFromSessionProvider(dlmsDevice);
     }
+    /* Ip Address is a transient attribute for DlmsDevice, so save is not required */
     dlmsDevice.setIpAddress(ipAddress);
-    this.dlmsDeviceRepository.save(dlmsDevice);
     return dlmsDevice;
   }
 

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/services/DomainHelperService.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/services/DomainHelperService.java
@@ -72,12 +72,7 @@ public class DomainHelperService {
   }
 
   public DlmsDevice findDlmsDevice(final MessageMetadata messageMetadata) throws OsgpException {
-    return this.findDlmsDevice(
-        messageMetadata.getDeviceIdentification(), messageMetadata.getIpAddress());
-  }
-
-  public DlmsDevice findDlmsDevice(final String deviceIdentification, final String ipAddress)
-      throws OsgpException {
+    final String deviceIdentification = messageMetadata.getDeviceIdentification();
     final DlmsDevice dlmsDevice =
         this.dlmsDeviceRepository.findByDeviceIdentification(deviceIdentification);
     if (dlmsDevice == null) {
@@ -88,11 +83,14 @@ public class DomainHelperService {
           FunctionalExceptionType.UNKNOWN_DEVICE, ComponentType.PROTOCOL_DLMS);
     }
 
+    final String ipAddress;
     if (dlmsDevice.isIpAddressIsStatic()) {
-      dlmsDevice.setIpAddress(ipAddress);
+      ipAddress = messageMetadata.getIpAddress();
     } else {
-      dlmsDevice.setIpAddress(this.getDeviceIpAddressFromSessionProvider(dlmsDevice));
+      ipAddress = this.getDeviceIpAddressFromSessionProvider(dlmsDevice);
     }
+    dlmsDevice.setIpAddress(ipAddress);
+    this.dlmsDeviceRepository.save(dlmsDevice);
     return dlmsDevice;
   }
 

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/threads/RecoverKeyProcess.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/threads/RecoverKeyProcess.java
@@ -122,7 +122,7 @@ public class RecoverKeyProcess implements Runnable {
 
   private DlmsDevice findDevice() {
     try {
-      return this.domainHelperService.findDlmsDevice(this.messageMetadata);
+      return this.domainHelperService.findDlmsDevice(this.deviceIdentification, this.ipAddress);
     } catch (final Exception e) {
       throw new RecoverKeyException(e);
     }

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/threads/RecoverKeyProcess.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/threads/RecoverKeyProcess.java
@@ -122,7 +122,7 @@ public class RecoverKeyProcess implements Runnable {
 
   private DlmsDevice findDevice() {
     try {
-      return this.domainHelperService.findDlmsDevice(this.deviceIdentification, this.ipAddress);
+      return this.domainHelperService.findDlmsDevice(this.messageMetadata);
     } catch (final Exception e) {
       throw new RecoverKeyException(e);
     }

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/factories/DlmsConnectionHelper.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/factories/DlmsConnectionHelper.java
@@ -149,6 +149,7 @@ public class DlmsConnectionHelper {
             messageMetadata,
             permit,
             taskForConnectionManager);
+        return;
       }
       /*
        * The connection exception is assumed not to be related to the invocation counter, or has

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/factories/DlmsConnectionManager.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/factories/DlmsConnectionManager.java
@@ -166,7 +166,9 @@ public class DlmsConnectionManager implements AutoCloseable {
   @Override
   public void close() {
     try {
-      this.dlmsConnection.close();
+      if (this.dlmsConnection != null) {
+        this.dlmsConnection.close();
+      }
     } catch (final IOException e) {
       LOGGER.warn("Failure while trying to close a DLMS connection", e);
     }

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/factories/InvocationCounterManager.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/factories/InvocationCounterManager.java
@@ -14,6 +14,7 @@ import org.openmuc.jdlms.AttributeAddress;
 import org.openmuc.jdlms.ObisCode;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.utils.DlmsHelper;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.entities.DlmsDevice;
+import org.opensmartgridplatform.adapter.protocol.dlms.domain.repositories.DlmsDeviceRepository;
 import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.exceptionhandling.OsgpException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
@@ -35,12 +36,16 @@ public class InvocationCounterManager {
 
   private final DlmsConnectionFactory connectionFactory;
   private final DlmsHelper dlmsHelper;
+  private final DlmsDeviceRepository deviceRepository;
 
   @Autowired
   public InvocationCounterManager(
-      final DlmsConnectionFactory connectionFactory, final DlmsHelper dlmsHelper) {
+      final DlmsConnectionFactory connectionFactory,
+      final DlmsHelper dlmsHelper,
+      final DlmsDeviceRepository deviceRepository) {
     this.connectionFactory = connectionFactory;
     this.dlmsHelper = dlmsHelper;
+    this.deviceRepository = deviceRepository;
   }
 
   /**
@@ -87,6 +92,7 @@ public class InvocationCounterManager {
             previousKnownInvocationCounter);
       } else {
         device.setInvocationCounter(invocationCounterFromDevice);
+        this.deviceRepository.save(device);
         LOGGER.info(
             "Property invocationCounter of device {} initialized to the value of the invocation counter "
                 + "stored on the device: {}{}",

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/DeviceRequestMessageProcessor.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/DeviceRequestMessageProcessor.java
@@ -136,7 +136,7 @@ public abstract class DeviceRequestMessageProcessor extends DlmsConnectionMessag
       }
 
       log.info(
-          "{} called for device: {} for organisation: {}, correlationUID={}",
+          "{} called for device: {} for organisation: {}, correlationUID: {}",
           messageMetadata.getMessageType(),
           messageMetadata.getDeviceIdentification(),
           messageMetadata.getOrganisationIdentification(),
@@ -183,7 +183,7 @@ public abstract class DeviceRequestMessageProcessor extends DlmsConnectionMessag
     if (!(exception instanceof SilentException)) {
       final String errorMessage =
           String.format(
-              "Unexpected exception during %s, correlationUID=%s",
+              "Unexpected exception during %s, correlationUID: %s",
               this.messageType.name(), metadata.getCorrelationUid());
       log.error(errorMessage, exception);
     }

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/DeviceRequestMessageProcessor.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/DeviceRequestMessageProcessor.java
@@ -114,8 +114,8 @@ public abstract class DeviceRequestMessageProcessor extends DlmsConnectionMessag
       final MessageMetadata messageMetadata,
       final DlmsConnectionManager connectionManager)
       throws OsgpException {
+    DlmsDevice device = null;
     try {
-      DlmsDevice device = null;
       if (this.maxScheduleTimeExceeded(messageMetadata)) {
         log.info(
             "Processing message of type {} for correlation UID {} exceeded max schedule time: {} ({})",
@@ -147,7 +147,6 @@ public abstract class DeviceRequestMessageProcessor extends DlmsConnectionMessag
       this.sendResponse(messageMetadata, response);
 
     } finally {
-      final DlmsDevice device = this.domainHelperService.findDlmsDevice(messageMetadata);
       this.doConnectionPostProcessing(device, connectionManager, messageMetadata);
     }
   }

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/application/services/DomainHelperServiceTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/application/services/DomainHelperServiceTest.java
@@ -59,7 +59,7 @@ class DomainHelperServiceTest {
   }
 
   @Test
-  void findDlmsDeviceNotFound() {
+  void findDlmsDeviceMetadataNotFound() {
     final MessageMetadata messageMetadata = mock(MessageMetadata.class);
     when(messageMetadata.getDeviceIdentification()).thenReturn(DEVICE_IDENTIFICATION);
 
@@ -77,7 +77,7 @@ class DomainHelperServiceTest {
   }
 
   @Test
-  void findDlmsDeviceIpAddressStatic() throws OsgpException {
+  void findDlmsDeviceMetadataIpAddressStatic() throws OsgpException {
     final MessageMetadata messageMetadata = mock(MessageMetadata.class);
     when(messageMetadata.getDeviceIdentification()).thenReturn(DEVICE_IDENTIFICATION);
     when(messageMetadata.getIpAddress()).thenReturn(IP_ADDRESS);
@@ -92,7 +92,7 @@ class DomainHelperServiceTest {
   }
 
   @Test
-  void findDlmsDeviceIpNotStatic() throws OsgpException {
+  void findDlmsDeviceMetadataIpNotStatic() throws OsgpException {
     final MessageMetadata messageMetadata = mock(MessageMetadata.class);
     when(messageMetadata.getDeviceIdentification()).thenReturn(DEVICE_IDENTIFICATION);
 
@@ -115,5 +115,32 @@ class DomainHelperServiceTest {
     final DlmsDevice foundDevice = this.domainHelperService.findDlmsDevice(messageMetadata);
 
     assertThat(foundDevice.getIpAddress()).isEqualTo(ipAddressFromSession);
+  }
+
+  @Test
+  void findDlmsDeviceNotFound() {
+    when(this.dlmsDeviceRepository.findByDeviceIdentification(DEVICE_IDENTIFICATION))
+        .thenReturn(null);
+
+    final FunctionalException exception =
+        assertThrows(
+            FunctionalException.class,
+            () -> {
+              this.domainHelperService.findDlmsDevice(DEVICE_IDENTIFICATION, IP_ADDRESS);
+            });
+    assertThat(exception.getExceptionType()).isEqualTo(FunctionalExceptionType.UNKNOWN_DEVICE);
+    assertThat(exception.getComponentType()).isEqualTo(ComponentType.PROTOCOL_DLMS);
+  }
+
+  @Test
+  void findDlmsDeviceIpAddressStatic() throws OsgpException {
+    final DlmsDevice device = new DlmsDeviceBuilder().withIpAddressStatic(true).build();
+    when(this.dlmsDeviceRepository.findByDeviceIdentification(DEVICE_IDENTIFICATION))
+        .thenReturn(device);
+
+    final DlmsDevice foundDevice =
+        this.domainHelperService.findDlmsDevice(DEVICE_IDENTIFICATION, IP_ADDRESS);
+
+    assertThat(foundDevice.getIpAddress()).isEqualTo(IP_ADDRESS);
   }
 }

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/application/services/DomainHelperServiceTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/application/services/DomainHelperServiceTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2021 Alliander N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.opensmartgridplatform.adapter.protocol.dlms.application.services;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.AdditionalAnswers.returnsFirstArg;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensmartgridplatform.adapter.protocol.dlms.domain.entities.DlmsDevice;
+import org.opensmartgridplatform.adapter.protocol.dlms.domain.entities.DlmsDeviceBuilder;
+import org.opensmartgridplatform.adapter.protocol.dlms.domain.repositories.DlmsDeviceRepository;
+import org.opensmartgridplatform.adapter.protocol.jasper.infra.ws.JasperWirelessSmsClient;
+import org.opensmartgridplatform.adapter.protocol.jasper.sessionproviders.SessionProvider;
+import org.opensmartgridplatform.adapter.protocol.jasper.sessionproviders.SessionProviderService;
+import org.opensmartgridplatform.shared.exceptionhandling.ComponentType;
+import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
+import org.opensmartgridplatform.shared.exceptionhandling.FunctionalExceptionType;
+import org.opensmartgridplatform.shared.exceptionhandling.OsgpException;
+import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
+
+@Slf4j
+@ExtendWith(MockitoExtension.class)
+class DomainHelperServiceTest {
+
+  @Mock private DlmsDeviceRepository dlmsDeviceRepository;
+  @Mock private SessionProviderService sessionProviderService;
+  @Mock private JasperWirelessSmsClient jasperWirelessSmsClient;
+  private final int jasperGetSessionRetries = 1;
+  private final int jasperGetSessionSleepBetweenRetries = 2;
+
+  private DomainHelperService domainHelperService;
+
+  private static final String DEVICE_IDENTIFICATION = "E000123456789";
+  private static final String IP_ADDRESS = "1.1.1.1";
+
+  @BeforeEach
+  void setUp() {
+    this.domainHelperService =
+        new DomainHelperService(
+            this.dlmsDeviceRepository,
+            this.sessionProviderService,
+            this.jasperWirelessSmsClient,
+            this.jasperGetSessionRetries,
+            this.jasperGetSessionSleepBetweenRetries);
+  }
+
+  @Test
+  void findDlmsDeviceNotFound() {
+    final MessageMetadata messageMetadata = mock(MessageMetadata.class);
+    when(messageMetadata.getDeviceIdentification()).thenReturn(DEVICE_IDENTIFICATION);
+
+    when(this.dlmsDeviceRepository.findByDeviceIdentification(DEVICE_IDENTIFICATION))
+        .thenReturn(null);
+
+    final FunctionalException exception =
+        assertThrows(
+            FunctionalException.class,
+            () -> {
+              this.domainHelperService.findDlmsDevice(messageMetadata);
+            });
+    assertThat(exception.getExceptionType()).isEqualTo(FunctionalExceptionType.UNKNOWN_DEVICE);
+    assertThat(exception.getComponentType()).isEqualTo(ComponentType.PROTOCOL_DLMS);
+  }
+
+  @Test
+  void findDlmsDeviceIpAddressStatic() throws OsgpException {
+    final MessageMetadata messageMetadata = mock(MessageMetadata.class);
+    when(messageMetadata.getDeviceIdentification()).thenReturn(DEVICE_IDENTIFICATION);
+    when(messageMetadata.getIpAddress()).thenReturn(IP_ADDRESS);
+
+    final DlmsDevice device = new DlmsDeviceBuilder().withIpAddressStatic(true).build();
+    when(this.dlmsDeviceRepository.findByDeviceIdentification(DEVICE_IDENTIFICATION))
+        .thenReturn(device);
+
+    when(this.dlmsDeviceRepository.save(device)).then(returnsFirstArg());
+    final DlmsDevice foundDevice = this.domainHelperService.findDlmsDevice(messageMetadata);
+
+    verify(this.dlmsDeviceRepository).save(device);
+    assertThat(foundDevice.getIpAddress()).isEqualTo(IP_ADDRESS);
+  }
+
+  @Test
+  void findDlmsDeviceIpNotStatic() throws OsgpException {
+    final MessageMetadata messageMetadata = mock(MessageMetadata.class);
+    when(messageMetadata.getDeviceIdentification()).thenReturn(DEVICE_IDENTIFICATION);
+
+    final DlmsDevice device =
+        new DlmsDeviceBuilder()
+            .withIpAddressStatic(false)
+            .withCommunicationMethod("CDMA")
+            .setIccId("ICC ID")
+            .build();
+    when(this.dlmsDeviceRepository.findByDeviceIdentification(DEVICE_IDENTIFICATION))
+        .thenReturn(device);
+
+    final SessionProvider sessionProvider = mock(SessionProvider.class);
+    when(this.sessionProviderService.getSessionProvider(device.getCommunicationProvider()))
+        .thenReturn(sessionProvider);
+
+    final String ipAddressFromSession = "2.2.2.2";
+    when(sessionProvider.getIpAddress(device.getIccId())).thenReturn(ipAddressFromSession);
+
+    when(this.dlmsDeviceRepository.save(device)).then(returnsFirstArg());
+
+    final DlmsDevice foundDevice = this.domainHelperService.findDlmsDevice(messageMetadata);
+
+    verify(this.dlmsDeviceRepository).save(device);
+    assertThat(foundDevice.getIpAddress()).isEqualTo(ipAddressFromSession);
+  }
+}

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/application/services/DomainHelperServiceTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/application/services/DomainHelperServiceTest.java
@@ -11,9 +11,7 @@ package org.opensmartgridplatform.adapter.protocol.dlms.application.services;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.AdditionalAnswers.returnsFirstArg;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import lombok.extern.slf4j.Slf4j;
@@ -88,10 +86,8 @@ class DomainHelperServiceTest {
     when(this.dlmsDeviceRepository.findByDeviceIdentification(DEVICE_IDENTIFICATION))
         .thenReturn(device);
 
-    when(this.dlmsDeviceRepository.save(device)).then(returnsFirstArg());
     final DlmsDevice foundDevice = this.domainHelperService.findDlmsDevice(messageMetadata);
 
-    verify(this.dlmsDeviceRepository).save(device);
     assertThat(foundDevice.getIpAddress()).isEqualTo(IP_ADDRESS);
   }
 
@@ -116,11 +112,8 @@ class DomainHelperServiceTest {
     final String ipAddressFromSession = "2.2.2.2";
     when(sessionProvider.getIpAddress(device.getIccId())).thenReturn(ipAddressFromSession);
 
-    when(this.dlmsDeviceRepository.save(device)).then(returnsFirstArg());
-
     final DlmsDevice foundDevice = this.domainHelperService.findDlmsDevice(messageMetadata);
 
-    verify(this.dlmsDeviceRepository).save(device);
     assertThat(foundDevice.getIpAddress()).isEqualTo(ipAddressFromSession);
   }
 }

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/application/threads/RecoverKeyProcessTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/application/threads/RecoverKeyProcessTest.java
@@ -44,7 +44,7 @@ import org.opensmartgridplatform.shared.exceptionhandling.OsgpException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 
 @ExtendWith(MockitoExtension.class)
-public class RecoverKeyProcessTest {
+class RecoverKeyProcessTest {
 
   @InjectMocks RecoverKeyProcess recoverKeyProcess;
 
@@ -70,10 +70,10 @@ public class RecoverKeyProcessTest {
   }
 
   @Test
-  public void testWhenDeviceNotFoundThenException() throws OsgpException {
+  void testWhenDeviceNotFoundThenException() throws OsgpException {
 
     // GIVEN
-    when(this.domainHelperService.findDlmsDevice(MESSAGE_METADATA))
+    when(this.domainHelperService.findDlmsDevice(DEVICE_IDENTIFICATION, IP_ADDRESS))
         .thenThrow(
             new FunctionalException(
                 FunctionalExceptionType.UNKNOWN_DEVICE, ComponentType.PROTOCOL_DLMS));
@@ -86,7 +86,7 @@ public class RecoverKeyProcessTest {
   }
 
   @Test
-  public void testWhenNoNewKeysThenNoActivate() throws OsgpException {
+  void testWhenNoNewKeysThenNoActivate() throws OsgpException {
 
     // GIVEN
     when(this.secretManagementService.hasNewSecretOfType(
@@ -97,15 +97,16 @@ public class RecoverKeyProcessTest {
     this.recoverKeyProcess.run();
 
     // THEN
-    verify(this.domainHelperService).findDlmsDevice(MESSAGE_METADATA);
+    verify(this.domainHelperService).findDlmsDevice(DEVICE_IDENTIFICATION, IP_ADDRESS);
     verify(this.secretManagementService, never()).activateNewKeys(any(), any(), any());
   }
 
   @Test
-  public void testThrottlingServiceCalledAndKeysActivated() throws Exception {
+  void testThrottlingServiceCalledAndKeysActivated() throws Exception {
 
     // GIVEN
-    when(this.domainHelperService.findDlmsDevice(MESSAGE_METADATA)).thenReturn(DEVICE);
+    when(this.domainHelperService.findDlmsDevice(DEVICE_IDENTIFICATION, IP_ADDRESS))
+        .thenReturn(DEVICE);
     when(this.secretManagementService.hasNewSecretOfType(
             MESSAGE_METADATA, DEVICE_IDENTIFICATION, E_METER_AUTHENTICATION))
         .thenReturn(true);
@@ -133,10 +134,11 @@ public class RecoverKeyProcessTest {
   }
 
   @Test
-  public void testWhenConnectionFailedThenConnectionClosedAtThrottlingService() throws Exception {
+  void testWhenConnectionFailedThenConnectionClosedAtThrottlingService() throws Exception {
 
     // GIVEN
-    when(this.domainHelperService.findDlmsDevice(MESSAGE_METADATA)).thenReturn(DEVICE);
+    when(this.domainHelperService.findDlmsDevice(DEVICE_IDENTIFICATION, IP_ADDRESS))
+        .thenReturn(DEVICE);
     when(this.secretManagementService.hasNewSecretOfType(
             MESSAGE_METADATA, DEVICE_IDENTIFICATION, E_METER_AUTHENTICATION))
         .thenReturn(true);

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/application/threads/RecoverKeyProcessTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/application/threads/RecoverKeyProcessTest.java
@@ -73,7 +73,7 @@ public class RecoverKeyProcessTest {
   public void testWhenDeviceNotFoundThenException() throws OsgpException {
 
     // GIVEN
-    when(this.domainHelperService.findDlmsDevice(DEVICE_IDENTIFICATION, IP_ADDRESS))
+    when(this.domainHelperService.findDlmsDevice(MESSAGE_METADATA))
         .thenThrow(
             new FunctionalException(
                 FunctionalExceptionType.UNKNOWN_DEVICE, ComponentType.PROTOCOL_DLMS));
@@ -97,7 +97,7 @@ public class RecoverKeyProcessTest {
     this.recoverKeyProcess.run();
 
     // THEN
-    verify(this.domainHelperService).findDlmsDevice(DEVICE_IDENTIFICATION, IP_ADDRESS);
+    verify(this.domainHelperService).findDlmsDevice(MESSAGE_METADATA);
     verify(this.secretManagementService, never()).activateNewKeys(any(), any(), any());
   }
 
@@ -105,8 +105,7 @@ public class RecoverKeyProcessTest {
   public void testThrottlingServiceCalledAndKeysActivated() throws Exception {
 
     // GIVEN
-    when(this.domainHelperService.findDlmsDevice(DEVICE_IDENTIFICATION, IP_ADDRESS))
-        .thenReturn(DEVICE);
+    when(this.domainHelperService.findDlmsDevice(MESSAGE_METADATA)).thenReturn(DEVICE);
     when(this.secretManagementService.hasNewSecretOfType(
             MESSAGE_METADATA, DEVICE_IDENTIFICATION, E_METER_AUTHENTICATION))
         .thenReturn(true);
@@ -137,8 +136,7 @@ public class RecoverKeyProcessTest {
   public void testWhenConnectionFailedThenConnectionClosedAtThrottlingService() throws Exception {
 
     // GIVEN
-    when(this.domainHelperService.findDlmsDevice(DEVICE_IDENTIFICATION, IP_ADDRESS))
-        .thenReturn(DEVICE);
+    when(this.domainHelperService.findDlmsDevice(MESSAGE_METADATA)).thenReturn(DEVICE);
     when(this.secretManagementService.hasNewSecretOfType(
             MESSAGE_METADATA, DEVICE_IDENTIFICATION, E_METER_AUTHENTICATION))
         .thenReturn(true);

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/entities/DlmsDeviceBuilder.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/entities/DlmsDeviceBuilder.java
@@ -24,6 +24,10 @@ public class DlmsDeviceBuilder {
   private DefaultValue<Boolean> hls5Active = notSet();
   private DefaultValue<String> protocol = notSet();
   private DefaultValue<Long> invocationCounter = notSet();
+  private DefaultValue<String> ipAddress = notSet();
+  private DefaultValue<Boolean> ipAddressStatic = notSet();
+  private DefaultValue<String> iccId = notSet();
+  private DefaultValue<String> communicationMethod = notSet();
 
   public DlmsDevice build() {
     counter += 1;
@@ -35,6 +39,10 @@ public class DlmsDeviceBuilder {
     device.setHls5Active(this.hls5Active.orElse(false));
     device.setProtocol(this.protocol.orElse("protocol" + counter), "protocolVersion" + counter);
     device.setInvocationCounter(this.invocationCounter.orElse(100L + counter));
+    device.setIpAddress(this.ipAddress.orElse(null));
+    device.setIpAddressIsStatic(this.ipAddressStatic.orElse(true));
+    device.setIccId(this.iccId.orElse(null));
+    device.setCommunicationMethod(this.communicationMethod.orElse(null));
     return device;
   }
 
@@ -70,6 +78,26 @@ public class DlmsDeviceBuilder {
 
   public DlmsDeviceBuilder withInvocationCounter(final Long invocationCounter) {
     this.invocationCounter = setTo(invocationCounter);
+    return this;
+  }
+
+  public DlmsDeviceBuilder withIpAddress(final String ipAddress) {
+    this.ipAddress = setTo(ipAddress);
+    return this;
+  }
+
+  public DlmsDeviceBuilder withIpAddressStatic(final boolean ipAddressStatic) {
+    this.ipAddressStatic = setTo(ipAddressStatic);
+    return this;
+  }
+
+  public DlmsDeviceBuilder setIccId(final String iccId) {
+    this.iccId = setTo(iccId);
+    return this;
+  }
+
+  public DlmsDeviceBuilder withCommunicationMethod(final String communicationMethod) {
+    this.communicationMethod = setTo(communicationMethod);
     return this;
   }
 }

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/factories/DlmsConnectionManagerTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/factories/DlmsConnectionManagerTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2021 Alliander N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.opensmartgridplatform.adapter.protocol.dlms.domain.factories;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.openmuc.jdlms.DlmsConnection;
+import org.opensmartgridplatform.adapter.protocol.dlms.application.services.DomainHelperService;
+import org.opensmartgridplatform.adapter.protocol.dlms.domain.entities.DlmsDevice;
+import org.opensmartgridplatform.adapter.protocol.dlms.infra.messaging.DlmsMessageListener;
+import org.opensmartgridplatform.shared.exceptionhandling.OsgpException;
+import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
+
+@ExtendWith(MockitoExtension.class)
+class DlmsConnectionManagerTest {
+  @Mock DlmsConnector connector;
+  @Mock MessageMetadata messageMetadata;
+  @Mock DlmsDevice device;
+  @Mock DlmsMessageListener dlmsMessageListener;
+  @Mock DomainHelperService domainHelperService;
+  @InjectMocks DlmsConnectionManager manager;
+
+  @BeforeEach
+  void setUp() {
+    this.manager =
+        new DlmsConnectionManager(
+            this.connector,
+            this.messageMetadata,
+            this.device,
+            this.dlmsMessageListener,
+            this.domainHelperService);
+  }
+
+  @Test
+  void connectAndClose() throws OsgpException {
+    final DlmsConnection dlmsConnection = mock(DlmsConnection.class);
+    when(this.connector.connect(this.messageMetadata, this.device, this.dlmsMessageListener))
+        .thenReturn(dlmsConnection);
+    this.manager.connect();
+
+    assertThat(this.manager.getConnection()).isEqualTo(dlmsConnection);
+
+    this.manager.close();
+
+    assertThat(this.manager.isConnected()).isFalse();
+  }
+
+  @Test
+  void closeWithoutConnectionShouldNotFail() throws OsgpException {
+    this.manager.close();
+
+    assertThat(this.manager.isConnected()).isFalse();
+  }
+
+  @Test
+  void closeWithIOExceptionShouldNotFail() throws OsgpException, IOException {
+    final DlmsConnection dlmsConnection = mock(DlmsConnection.class);
+    when(this.connector.connect(this.messageMetadata, this.device, this.dlmsMessageListener))
+        .thenReturn(dlmsConnection);
+    this.manager.connect();
+    assertThat(this.manager.getConnection()).isEqualTo(dlmsConnection);
+
+    doThrow(new IOException()).when(dlmsConnection).close();
+    this.manager.close();
+
+    assertThat(this.manager.isConnected()).isFalse();
+  }
+}

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/factories/DlmsConnectionManagerTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/factories/DlmsConnectionManagerTest.java
@@ -64,6 +64,8 @@ class DlmsConnectionManagerTest {
 
   @Test
   void closeWithoutConnectionShouldNotFail() throws OsgpException {
+    assertThat(this.manager.isConnected()).isFalse();
+
     this.manager.close();
 
     assertThat(this.manager.isConnected()).isFalse();

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/factories/DlmsConnectionManagerTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/factories/DlmsConnectionManagerTest.java
@@ -64,8 +64,6 @@ class DlmsConnectionManagerTest {
 
   @Test
   void closeWithoutConnectionShouldNotFail() throws OsgpException {
-    assertThat(this.manager.isConnected()).isFalse();
-
     this.manager.close();
 
     assertThat(this.manager.isConnected()).isFalse();

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/factories/InvocationCounterManagerTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/factories/InvocationCounterManagerTest.java
@@ -29,6 +29,7 @@ import org.openmuc.jdlms.datatypes.DataObject;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.utils.DlmsHelper;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.entities.DlmsDevice;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.entities.DlmsDeviceBuilder;
+import org.opensmartgridplatform.adapter.protocol.dlms.domain.repositories.DlmsDeviceRepository;
 import org.opensmartgridplatform.shared.exceptionhandling.OsgpException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 
@@ -45,10 +46,13 @@ class InvocationCounterManagerTest {
   @Mock private DlmsConnectionFactory connectionFactory;
 
   @Mock private DlmsHelper dlmsHelper;
+  @Mock private DlmsDeviceRepository deviceRepository;
 
   @BeforeEach
   void setUp() {
-    this.manager = new InvocationCounterManager(this.connectionFactory, this.dlmsHelper);
+    this.manager =
+        new InvocationCounterManager(
+            this.connectionFactory, this.dlmsHelper, this.deviceRepository);
     this.messageMetadata = MessageMetadata.newBuilder().withCorrelationUid("123456").build();
     this.device =
         new DlmsDeviceBuilder()
@@ -77,6 +81,7 @@ class InvocationCounterManagerTest {
         .thenReturn(dataObject);
 
     this.manager.initializeWithInvocationCounterStoredOnDeviceTask(this.device, connectionManager);
+    verify(this.deviceRepository).save(this.device);
 
     assertThat(this.device.getInvocationCounter()).isEqualTo(invocationCounterValueOnDevice);
   }

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/DeviceRequestMessageListenerIT.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/DeviceRequestMessageListenerIT.java
@@ -57,8 +57,6 @@ class DeviceRequestMessageListenerIT {
     dlmsDevice.setIpAddress("127.0.0.1");
     dlmsDevice.setHls5Active(true);
 
-    when(this.domainHelperService.findDlmsDevice(any(String.class), any(String.class)))
-        .thenReturn(dlmsDevice);
     when(this.domainHelperService.findDlmsDevice(any(MessageMetadata.class)))
         .thenReturn(dlmsDevice);
     doNothing()

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/MessagingTestConfiguration.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/MessagingTestConfiguration.java
@@ -23,6 +23,7 @@ import org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.utils.Dlm
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.factories.DlmsConnectionFactory;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.factories.DlmsConnectionHelper;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.factories.InvocationCounterManager;
+import org.opensmartgridplatform.adapter.protocol.dlms.domain.repositories.DlmsDeviceRepository;
 import org.opensmartgridplatform.adapter.protocol.dlms.exceptions.OsgpExceptionConverter;
 import org.opensmartgridplatform.adapter.protocol.dlms.infra.messaging.processors.GetPowerQualityProfileRequestMessageProcessor;
 import org.opensmartgridplatform.adapter.protocol.dlms.infra.messaging.requests.to.core.OsgpRequestMessageSender;
@@ -109,12 +110,14 @@ public class MessagingTestConfiguration extends AbstractConfig {
   }
 
   @Bean
-  public InvocationCounterManager invocationCounterManager() {
-    return new InvocationCounterManager(this.dlmsConnectionFactory(), this.dlmsHelper());
+  public InvocationCounterManager invocationCounterManager(
+      final DlmsDeviceRepository deviceRepository) {
+    return new InvocationCounterManager(
+        this.dlmsConnectionFactory(), this.dlmsHelper(), deviceRepository);
   }
 
   @Bean
-  public DlmsConnectionHelper dlmsConnectionHelper() {
+  public DlmsConnectionHelper dlmsConnectionHelper(final DlmsDeviceRepository deviceRepository) {
     final DevicePingConfig devicePingConfig =
         new DevicePingConfig() {
           @Override
@@ -128,7 +131,10 @@ public class MessagingTestConfiguration extends AbstractConfig {
           }
         };
     return new DlmsConnectionHelper(
-        this.invocationCounterManager(), this.dlmsConnectionFactory(), devicePingConfig, 0);
+        this.invocationCounterManager(deviceRepository),
+        this.dlmsConnectionFactory(),
+        devicePingConfig,
+        0);
   }
 
   @Bean


### PR DESCRIPTION
If the invocationcounter is out of sync the DlmsConnectionManager tries to close connections that are not opened yet, this is caused by: the change in DlmsConnectionFactory where the DlmsConnectionManager is now used with try-with-resources in the method 
createAndHandleConnectionWithSecurityLevel that closes the connections.
Second issue was that when the invocationcounter was not in sync the value was not saved to the database. This is caused by a change in the DeviceRequestMessageProcessor-> processMessageTasks(). in the finally block is fresh device retrieved from the database. Before this changes the updated device with updated invocationCounter value was used, and therefor saved
```    } finally {
      final DlmsDevice device = this.domainHelperService.findDlmsDevice(messageMetadata);
      this.doConnectionPostProcessing(device, connectionManager, messageMetadata);
    }
``` 