### PR TITLE
Feature/kpn session enddate

### DIFF
--- a/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/main/java/org/opensmartgridplatform/adapter/protocol/jasper/rest/client/JasperWirelessSmsRestClient.java
+++ b/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/main/java/org/opensmartgridplatform/adapter/protocol/jasper/rest/client/JasperWirelessSmsRestClient.java
@@ -11,8 +11,8 @@ package org.opensmartgridplatform.adapter.protocol.jasper.rest.client;
 import org.opensmartgridplatform.adapter.protocol.jasper.client.JasperWirelessSmsClient;
 import org.opensmartgridplatform.adapter.protocol.jasper.config.JasperWirelessAccess;
 import org.opensmartgridplatform.adapter.protocol.jasper.exceptions.OsgpJasperException;
-import org.opensmartgridplatform.adapter.protocol.jasper.response.SendSMSResponse;
 import org.opensmartgridplatform.adapter.protocol.jasper.rest.json.SendSMSRequest;
+import org.opensmartgridplatform.adapter.protocol.jasper.rest.json.SendSMSResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -36,7 +36,8 @@ public class JasperWirelessSmsRestClient extends JasperWirelessRestClient
   @Autowired private short jasperGetValidityPeriod;
 
   @Override
-  public SendSMSResponse sendWakeUpSMS(final String iccId) throws OsgpJasperException {
+  public org.opensmartgridplatform.adapter.protocol.jasper.response.SendSMSResponse sendWakeUpSMS(
+      final String iccId) throws OsgpJasperException {
 
     final SendSMSRequest sendSMSRequest = new SendSMSRequest();
     sendSMSRequest.setMessageText("");
@@ -71,6 +72,7 @@ public class JasperWirelessSmsRestClient extends JasperWirelessRestClient
       throw new OsgpJasperException(e.getMessage(), e);
     }
 
-    return sendSmsResponse;
+    return new org.opensmartgridplatform.adapter.protocol.jasper.response.SendSMSResponse(
+        sendSmsResponse.getSmsMessageId());
   }
 }

--- a/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/main/java/org/opensmartgridplatform/adapter/protocol/jasper/rest/client/JasperWirelessSmsRestClient.java
+++ b/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/main/java/org/opensmartgridplatform/adapter/protocol/jasper/rest/client/JasperWirelessSmsRestClient.java
@@ -59,13 +59,14 @@ public class JasperWirelessSmsRestClient extends JasperWirelessRestClient
     headers.add(HttpHeaders.AUTHORIZATION, "Basic " + authorizationCredentials);
     final HttpEntity<SendSMSRequest> entity = new HttpEntity<>(sendSMSRequest, headers);
 
-    SendSMSResponse sendSmsResponse = null;
+    long smsMessageId = 0;
     try {
       final ResponseEntity<SendSMSResponse> sendSMSResponseEntity =
           this.jasperwirelessRestTemplate.exchange(
               url, HttpMethod.POST, entity, SendSMSResponse.class);
 
-      sendSmsResponse = sendSMSResponseEntity.getBody();
+      final SendSMSResponse sendSmsResponse = sendSMSResponseEntity.getBody();
+      smsMessageId = sendSmsResponse.getSmsMessageId();
     } catch (final HttpClientErrorException | HttpServerErrorException e) {
       this.handleException(e);
     } catch (final RestClientException e) {
@@ -73,6 +74,6 @@ public class JasperWirelessSmsRestClient extends JasperWirelessRestClient
     }
 
     return new org.opensmartgridplatform.adapter.protocol.jasper.response.SendSMSResponse(
-        sendSmsResponse.getSmsMessageId());
+        smsMessageId);
   }
 }

--- a/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/main/java/org/opensmartgridplatform/adapter/protocol/jasper/rest/client/JasperWirelessTerminalRestClient.java
+++ b/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/main/java/org/opensmartgridplatform/adapter/protocol/jasper/rest/client/JasperWirelessTerminalRestClient.java
@@ -58,9 +58,7 @@ public class JasperWirelessTerminalRestClient extends JasperWirelessRestClient
           this.jasperwirelessRestTemplate.exchange(
               url, HttpMethod.GET, entity, GetSessionInfoResponse.class);
 
