### PR TITLE
FDP-697 Add some support for zipped MQTT messages

### DIFF
--- a/integration-tests/cucumber-tests-platform-distributionautomation/src/test/java/org/opensmartgridplatform/cucumber/platform/distributionautomation/glue/steps/MqttDeviceSteps.java
+++ b/integration-tests/cucumber-tests-platform-distributionautomation/src/test/java/org/opensmartgridplatform/cucumber/platform/distributionautomation/glue/steps/MqttDeviceSteps.java
@@ -15,6 +15,7 @@ import static org.opensmartgridplatform.cucumber.core.ReadSettingsHelper.getStri
 import com.hivemq.client.mqtt.MqttClientSslConfig;
 import io.cucumber.java.en.When;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import org.opensmartgridplatform.cucumber.core.ReadSettingsHelper;
@@ -68,7 +69,14 @@ public class MqttDeviceSteps {
     LOGGER.info("Payload: {}", payload);
 
     for (final String topic : topics) {
-      this.startPublishingClient(host, port, cleanSession, keepAlive, topic, payload, parameters);
+      this.startPublishingClient(
+          host,
+          port,
+          cleanSession,
+          keepAlive,
+          topic,
+          payload.getBytes(StandardCharsets.UTF_8),
+          parameters);
     }
   }
 
@@ -78,7 +86,7 @@ public class MqttDeviceSteps {
       final boolean cleanSession,
       final int keepAlive,
       final String topic,
-      final String payload,
+      final byte[] payload,
       final Map<String, String> parameters) {
     final SimulatorSpec spec = new SimulatorSpec(host, port);
     spec.setStartupPauseMillis(2000);

--- a/osgp/protocol-adapter-mqtt/osgp-protocol-adapter-mqtt/src/main/resources/osgp-adapter-protocol-mqtt.properties
+++ b/osgp/protocol-adapter-mqtt/osgp-protocol-adapter-mqtt/src/main/resources/osgp-adapter-protocol-mqtt.properties
@@ -22,10 +22,11 @@ mqtt.default.port=8883
 # Default:
 # mqtt.default.qos=AT_LEAST_ONCE
 
-# Default topics (comma separated) to be used when subscribing
-# Default:
-# mqtt.default.topics=+/measurement
-mqtt.default.topics=+/measurement,+/congestion,msr/#
+# Default topics (comma separated) to be used when subscribing, e.g.
+# mqtt.default.topics=+/measurement,+/congestion
+# Default (all topics):
+# mqtt.default.topics=#
+mqtt.default.topics=#
 
 # Sets whether the client connects with a clean session.
 # Default:

--- a/osgp/protocol-adapter-mqtt/osgp-protocol-adapter-mqtt/src/main/resources/osgp-adapter-protocol-mqtt.properties
+++ b/osgp/protocol-adapter-mqtt/osgp-protocol-adapter-mqtt/src/main/resources/osgp-adapter-protocol-mqtt.properties
@@ -25,7 +25,7 @@ mqtt.default.port=8883
 # Default topics (comma separated) to be used when subscribing
 # Default:
 # mqtt.default.topics=+/measurement
-mqtt.default.topics=+/measurement,+/congestion
+mqtt.default.topics=+/measurement,+/congestion,msr/#
 
 # Sets whether the client connects with a clean session.
 # Default:

--- a/osgp/protocol-adapter-mqtt/osgp-protocol-simulator-mqtt/src/main/java/org/opensmartgridplatform/simulator/protocol/mqtt/Broker.java
+++ b/osgp/protocol-adapter-mqtt/osgp-protocol-simulator-mqtt/src/main/java/org/opensmartgridplatform/simulator/protocol/mqtt/Broker.java
@@ -8,8 +8,6 @@
  */
 package org.opensmartgridplatform.simulator.protocol.mqtt;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 import io.moquette.BrokerConstants;
 import io.moquette.broker.ClientDescriptor;
 import io.moquette.broker.Server;
@@ -18,20 +16,12 @@ import io.moquette.interception.AbstractInterceptHandler;
 import io.moquette.interception.messages.InterceptConnectMessage;
 import io.moquette.interception.messages.InterceptDisconnectMessage;
 import io.moquette.interception.messages.InterceptPublishMessage;
-import io.netty.buffer.ByteBuf;
-import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.UncheckedIOException;
-import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import java.util.zip.GZIPInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,13 +29,6 @@ public final class Broker {
 
   private static final Logger LOG = LoggerFactory.getLogger(Broker.class);
   private static final String LISTENER_ID = "MoquetteBroker";
-
-  /*
-   * Reserve topics that match the following pattern to be topics where text is sent as zipped bytes
-   * instead of plain UTF-8 bytes representing a text message.
-   */
-  private final Pattern zipTopicPattern =
-      Pattern.compile("\\A[^/]++/[^/]++/data/.++\\Z", Pattern.CASE_INSENSITIVE);
 
   private boolean running;
   private final IConfig config;
@@ -154,37 +137,11 @@ public final class Broker {
 
               @Override
               public void onPublish(final InterceptPublishMessage msg) {
-                String messageText;
-                if (Broker.this.zipTopicPattern.matcher(msg.getTopicName()).matches()) {
-                  messageText = unzip(getBytes(msg));
-                } else {
-                  messageText = new String(getBytes(msg), UTF_8);
-                }
-                LOG.info(
-                    "Broker received on topic: {} content: {}", msg.getTopicName(), messageText);
+                LOG.info("Broker received message published on topic: {}", msg.getTopicName());
               }
             }));
     this.running = true;
     LOG.info("Broker started press [CTRL+C] to stop");
