### PR TITLE
Feature/osgp jasper interface cxf upgrade use apikey for rest

### DIFF
--- a/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/main/java/org/opensmartgridplatform/adapter/protocol/jasper/config/JasperWirelessAccess.java
+++ b/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/main/java/org/opensmartgridplatform/adapter/protocol/jasper/config/JasperWirelessAccess.java
@@ -15,6 +15,7 @@ public class JasperWirelessAccess {
 
   private String uri;
   private String licenseKey;
+  private String apiKey;
   private String username;
   private String password;
   private String apiVersion;
@@ -23,12 +24,14 @@ public class JasperWirelessAccess {
   public JasperWirelessAccess(
       final String uri,
       final String licenseKey,
+      final String apiKey,
       final String username,
       final String password,
       final String apiVersion,
       final String apiType) {
     this.uri = uri;
     this.licenseKey = licenseKey;
+    this.apiKey = apiKey;
     this.username = username;
     this.password = password;
     this.apiVersion = apiVersion;

--- a/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/main/java/org/opensmartgridplatform/adapter/protocol/jasper/config/JasperWirelessConfig.java
+++ b/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/main/java/org/opensmartgridplatform/adapter/protocol/jasper/config/JasperWirelessConfig.java
@@ -59,6 +59,9 @@ public class JasperWirelessConfig extends AbstractConfig {
   @Value("${jwcc.licensekey}")
   private String licenceKey;
 
+  @Value("${jwcc.apikey}")
+  private String apiKey;
+
   @Value("${jwcc.username}")
   private String username;
 
@@ -124,7 +127,13 @@ public class JasperWirelessConfig extends AbstractConfig {
   @Bean
   public JasperWirelessAccess jasperWirelessAccess() {
     return new JasperWirelessAccess(
-        this.uri, this.licenceKey, this.username, this.password, this.apiVersion, this.apiType);
+        this.uri,
+        this.licenceKey,
+        this.apiKey,
+        this.username,
+        this.password,
+        this.apiVersion,
+        this.apiType);
   }
 
   @Bean

--- a/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/main/java/org/opensmartgridplatform/adapter/protocol/jasper/rest/client/JasperWirelessRestClient.java
+++ b/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/main/java/org/opensmartgridplatform/adapter/protocol/jasper/rest/client/JasperWirelessRestClient.java
@@ -32,9 +32,7 @@ public class JasperWirelessRestClient {
       final JasperWirelessAccess jasperWirelessRestAccess) {
     return Base64.getEncoder()
         .encodeToString(
-            (jasperWirelessRestAccess.getUsername()
-                    + ":"
-                    + jasperWirelessRestAccess.getLicenseKey())
+            (jasperWirelessRestAccess.getUsername() + ":" + jasperWirelessRestAccess.getApiKey())
                 .getBytes());
   }
 

--- a/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/main/resources/jasper-interface.properties
+++ b/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/main/resources/jasper-interface.properties
@@ -3,6 +3,7 @@
 # =========================================================
 jwcc.uri.sms=https://localhost/smsService
 jwcc.licensekey=00000000-0000-0000-0000-000000000000
+jwcc.apikey=00000000-0000-0000-0000-000000000000
 jwcc.api.version=0.01
 jwcc.api.type=SOAP
 jwcc.username=TestUser

--- a/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/test/java/org/opensmartgridplatform/adapter/protocol/jasper/infra/ws/JasperWirelessTestConfig.java
+++ b/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/test/java/org/opensmartgridplatform/adapter/protocol/jasper/infra/ws/JasperWirelessTestConfig.java
@@ -33,6 +33,7 @@ public class JasperWirelessTestConfig {
   // JMS Settings
   private static final String PROPERTY_NAME_CONTROLCENTER_SMS_URI = "jwcc.uri.sms";
   private static final String PROPERTY_NAME_CONTROLCENTER_LICENSEKEY = "jwcc.licensekey";
+  private static final String PROPERTY_NAME_CONTROLCENTER_APIKEY = "jwcc.apikey";
   private static final String PROPERTY_NAME_CONTROLCENTER_USERNAME = "jwcc.username";
   private static final String PROPERTY_NAME_CONTROLCENTER_PASSWORD = "jwcc.password";
   private static final String PROPERTY_NAME_CONTROLCENTER_API_VERSION = "jwcc.api.version";
@@ -77,9 +78,10 @@ public class JasperWirelessTestConfig {
   public JasperWirelessAccess jwccWSConfig() {
     return new JasperWirelessAccess(
         this.environment.getRequiredProperty(PROPERTY_NAME_CONTROLCENTER_SMS_URI),
-        this.environment.getRequiredProperty(PROPERTY_NAME_CONTROLCENTER_LICENSEKEY),
+        this.environment.getProperty(PROPERTY_NAME_CONTROLCENTER_LICENSEKEY),
+        this.environment.getProperty(PROPERTY_NAME_CONTROLCENTER_APIKEY),
         this.environment.getRequiredProperty(PROPERTY_NAME_CONTROLCENTER_USERNAME),
-        this.environment.getRequiredProperty(PROPERTY_NAME_CONTROLCENTER_PASSWORD),
+        this.environment.getProperty(PROPERTY_NAME_CONTROLCENTER_PASSWORD),
         this.environment.getRequiredProperty(PROPERTY_NAME_CONTROLCENTER_API_VERSION),
         this.environment.getRequiredProperty(PROPERTY_NAME_CONTROLCENTER_API_TYPE));
   }

--- a/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/test/java/org/opensmartgridplatform/adapter/protocol/jasper/rest/client/JasperWirelessSmsRestClientTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/test/java/org/opensmartgridplatform/adapter/protocol/jasper/rest/client/JasperWirelessSmsRestClientTest.java
@@ -40,7 +40,7 @@ public class JasperWirelessSmsRestClientTest {
   private static final String SERVICE_SMS_SEND_SMS = "/rws/api/%s/devices/%s/smsMessages";
   private static final String ICCID = "12345";
   private static final String USERNAME = "user";
-  private static final String LICENCEKEY = "1234-abcd-5678-ef";
+  private static final String APIKEY = "1234-abcd-5678-ef";
   private static final int SMSMSGID = 67890;
   private static final String BASEURL = "http://localhost";
   private static final String APIVERSION = "v1";
@@ -59,7 +59,7 @@ public class JasperWirelessSmsRestClientTest {
     when(this.jasperWirelessAccess.getUri()).thenReturn(BASEURL);
     when(this.jasperWirelessAccess.getApiVersion()).thenReturn(APIVERSION);
     when(this.jasperWirelessAccess.getUsername()).thenReturn(USERNAME);
-    when(this.jasperWirelessAccess.getLicenseKey()).thenReturn(LICENCEKEY);
+    when(this.jasperWirelessAccess.getApiKey()).thenReturn(APIKEY);
   }
 
   @Test

--- a/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/test/java/org/opensmartgridplatform/adapter/protocol/jasper/rest/client/JasperWirelessTerminalRestClientTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/test/java/org/opensmartgridplatform/adapter/protocol/jasper/rest/client/JasperWirelessTerminalRestClientTest.java
@@ -40,7 +40,7 @@ public class JasperWirelessTerminalRestClientTest {
   private static final String SERVICE_GET_SESSION_INFO = "/rws/api/%s/devices/%s/sessionInfo";
   private static final String ICCID = "12345";
   private static final String USERNAME = "user";
-  private static final String LICENCEKEY = "1234-abcd-5678-ef";
+  private static final String APIKEY = "1234-abcd-5678-ef";
   private static final String BASEURL = "http://localhost:8081";
   private static final String APIVERSION = "v1";
   private static final String URL =
@@ -57,7 +57,7 @@ public class JasperWirelessTerminalRestClientTest {
     when(this.jasperWirelessAccess.getUri()).thenReturn(BASEURL);
     when(this.jasperWirelessAccess.getApiVersion()).thenReturn(APIVERSION);
     when(this.jasperWirelessAccess.getUsername()).thenReturn(USERNAME);
-    when(this.jasperWirelessAccess.getLicenseKey()).thenReturn(LICENCEKEY);
+    when(this.jasperWirelessAccess.getApiKey()).thenReturn(APIKEY);
   }
 
   @Test

--- a/super/pom.xml
+++ b/super/pom.xml
@@ -115,7 +115,7 @@
     <license.maven.plugin>3.0</license.maven.plugin>
     <jackson.version>2.13.3</jackson.version>
     <jackson-databind.version>2.13.3</jackson-databind.version>
-    <cxf.version>3.4.1</cxf.version>
+    <cxf.version>3.4.8</cxf.version>
     <quartz.version>2.3.2</quartz.version>
     <hikaricp.version>3.4.5</hikaricp.version>
     <micrometer.version>1.6.3</micrometer.version>


### PR DESCRIPTION
In this PR the REST client uses the _apikey_ configured in the properties.
_licensekey_ and _password_ are NOT used by the rest client.
The SOAP client does not use this newly added _apikey_.

The versions of cxf libraries are upgraded to 3.4.8 to solved class loading issues (apache's ReflectionUtil)
