### PR TITLE
FDP-131 Update POMs to get rid of some maven build warnings

### DIFF
--- a/integration-tests/cucumber-tests-platform/pom.xml
+++ b/integration-tests/cucumber-tests-platform/pom.xml
@@ -52,10 +52,6 @@
       <artifactId>logback-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-core</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.zaxxer</groupId>
       <artifactId>HikariCP</artifactId>
     </dependency>

--- a/osgp/pom.xml
+++ b/osgp/pom.xml
@@ -6,10 +6,16 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+    <groupId>org.opensmartgridplatform</groupId>
+    <artifactId>super-osgp</artifactId>
+    <version>5.23.0-SNAPSHOT</version>
+    <relativePath>../super/pom.xml</relativePath>
+  </parent>
+
   <groupId>org.opensmartgridplatform</groupId>
   <artifactId>osgp</artifactId>
   <packaging>pom</packaging>
-  <version>5.23.0-SNAPSHOT</version>
 
   <modules>
     <module>platform</module>

--- a/super/pom.xml
+++ b/super/pom.xml
@@ -79,10 +79,10 @@
     <apache.httpcomponents.httpcore.version>4.4.13</apache.httpcomponents.httpcore.version>
     <commons.codec.version>1.14</commons.codec.version>
     <orika.version>1.5.4</orika.version>
-    <jxr.version>3.0.0</jxr.version>
-    <maven.project.info.reports.plugin.version>3.0.0</maven.project.info.reports.plugin.version>
-    <maven.site.plugin>3.9.0</maven.site.plugin>
-    <maven.javadoc.version>3.2.0</maven.javadoc.version>
+    <jxr.version>3.1.1</jxr.version>
+    <maven.project.info.reports.plugin.version>3.2.2</maven.project.info.reports.plugin.version>
+    <maven.site.plugin>3.11.0</maven.site.plugin>
+    <maven.javadoc.version>3.3.2</maven.javadoc.version>
     <maven.jar.plugin.version>3.2.2</maven.jar.plugin.version>
     <maven.war.plugin.version>3.3.2</maven.war.plugin.version>
     <maven.dependency.plugin.version>3.3.0</maven.dependency.plugin.version>
@@ -104,6 +104,7 @@
     <apache.activemq.version>5.16.0</apache.activemq.version>
     <logback.version>1.2.8</logback.version>
     <apache.commons.schema>2.2.5</apache.commons.schema>
+    <maven.clean.plugin.version>3.1.0</maven.clean.plugin.version>
     <maven.compiler.plugin.version>3.10.1</maven.compiler.plugin.version>
     <netty.version>4.1.53.Final</netty.version>
     <openmuc.jdlms.version>1.7.1</openmuc.jdlms.version>
@@ -1144,6 +1145,12 @@
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>${maven.clean.plugin.version}</version>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>${maven.compiler.plugin.version}</version>
         </plugin>
@@ -1236,6 +1243,11 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
           <version>${checkstyle.maven.plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>${maven.javadoc.version}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Updates POMs to get rid off warnings in the maven site build concerning
potential future build stability issues.
Updates some versions to the currently most recent value and makes sure
some versions are explicitly set in plugin management.