-  }
-
-  private static byte[] getBytes(final InterceptPublishMessage msg) {
-    final ByteBuf buf = msg.getPayload();
-    final byte[] bytes = new byte[buf.readableBytes()];
-    final int readerIndex = buf.readerIndex();
-    buf.getBytes(readerIndex, bytes);
-    return bytes;
-  }
-
-  private static String unzip(final byte[] bytes) {
-    final ByteArrayInputStream inputStream = new ByteArrayInputStream(bytes);
-    try (BufferedReader reader =
-        new BufferedReader(
-            new InputStreamReader(new GZIPInputStream(inputStream), StandardCharsets.UTF_8))) {
-      return reader.lines().collect(Collectors.joining(System.lineSeparator()));
-    } catch (final IOException e) {
-      throw new UncheckedIOException("Can't unzip bytes to UTF-8 String", e);
-    }
   }
 
   private void handleShutdown(final Broker broker) {

--- a/osgp/protocol-adapter-mqtt/osgp-protocol-simulator-mqtt/src/main/java/org/opensmartgridplatform/simulator/protocol/mqtt/Client.java
+++ b/osgp/protocol-adapter-mqtt/osgp-protocol-simulator-mqtt/src/main/java/org/opensmartgridplatform/simulator/protocol/mqtt/Client.java
@@ -98,7 +98,7 @@ public abstract class Client extends Thread {
     Runtime.getRuntime().addShutdownHook(new Thread(this::stopClient));
   }
 
-  private void stopClient() {
+  protected void stopClient() {
     LOG.info("Stopping {} identified by {}", this.getClass().getSimpleName(), this.uuid);
     this.disconnect();
     this.running = false;

--- a/osgp/protocol-adapter-mqtt/osgp-protocol-simulator-mqtt/src/main/java/org/opensmartgridplatform/simulator/protocol/mqtt/SimulatorSpecPublishingClient.java
+++ b/osgp/protocol-adapter-mqtt/osgp-protocol-simulator-mqtt/src/main/java/org/opensmartgridplatform/simulator/protocol/mqtt/SimulatorSpecPublishingClient.java
@@ -42,6 +42,10 @@ public class SimulatorSpecPublishingClient extends Client {
     if (this.hasMessages()) {
       while (this.isRunning()) {
         final Message message = this.getNextMessage();
+        if (message == null) {
+          this.stopClient();
+          return;
+        }
         this.publish(client, message);
         this.pause(message.getPauseMillis());
       }
@@ -51,7 +55,11 @@ public class SimulatorSpecPublishingClient extends Client {
   private Message getNextMessage() {
     final Message[] messages = this.simulatorSpec.getMessages();
     if (this.i >= messages.length) {
-      this.i = 0;
+      if (this.simulatorSpec.keepReplayingMessages()) {
+        this.i = 0;
+      } else {
+        return null;
+      }
     }
     return messages[this.i++];
   }
@@ -80,7 +88,7 @@ public class SimulatorSpecPublishingClient extends Client {
         .publishWith()
         .topic(message.getTopic())
         .qos(MqttQos.AT_LEAST_ONCE)
-        .payload(message.getPayload().getBytes())
+        .payload(message.getPayloadAsBytes())
         .send();
   }
 }

--- a/osgp/protocol-adapter-mqtt/osgp-protocol-simulator-mqtt/src/main/java/org/opensmartgridplatform/simulator/protocol/mqtt/SimulatorSpecPublishingClient.java
+++ b/osgp/protocol-adapter-mqtt/osgp-protocol-simulator-mqtt/src/main/java/org/opensmartgridplatform/simulator/protocol/mqtt/SimulatorSpecPublishingClient.java
@@ -79,16 +79,15 @@ public class SimulatorSpecPublishingClient extends Client {
 
   public void publish(final Mqtt3BlockingClient client, final Message message) {
     LOG.debug(
-        "{} identified by {} is about to publish on topic {} with payload: {}",
+        "{} identified by {} is about to publish on topic {}",
         SimulatorSpecPublishingClient.class.getSimpleName(),
         this.uuid,
-        message.getTopic(),
-        message.getPayload());
+        message.getTopic());
     client
         .publishWith()
         .topic(message.getTopic())
         .qos(MqttQos.AT_LEAST_ONCE)
-        .payload(message.getPayloadAsBytes())
+        .payload(message.getPayload())
         .send();
   }
 }

--- a/osgp/protocol-adapter-mqtt/osgp-protocol-simulator-mqtt/src/main/java/org/opensmartgridplatform/simulator/protocol/mqtt/spec/Message.java
+++ b/osgp/protocol-adapter-mqtt/osgp-protocol-simulator-mqtt/src/main/java/org/opensmartgridplatform/simulator/protocol/mqtt/spec/Message.java
@@ -8,25 +8,15 @@
  */
 package org.opensmartgridplatform.simulator.protocol.mqtt.spec;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.charset.StandardCharsets;
-import java.util.regex.Pattern;
-import java.util.zip.GZIPOutputStream;
-
 public class Message {
 
-  private final Pattern zipTopicPattern =
-      Pattern.compile("\\Amsr/[^/]++/(?:data/.++)\\Z", Pattern.CASE_INSENSITIVE);
-
   private String topic;
-  private String payload;
+  private byte[] payload;
   private long pauseMillis;
 
   public Message() {}
 
-  public Message(final String topic, final String payload, final long pauseMillis) {
+  public Message(final String topic, final byte[] payload, final long pauseMillis) {
     this.topic = topic;
     this.payload = payload;
     this.pauseMillis = pauseMillis;
@@ -36,28 +26,11 @@ public class Message {
     return this.topic;
   }
 
-  public String getPayload() {
+  public byte[] getPayload() {
     return this.payload;
   }
 
   public long getPauseMillis() {
     return this.pauseMillis;
-  }
-
-  public byte[] getPayloadAsBytes() {
-    if (this.zipTopicPattern.matcher(this.topic).matches()) {
-      return this.zippedPayload();
-    }
-    return this.getPayload().getBytes(StandardCharsets.UTF_8);
-  }
-
-  private byte[] zippedPayload() {
-    final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-    try (GZIPOutputStream gzipOutputStream = new GZIPOutputStream(outputStream)) {
-      gzipOutputStream.write(this.payload.getBytes(StandardCharsets.UTF_8));
-    } catch (final IOException e) {
-      throw new UncheckedIOException(e);
-    }
-    return outputStream.toByteArray();
   }
 }

--- a/osgp/protocol-adapter-mqtt/osgp-protocol-simulator-mqtt/src/main/java/org/opensmartgridplatform/simulator/protocol/mqtt/spec/SimulatorSpec.java
+++ b/osgp/protocol-adapter-mqtt/osgp-protocol-simulator-mqtt/src/main/java/org/opensmartgridplatform/simulator/protocol/mqtt/spec/SimulatorSpec.java
@@ -14,6 +14,7 @@ public class SimulatorSpec {
   private int brokerPort;
   private int startupPauseMillis;
   private Message[] messages;
+  private boolean keepReplayingMessages = true;
 
   public SimulatorSpec() {
     // when instantiated from JSON
@@ -30,6 +31,14 @@ public class SimulatorSpec {
 
   public void setMessages(final Message[] messages) {
     this.messages = messages;
+  }
+
+  public void processMessagesOnlyOnce() {
+    this.keepReplayingMessages = false;
+  }
+
+  public boolean keepReplayingMessages() {
+    return this.keepReplayingMessages;
   }
 
   public String getBrokerHost() {


### PR DESCRIPTION
Prevents some issues handling MQTT messages by allowing messages from
certain topics to be considered as zipped.
Instead of creating a String from the bytes, in such cases an unzip
action is done first.

Adds support to the SimulatorSpecPublischingClient to only send the
messages from a spec once, instead of continuously replaying the same
messages over and over. This should enable Cucumber tests where step
data can have a message that should be sent only once.
