### PR TITLE
Always close a executor service

### DIFF
--- a/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/infra/networking/ping/CommandExecutor.java
+++ b/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/infra/networking/ping/CommandExecutor.java
@@ -36,22 +36,16 @@ public class CommandExecutor {
     final Process process = this.start(commands);
 
     final ExecutorService executorService = Executors.newSingleThreadExecutor();
-    final Future<List<String>> inputLines =
-        executorService.submit(() -> this.readLinesFromInput(process));
     try {
-      final List<String> results = inputLines.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
-
-      executorService.shutdownNow();
-
-      return results;
+      final Future<List<String>> inputLines =
+          executorService.submit(() -> this.readLinesFromInput(process));
+      return inputLines.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
     } catch (final InterruptedException e) {
-      // (Re-)Cancel if current thread also interrupted
-      executorService.shutdownNow();
-
       Thread.currentThread().interrupt();
       LOGGER.warn(
           "Reading input lines from executed process was interrupted: \"{}\"", commandLine, e);
     } finally {
+      executorService.shutdownNow();
       if (process.isAlive()) {
         LOGGER.debug("Destroy the process running \"{}\"", commandLine);
         process.destroyForcibly();

--- a/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/infra/networking/ping/CommandExecutor.java
+++ b/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/infra/networking/ping/CommandExecutor.java
@@ -41,7 +41,7 @@ public class CommandExecutor {
     try {
       final List<String> results = inputLines.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
 
-      this.shutdownAndAwaitTermination(executorService);
+      executorService.shutdownNow();
 
       return results;
     } catch (final InterruptedException e) {
@@ -61,19 +61,6 @@ public class CommandExecutor {
       }
     }
     return Collections.emptyList();
-  }
-
-  private void shutdownAndAwaitTermination(final ExecutorService executorService)
-      throws InterruptedException {
-    executorService.shutdown(); // Disable new tasks from being submitted
-    // Wait a while for existing tasks to terminate
-    if (!executorService.awaitTermination(60, TimeUnit.SECONDS)) {
-      executorService.shutdownNow(); // Cancel currently executing tasks
-      // Wait a while for tasks to respond to being cancelled
-      if (!executorService.awaitTermination(60, TimeUnit.SECONDS)) {
-        LOGGER.warn("Pool did not terminate");
-      }
-    }
   }
 
   private String commandLine(final List<String> commands) {

--- a/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/infra/networking/ping/Pinger.java
+++ b/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/infra/networking/ping/Pinger.java
@@ -79,9 +79,7 @@ public class Pinger {
     } catch (final TimeoutException e) {
       LOGGER.info("Timeout executing ping command");
     } catch (final RejectedExecutionException e) {
-      LOGGER.error(
-          "RejectedExecutionException occurred while processing input from the executed ping command",
-          e);
+      LOGGER.error("Exception occurred preventing processing the output of the ping command", e);
     } catch (final ExecutionException e) {
       LOGGER.error("Exception occurred while processing input from the executed ping command", e);
     }

--- a/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/infra/networking/ping/Pinger.java
+++ b/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/infra/networking/ping/Pinger.java
@@ -13,6 +13,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Predicate;
 import org.slf4j.Logger;
@@ -77,6 +78,10 @@ public class Pinger {
       LOGGER.error("Exception occurred while executing ping command", e);
     } catch (final TimeoutException e) {
       LOGGER.info("Timeout executing ping command");
+    } catch (final RejectedExecutionException e) {
+      LOGGER.error(
+          "RejectedExecutionException occurred while processing input from the executed ping command",
+          e);
     } catch (final ExecutionException e) {
       LOGGER.error("Exception occurred while processing input from the executed ping command", e);
     }


### PR DESCRIPTION
Always close executor services to allow reclamation of its resources.

https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ExecutorService.html