### PR TITLE
FDP-497 Make throttling service dependency in recover key process non-required

### DIFF
--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/config/DlmsConfig.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/config/DlmsConfig.java
@@ -37,6 +37,7 @@ import org.opensmartgridplatform.shared.application.config.AbstractConfig;
 import org.opensmartgridplatform.shared.infra.networking.DisposableNioEventLoopGroup;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -163,7 +164,7 @@ public class DlmsConfig extends AbstractConfig {
       final DomainHelperService domainHelperService,
       final Hls5Connector hls5Connector,
       final SecretManagementService secretManagementService,
-      final ThrottlingService throttlingService,
+      @Autowired(required = false) final ThrottlingService throttlingService,
       final ThrottlingClientConfig throttlingClientConfig,
       final DlmsDeviceRepository deviceRepository) {
     return new RecoverKeyProcess(


### PR DESCRIPTION
Either the throttlingService or the throttling client in the
ThrottlingClientConfig is available. The autowired bean parameter for
the TrottlingService should not be required.