### PR TITLE
SMHE-565 Update datatype for mbus identification number

### DIFF
--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/configuration/Firmware.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/configuration/Firmware.feature
@@ -273,7 +273,7 @@ Feature: SmartMetering Configuration - Firmware
       | ManufacturerCode            | GMAN              |
       | DeviceModelCode             | G_METER_MODEL_1   |
       | GatewayDeviceIdentification | ETEST102400000002 |
-      | MbusIdentificationNumber    | 0000000           |
+      | MbusIdentificationNumber    | 00000000          |
       | FirmwareUpdateKey           | SECURITY_KEY_2    |
     And a firmware
       | FirmwareFileIdentification  | TEST_FW_FILE_GAS_0002          |

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/application/services/MBusGatewayService.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/application/services/MBusGatewayService.java
@@ -11,7 +11,6 @@ package org.opensmartgridplatform.adapter.domain.smartmetering.application.servi
 import java.util.List;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.opensmartgridplatform.adapter.domain.smartmetering.infra.jms.core.JmsMessageSender;
 import org.opensmartgridplatform.domain.core.entities.Device;
 import org.opensmartgridplatform.domain.core.entities.SmartMeter;
@@ -325,8 +324,6 @@ public class MBusGatewayService {
   private MbusChannelElementsDto makeMbusChannelElementsDto(final SmartMeter mbusDevice) {
 
     final String mbusDeviceIdentification = mbusDevice.getDeviceIdentification();
-    final String mbusIdentificationNumber =
-        StringUtils.leftPad(mbusDevice.getMbusIdentificationNumber(), 8, "0");
     final String mbusManufacturerIdentification = mbusDevice.getMbusManufacturerIdentification();
     final Short mbusVersion = mbusDevice.getMbusVersion();
     final Short mbusDeviceTypeIdentification = mbusDevice.getMbusDeviceTypeIdentification();
@@ -339,7 +336,7 @@ public class MBusGatewayService {
     return new MbusChannelElementsDto(
         primaryAddress,
         mbusDeviceIdentification,
-        mbusIdentificationNumber,
+        mbusDevice.getMbusIdentificationNumber(),
         mbusManufacturerIdentification,
         mbusVersion,
         mbusDeviceTypeIdentification);

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/entities/DlmsDevice.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/entities/DlmsDevice.java
@@ -13,7 +13,6 @@ import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Transient;
-import org.apache.commons.lang3.StringUtils;
 import org.opensmartgridplatform.shared.domain.entities.AbstractEntity;
 
 @Entity
@@ -319,7 +318,7 @@ public class DlmsDevice extends AbstractEntity {
     if (this.mbusIdentificationNumber == null) {
       return null;
     }
-    return StringUtils.leftPad(this.mbusIdentificationNumber, 8, "0");
+    return this.mbusIdentificationNumber;
   }
 
   public void setMbusIdentificationNumber(final String mbusIdentificationNumber) {


### PR DESCRIPTION
revert leftpadding with zeros of mbus identification number and update test data, mbus identification number with length 7 is not a valid case

Signed-off-by: Natasja Nortier <natasja.nortier@alliander.com>