-      getSessionInfoResponse = getSessionInfoResponseEntity.getBody();
-
-      getSessionInfoResponse = this.checkOnSessionValidity(getSessionInfoResponse);
+      getSessionInfoResponse = this.checkOnSessionValidity(getSessionInfoResponseEntity);
 
     } catch (final HttpClientErrorException | HttpServerErrorException e) {
       this.handleException(e);
@@ -71,7 +69,7 @@ public class JasperWirelessTerminalRestClient extends JasperWirelessRestClient
   }
 
   private GetSessionInfoResponse checkOnSessionValidity(
-      final GetSessionInfoResponse getSessionInfoResponse) {
+      final ResponseEntity<GetSessionInfoResponse> getSessionInfoResponseEntity) {
     // To simulated to same behaviour as the SOAP interface. Session info of an expired session is
     // removed form the response.
     // REST-interface returns information about the current or most recent data session for a given
@@ -79,6 +77,7 @@ public class JasperWirelessTerminalRestClient extends JasperWirelessRestClient
     // SOAP-interface returns the current session information (IP address and session start time)
     // for one or more devices. If the specified device is not in session, no information is
     // returned.
+    final GetSessionInfoResponse getSessionInfoResponse = getSessionInfoResponseEntity.getBody();
     if (this.hasCurrentSession(getSessionInfoResponse)) {
       return getSessionInfoResponse;
     } else {

--- a/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/main/java/org/opensmartgridplatform/adapter/protocol/jasper/rest/json/SendSMSResponse.java
+++ b/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/main/java/org/opensmartgridplatform/adapter/protocol/jasper/rest/json/SendSMSResponse.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 Alliander N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.opensmartgridplatform.adapter.protocol.jasper.rest.json;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SendSMSResponse {
+
+  private long smsMessageId;
+
+  public SendSMSResponse() {}
+
+  public SendSMSResponse(final long smsMessageId) {
+    this.smsMessageId = smsMessageId;
+  }
+}

--- a/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/test/java/org/opensmartgridplatform/adapter/protocol/jasper/rest/client/JasperWirelessSmsRestClientTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/test/java/org/opensmartgridplatform/adapter/protocol/jasper/rest/client/JasperWirelessSmsRestClientTest.java
@@ -25,7 +25,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensmartgridplatform.adapter.protocol.jasper.config.JasperWirelessAccess;
 import org.opensmartgridplatform.adapter.protocol.jasper.exceptions.OsgpJasperException;
-import org.opensmartgridplatform.adapter.protocol.jasper.response.SendSMSResponse;
+import org.opensmartgridplatform.adapter.protocol.jasper.rest.json.SendSMSResponse;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
@@ -69,7 +69,8 @@ public class JasperWirelessSmsRestClientTest {
             eq(URL), eq(HttpMethod.POST), any(HttpEntity.class), eq(SendSMSResponse.class)))
         .thenReturn(this.createResponseEntity(HttpStatus.OK));
 
-    final SendSMSResponse sendSMSResponse = this.jasperWirelessSmsRestClient.sendWakeUpSMS(ICCID);
+    final org.opensmartgridplatform.adapter.protocol.jasper.response.SendSMSResponse
+        sendSMSResponse = this.jasperWirelessSmsRestClient.sendWakeUpSMS(ICCID);
 
     assertEquals(SMSMSGID, sendSMSResponse.getSmsMsgId());
   }


### PR DESCRIPTION
The GetSessionInfo request functionally differ between REST and SOAP interfaces of JasperWireless
- REST-interface returns information about the current **or most recent data session** for a given device.
- SOAP-interface returns the current session information (IP address and session start time) for one or more devices. If the specified device is **not in session, no information** is returned.

Furthermore the SendSmsResponse of the REST interface returns in contradiction to the documentation a  **_smsMessageId_** insteadof a **_smsMsgId_**