### PR TITLE
Enable skipped tests

### DIFF
--- a/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/database/ws/NotificationWebServiceConfigurationBuilder.java
+++ b/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/steps/database/ws/NotificationWebServiceConfigurationBuilder.java
@@ -16,7 +16,7 @@ public class NotificationWebServiceConfigurationBuilder {
   private String organisationIdentification = "test-org";
   private String applicationName = "application-name";
   private String marshallerContextPath = "org.opensmartgridplatform.adapter.ws.schema";
-  private String targetUri = "http://localhost:8088/notifications";
+  private String targetUri = "http://localhost:8188/notifications";
   private String keyStoreType = "pkcs12";
   private String keyStoreLocation = "/etc/ssl/certs/OSGP.pfx";
   private String keyStorePassword = "1234";

--- a/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/support/ws/core/notification/CoreNotificationService.java
+++ b/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/support/ws/core/notification/CoreNotificationService.java
@@ -72,7 +72,7 @@ public class CoreNotificationService {
       return CompletableFuture.supplyAsync(
               () -> {
                 final Predicate<Notification> correlationUidEquals =
-                    notification -> notification.getCorrelationUid().equals(correlationUid);
+                    notification -> correlationUid.equals(notification.getCorrelationUid());
                 return this.getNotification(correlationUidEquals, maxTimeout);
               })
           .get(maxTimeout, TimeUnit.MILLISECONDS);

--- a/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/support/ws/core/notification/CoreNotificationService.java
+++ b/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/support/ws/core/notification/CoreNotificationService.java
@@ -19,6 +19,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Predicate;
+import org.junit.jupiter.api.Assertions;
 import org.opensmartgridplatform.adapter.ws.schema.core.notification.Notification;
 import org.opensmartgridplatform.adapter.ws.schema.core.notification.NotificationType;
 import org.slf4j.Logger;
@@ -80,8 +81,8 @@ public class CoreNotificationService {
       Thread.currentThread().interrupt();
       LOGGER.trace("getNotification for correlation UID {} was interrupted", correlationUid, e);
     } catch (final ExecutionException e) {
-      LOGGER.error(
-          "An exception occurred getting a notification for correlation UID {}", correlationUid, e);
+      Assertions.fail(
+          "An exception occurred getting a notification for correlation UID " + correlationUid, e);
     } catch (final TimeoutException e) {
       LOGGER.trace("getNotification for correlation UID {} timed out", correlationUid, e);
     }

--- a/integration-tests/cucumber-tests-platform-common/src/test/resources/cucumber-tests-platform-common.properties
+++ b/integration-tests/cucumber-tests-platform-common/src/test/resources/cucumber-tests-platform-common.properties
@@ -25,4 +25,4 @@ jaxb2.marshaller.context.path.core.notification=org.opensmartgridplatform.adapte
 
 web.service.core.notification.application.name=OSGP
 web.service.core.notification.context=/notifications/
-web.service.core.notification.port=8088
+web.service.core.notification.port=8188

--- a/integration-tests/cucumber-tests-platform-common/src/test/resources/features/common/osgp-adapter-ws-core/notifications/ResendNotifications.feature
+++ b/integration-tests/cucumber-tests-platform-common/src/test/resources/features/common/osgp-adapter-ws-core/notifications/ResendNotifications.feature
@@ -6,7 +6,6 @@ Feature: GXF notifications (WS Core) - Resend notifications
 
   # When running separately this scenario succeeds,
   # but it still fails in the nightly build...
-  @Skip
   Scenario: Resend missed notifications
     Given a response data record in ws-core
       | DeviceIdentification      | TEST1024000000001                                      |
@@ -24,7 +23,6 @@ Feature: GXF notifications (WS Core) - Resend notifications
 
   # When running separately this scenario succeeds,
   # but it still fails in the nightly build...
-  @Skip
   Scenario: Resend missed notifications with response url
     Given a response data record in ws-core
       | DeviceIdentification      | TEST1024000000001                                      |

--- a/integration-tests/cucumber-tests-platform-common/src/test/resources/features/common/osgp-adapter-ws-core/notifications/ResendNotifications.feature
+++ b/integration-tests/cucumber-tests-platform-common/src/test/resources/features/common/osgp-adapter-ws-core/notifications/ResendNotifications.feature
@@ -1,11 +1,9 @@
-@Common @Platform
+@Common @Platform @NightlyBuildOnly
 Feature: GXF notifications (WS Core) - Resend notifications
   As an OSGP user
   I want the platform to resend missed notifications
   So the notification mechanism is more robust
 
-  # When running separately this scenario succeeds,
-  # but it still fails in the nightly build...
   Scenario: Resend missed notifications
     Given a response data record in ws-core
       | DeviceIdentification      | TEST1024000000001                                      |
@@ -21,8 +19,6 @@ Feature: GXF notifications (WS Core) - Resend notifications
       | CorrelationUid            | test-org\|\|\|TEST1024000000001\|\|\|20170101010000000 |
       | NumberOfNotificationsSent |                                                      1 |
 
-  # When running separately this scenario succeeds,
-  # but it still fails in the nightly build...
   Scenario: Resend missed notifications with response url
     Given a response data record in ws-core
       | DeviceIdentification      | TEST1024000000001                                      |
@@ -32,12 +28,12 @@ Feature: GXF notifications (WS Core) - Resend notifications
       | NumberOfNotificationsSent |                                                      0 |
     And a response url data record in ws-core
       | CorrelationUid | test-org\|\|\|TEST1024000000001\|\|\|20170101020000000 |
-      | ResponseUrl    | http://localhost:8088/notifications/                   |
+      | ResponseUrl    | http://localhost:8188/notifications/                   |
     When OSGP checks for which response data a notification has to be resend
     Then a notification is sent in ws-core
     And the response url data in ws-core has values
       | CorrelationUid            | test-org\|\|\|TEST1024000000001\|\|\|20170101020000000 |
-      | ResponseUrl               | http://localhost:8088/notifications/                   |
+      | ResponseUrl               | http://localhost:8188/notifications/                   |
 
   Scenario: Don't send notifications when the configurable time has not passed
     Given a response data record in ws-core

--- a/integration-tests/cucumber-tests-platform-common/src/test/resources/features/common/osgp-adapter-ws-core/notifications/ResendNotifications.feature
+++ b/integration-tests/cucumber-tests-platform-common/src/test/resources/features/common/osgp-adapter-ws-core/notifications/ResendNotifications.feature
@@ -1,4 +1,4 @@
-@Common @Platform @NightlyBuildOnly
+@Common @Platform
 Feature: GXF notifications (WS Core) - Resend notifications
   As an OSGP user
   I want the platform to resend missed notifications

--- a/integration-tests/cucumber-tests-platform-distributionautomation/src/test/resources/cucumber-tests-platform-distributionautomation.properties
+++ b/integration-tests/cucumber-tests-platform-distributionautomation/src/test/resources/cucumber-tests-platform-distributionautomation.properties
@@ -22,7 +22,7 @@ jaxb2.marshaller.context.path.distributionautomation.notification=org.opensmartg
 #Notification service
 web.service.distributionautomation.notification.application.name=DISTRIBUTION_AUTOMATION
 web.service.distributionautomation.notification.context=/notifications/
-web.service.distributionautomation.notification.port=8091
+web.service.distributionautomation.notification.port=8191
 
 # kafka distribution automation
 distributionautomation.kafka.common.properties.prefix=distributionautomation.kafka

--- a/integration-tests/cucumber-tests-platform-microgrids/src/test/resources/cucumber-tests-platform-microgrids.properties
+++ b/integration-tests/cucumber-tests-platform-microgrids/src/test/resources/cucumber-tests-platform-microgrids.properties
@@ -30,4 +30,4 @@ jaxb2.marshaller.context.path.microgrids.notification=org.opensmartgridplatform.
 #Notification service
 web.service.microgrids.notification.application.name=ZownStream
 web.service.microgrids.notification.context=/notifications/
-web.service.microgrids.notification.port=8092
+web.service.microgrids.notification.port=8192

--- a/integration-tests/cucumber-tests-platform-publiclighting/src/test/resources/cucumber-tests-platform-publiclighting.properties
+++ b/integration-tests/cucumber-tests-platform-publiclighting/src/test/resources/cucumber-tests-platform-publiclighting.properties
@@ -44,4 +44,4 @@ jaxb2.marshaller.context.path.publiclighting.notification=org.opensmartgridplatf
 #Notification service
 web.service.publiclighting.notification.application.name=OSGP
 web.service.publiclighting.notification.context=/notifications/
-web.service.publiclighting.notification.port=8090
+web.service.publiclighting.notification.port=8190

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/cucumber-tests-platform-smartmetering.properties
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/cucumber-tests-platform-smartmetering.properties
@@ -53,4 +53,4 @@ jaxb2.marshaller.context.path.smartmetering.notification=org.opensmartgridplatfo
 
 web.service.smartmetering.notification.application.name=SMART_METERS
 web.service.smartmetering.notification.context=/notifications/
-web.service.smartmetering.notification.port=8089
+web.service.smartmetering.notification.port=8189

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/housekeeping/ResponseUrlDataCleanupJob.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/housekeeping/ResponseUrlDataCleanupJob.feature
@@ -8,7 +8,7 @@ Feature: SmartMetering Housekeeping - Response Url Data Cleanup Job
     Given a response url data record in ws-smartmetering
       | CreationTime   | now - 1 months                               |
       | CorrelationUid | test-org-TEST1024000000001-NOW-1-MONTH-00000 |
-      | ResponseUrl    | http://localhost:8089/notifications/         |
+      | ResponseUrl    | http://localhost:8189/notifications/         |
     When the response url data cleanup job runs
     Then the cleanup job should have removed the response url data with correlation uid "test-org-TEST1024000000001-NOW-1-MONTH-00000"
 
@@ -16,6 +16,6 @@ Feature: SmartMetering Housekeeping - Response Url Data Cleanup Job
     Given a response url data record in ws-smartmetering
       | CreationTime   | now                                      |
       | CorrelationUid | test-org-TEST1024000000001-NOW-000000000 |
-      | ResponseUrl    | http://localhost:8089/notifications/     |
+      | ResponseUrl    | http://localhost:8189/notifications/     |
     When the response url data cleanup job runs
     Then the cleanup job should not have removed the response url data with correlation uid "test-org-TEST1024000000001-NOW-000000000"

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/notifications/ResendNotifications.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/notifications/ResendNotifications.feature
@@ -28,12 +28,12 @@ Feature: SmartMetering notifications - Resend notifications
       | NumberOfNotificationsSent |                                                      0 |
     And a response url data record in ws-smartmetering
       | CorrelationUid | test-org\|\|\|TEST1024000000001\|\|\|20170101000000000 |
-      | ResponseUrl    | http://localhost:8089/notifications/                   |
+      | ResponseUrl    | http://localhost:8189/notifications/                   |
     When OSGP checks for which response data a notification has to be resend
     Then a notification is sent
     And the response url data in ws-smartmetering has values
       | CorrelationUid            | test-org\|\|\|TEST1024000000001\|\|\|20170101000000000 |
-      | ResponseUrl               | http://localhost:8089/notifications/                   |
+      | ResponseUrl               | http://localhost:8189/notifications/                   |
 
   Scenario: Don't send notifications when the configurable time has not passed
     Given a response data record

--- a/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/database/ws/ResponseUrlDataBuilder.java
+++ b/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/glue/steps/database/ws/ResponseUrlDataBuilder.java
@@ -15,7 +15,7 @@ import org.opensmartgridplatform.cucumber.platform.PlatformKeys;
 public class ResponseUrlDataBuilder {
 
   private String correlationUid = "test-org|||TEST1024000000001|||20170101000000000";
-  private String responseUrl = "http://localhost:8088/notifications";
+  private String responseUrl = "http://localhost:8188/notifications";
 
   public ResponseUrlData build() {
     return new ResponseUrlData(this.correlationUid, this.responseUrl);


### PR DESCRIPTION
This PR fixes 2 disabled tests, they were failing because of a NPE in the test. 
I also changed. the ports of the cucumber notification ports because a few of those were conflicting with other ports.
8090 we used for pgadmin interface
8088 was also used for a kafka project

So i added 100 to the port numbers

A link to each of the triggered nightly's tests are in the PR-comments