### PR TITLE
Update logback version to 1.2.8

### DIFF
--- a/super/pom.xml
+++ b/super/pom.xml
@@ -101,7 +101,7 @@
     <versions.maven.plugin.version>2.7</versions.maven.plugin.version>
     <fmt-maven-plugin.version>2.9.1</fmt-maven-plugin.version>
     <apache.activemq.version>5.16.0</apache.activemq.version>
-    <logback.version>1.2.3</logback.version>
+    <logback.version>1.2.8</logback.version>
     <apache.commons.schema>2.2.5</apache.commons.schema>
     <maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
     <netty.version>4.1.53.Final</netty.version>


### PR DESCRIPTION
Due to Logback issue LOGBACK-191 the version of Logback is updated to
1.2.8.
This should prevent remote code execution in case the attacker has
write access to logback.xml and configuration data is reloaded by
application restart, or because scan="true" prior to the configuration
change.
