### PR TITLE
base-ws-smartmetering xsd available

### DIFF
--- a/osgp/shared/osgp-ws-smartmetering/src/main/java/org/opensmartgridplatform/ws/smartmetering/config/SmartmeteringWebServiceConfig.java
+++ b/osgp/shared/osgp-ws-smartmetering/src/main/java/org/opensmartgridplatform/ws/smartmetering/config/SmartmeteringWebServiceConfig.java
@@ -64,6 +64,11 @@ public class SmartmeteringWebServiceConfig {
     return payloadValidatingInterceptor;
   }
 
+  @Bean(name = "base-ws-smartmetering")
+  public SimpleXsdSchema baseWsSmartmeteringXsd() {
+    return new SimpleXsdSchema(new ClassPathResource(COMMON_XSD_PATH));
+  }
+
   @Bean(name = "common")
   public SimpleXsdSchema commonXsd() {
     return new SimpleXsdSchema(new ClassPathResource(COMMON_XSD_PATH));


### PR DESCRIPTION
Added a bean with the base schema and the correct bean name 'base-ws-smartmetering' to make the base xsd available.