### PR TITLE
SMHE-1203: Prevent changes to firmware file in cache

### DIFF
--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/repositories/ByteArrayCachingRepository.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/repositories/ByteArrayCachingRepository.java
@@ -36,8 +36,14 @@ public abstract class ByteArrayCachingRepository implements CachingRepository<St
 
   @Override
   public byte[] retrieve(final String key) {
-    // To make sure the byte array in the cache is not changed accidentally, return a copy
-    return this.cache.get(key).clone();
+    final byte[] byteArray = this.cache.get(key);
+
+    if (byteArray != null) {
+      // To make sure the byte array in the cache is not changed accidentally, return a copy
+      return this.cache.get(key).clone();
+    } else {
+      return null;
+    }
   }
 
   @Override

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/repositories/ByteArrayCachingRepository.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/repositories/ByteArrayCachingRepository.java
@@ -36,7 +36,8 @@ public abstract class ByteArrayCachingRepository implements CachingRepository<St
 
   @Override
   public byte[] retrieve(final String key) {
-    return this.cache.get(key);
+    // To make sure the byte array in the cache is not changed accidentally, return a copy
+    return this.cache.get(key).clone();
   }
 
   @Override

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/repositories/ByteArrayCachingRepository.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/repositories/ByteArrayCachingRepository.java
@@ -35,10 +35,11 @@ public abstract class ByteArrayCachingRepository implements CachingRepository<St
   }
 
   @Override
+  // Sonar warning is suppressed, because when the key is not found, this function should return
+  // null and not an empty array (which could be a valid array stored in the cache).
+  @SuppressWarnings("java:S1168")
   public byte[] retrieve(final String key) {
-    final byte[] byteArray = this.cache.get(key);
-
-    if (byteArray != null) {
+    if (this.cache.containsKey(key)) {
       // To make sure the byte array in the cache is not changed accidentally, return a copy
       return this.cache.get(key).clone();
     } else {

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/repositories/FirmwareFileCachingRepositoryTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/repositories/FirmwareFileCachingRepositoryTest.java
@@ -15,7 +15,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class FirmwareFileCachingRepositoryTest {
+class FirmwareFileCachingRepositoryTest {
 
   private static final String FIRMWARE_IDENTIFICATION_UNAVAILABLE = "unavailable";
   private static final String FIRMWARE_IDENTIFICATION = "fw";
@@ -32,7 +32,7 @@ public class FirmwareFileCachingRepositoryTest {
   }
 
   @Test
-  public void isAvailableShouldReturnTrueWhenFirmwareFileInCache() {
+  void isAvailableShouldReturnTrueWhenFirmwareFileInCache() {
     // Arrange
 
     // Act
@@ -43,7 +43,7 @@ public class FirmwareFileCachingRepositoryTest {
   }
 
   @Test
-  public void isAvailableShouldReturnFalseWhenFirmwareFileNotInCache() {
+  void isAvailableShouldReturnFalseWhenFirmwareFileNotInCache() {
     // Arrange
 
     // Act
@@ -55,7 +55,7 @@ public class FirmwareFileCachingRepositoryTest {
   }
 
   @Test
-  public void retrieveShouldReturnFirmwareFileWhenFirmwareFileInCache() {
+  void retrieveShouldReturnFirmwareFileWhenFirmwareFileInCache() {
     // Arrange
     final byte[] expected = FIRMWARE_FILE;
 
@@ -67,7 +67,7 @@ public class FirmwareFileCachingRepositoryTest {
   }
 
   @Test
-  public void retrieveShouldReturnCopyOfFirmwareFile() {
+  void retrieveShouldReturnCopyOfFirmwareFile() {
     // Arrange
     final byte[] expected = FIRMWARE_FILE;
     final byte[] actual = this.firmwareFileCachingRepostitory.retrieve(FIRMWARE_IDENTIFICATION);
@@ -82,7 +82,7 @@ public class FirmwareFileCachingRepositoryTest {
   }
 
   @Test
-  public void retrieveShouldReturnNullWhenFirmwareFileNotInCache() {
+  void retrieveShouldReturnNullWhenFirmwareFileNotInCache() {
     // Arrange
     // Nothing to do
 
@@ -95,7 +95,7 @@ public class FirmwareFileCachingRepositoryTest {
   }
 
   @Test
-  public void storeShouldAddFirmwareFileToCache() {
+  void storeShouldAddFirmwareFileToCache() {
     // Arrange
     final String firmwareIdentificationToAdd = "fw-to-add";
     final byte[] firmwareFileToAdd = firmwareIdentificationToAdd.getBytes();

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/repositories/FirmwareFileCachingRepositoryTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/repositories/FirmwareFileCachingRepositoryTest.java
@@ -67,6 +67,21 @@ public class FirmwareFileCachingRepositoryTest {
   }
 
   @Test
+  public void retrieveShouldReturnCopyOfFirmwareFile() {
+    // Arrange
+    final byte[] expected = FIRMWARE_FILE;
+    final byte[] actual = this.firmwareFileCachingRepostitory.retrieve(FIRMWARE_IDENTIFICATION);
+    actual[0]++; // Change the first byte in the retrieved array
+
+    // Act
+    // When the file is retrieved again, it should be the original file
+    final byte[] actual2 = this.firmwareFileCachingRepostitory.retrieve(FIRMWARE_IDENTIFICATION);
+
+    // Assert
+    assertThat(actual2).isEqualTo(expected);
+  }
+
+  @Test
   public void retrieveShouldReturnNullWhenFirmwareFileNotInCache() {
     // Arrange
     // Nothing to do


### PR DESCRIPTION
In the update firmware process for g-meters, it's necessary to update some parts of the header of the firmware file. These changes should not be updated in the cache for firmware files, since it can cause problems in the next firmware update with the same file. The solution is to make the caching repositoty return a copy of the byte array.

Signed-off-by: stefanermens <stefan.ermens@alliander.com>