### PR TITLE
SMHE-1217: Use integer parameter in calendar activation

### DIFF
--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/datetime/SetActivityCalendarCommandActivationExecutor.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/datetime/SetActivityCalendarCommandActivationExecutor.java
@@ -50,7 +50,7 @@ public class SetActivityCalendarCommandActivationExecutor
             CLASS_ID,
             OBIS_CODE,
             METHOD_ID_ACTIVATE_PASSIVE_CALENDAR,
-            DataObject.newInteger32Data(0));
+            DataObject.newInteger8Data((byte) 0));
 
     conn.getDlmsMessageListener()
         .setDescription(

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/datetime/SetActivityCalendarCommandActivationExecutorTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/datetime/SetActivityCalendarCommandActivationExecutorTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2022 Alliander N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.datetime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.openmuc.jdlms.DlmsConnection;
+import org.openmuc.jdlms.MethodParameter;
+import org.openmuc.jdlms.MethodResult;
+import org.openmuc.jdlms.MethodResultCode;
+import org.openmuc.jdlms.ObisCode;
+import org.openmuc.jdlms.datatypes.DataObject.Type;
+import org.opensmartgridplatform.adapter.protocol.dlms.domain.entities.DlmsDevice;
+import org.opensmartgridplatform.adapter.protocol.dlms.domain.factories.DlmsConnectionManager;
+import org.opensmartgridplatform.adapter.protocol.dlms.exceptions.ProtocolAdapterException;
+import org.opensmartgridplatform.adapter.protocol.dlms.infra.messaging.DlmsMessageListener;
+import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
+
+@ExtendWith(MockitoExtension.class)
+class SetActivityCalendarCommandActivationExecutorTest {
+
+  private static final int CLASS_ID = 20;
+  private static final ObisCode OBIS_CODE = new ObisCode("0.0.13.0.0.255");
+  private static final int METHOD_ID_ACTIVATE_PASSIVE_CALENDAR = 1;
+
+  private final DlmsDevice DLMS_DEVICE = new DlmsDevice();
+
+  @Captor ArgumentCaptor<MethodParameter> actionParameterArgumentCaptor;
+
+  @Mock private DlmsConnectionManager conn;
+
+  @Mock private DlmsMessageListener dlmsMessageListener;
+
+  @Mock private DlmsConnection dlmsConnection;
+
+  @Mock private MessageMetadata messageMetadata;
+
+  @Mock private MethodResult methodResult;
+
+  private SetActivityCalendarCommandActivationExecutor executor;
+
+  @BeforeEach
+  public void setUp() throws IOException {
+    this.executor = new SetActivityCalendarCommandActivationExecutor();
+    when(this.conn.getDlmsMessageListener()).thenReturn(this.dlmsMessageListener);
+    when(this.conn.getConnection()).thenReturn(this.dlmsConnection);
+    when(this.dlmsConnection.action(any(MethodParameter.class))).thenReturn(this.methodResult);
+  }
+
+  @Test
+  void testActivationWithSuccess() throws ProtocolAdapterException, IOException {
+
+    // SETUP
+    when(this.methodResult.getResultCode()).thenReturn(MethodResultCode.SUCCESS);
+
+    // CALL
+    final MethodResultCode resultCode =
+        this.executor.execute(this.conn, this.DLMS_DEVICE, null, this.messageMetadata);
+
+    // VERIFY
+    assertThat(resultCode).isEqualTo(MethodResultCode.SUCCESS);
+    verify(this.dlmsConnection, times(1)).action(this.actionParameterArgumentCaptor.capture());
+
+    final MethodParameter methodParameter = this.actionParameterArgumentCaptor.getValue();
+    assertThat(methodParameter.getClassId()).isEqualTo(CLASS_ID);
+    assertThat(methodParameter.getInstanceId()).isEqualTo(OBIS_CODE);
+    assertThat(methodParameter.getId()).isEqualTo(METHOD_ID_ACTIVATE_PASSIVE_CALENDAR);
+    assertThat(methodParameter.getParameter().getType()).isEqualTo(Type.INTEGER);
+    assertThat((byte) methodParameter.getParameter().getValue()).isZero();
+  }
+
+  @Test
+  void testActivationWithFailure() throws IOException {
+
+    // SETUP
+    when(this.methodResult.getResultCode()).thenReturn(MethodResultCode.OTHER_REASON);
+
+    // CALL
+    assertThrows(
+        ProtocolAdapterException.class,
+        () -> {
+          this.executor.execute(this.conn, this.DLMS_DEVICE, null, this.messageMetadata);
+        });
+
+    // VERIFY
+    verify(this.dlmsConnection, times(1)).action(this.actionParameterArgumentCaptor.capture());
+
+    final MethodParameter methodParameter = this.actionParameterArgumentCaptor.getValue();
+    assertThat(methodParameter.getClassId()).isEqualTo(CLASS_ID);
+    assertThat(methodParameter.getInstanceId()).isEqualTo(OBIS_CODE);
+    assertThat(methodParameter.getId()).isEqualTo(METHOD_ID_ACTIVATE_PASSIVE_CALENDAR);
+    assertThat(methodParameter.getParameter().getType()).isEqualTo(Type.INTEGER);
+    assertThat((byte) methodParameter.getParameter().getValue()).isZero();
+  }
+}

--- a/osgp/protocol-adapter-dlms/osgp-protocol-simulator-dlms/simulator/dlms-device-simulator/src/main/java/org/opensmartgridplatform/simulator/protocol/dlms/cosem/ActivityCalendar.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-simulator-dlms/simulator/dlms-device-simulator/src/main/java/org/opensmartgridplatform/simulator/protocol/dlms/cosem/ActivityCalendar.java
@@ -19,31 +19,31 @@ import org.openmuc.jdlms.datatypes.DataObject.Type;
 public class ActivityCalendar extends CosemInterfaceObject {
 
   @CosemAttribute(id = 2, type = Type.OCTET_STRING)
-  private DataObject calendarNameActive;
+  private final DataObject calendarNameActive;
 
   @CosemAttribute(id = 3, type = Type.ARRAY)
-  private DataObject seasonProfileActive;
+  private final DataObject seasonProfileActive;
 
   @CosemAttribute(id = 4, type = Type.ARRAY)
-  private DataObject weekProfileTableActive;
+  private final DataObject weekProfileTableActive;
 
   @CosemAttribute(id = 5, type = Type.ARRAY)
-  private DataObject dayProfileTableActive;
+  private final DataObject dayProfileTableActive;
 
   @CosemAttribute(id = 6, type = Type.OCTET_STRING)
-  private DataObject calendarNamePassive;
+  private final DataObject calendarNamePassive;
 
   @CosemAttribute(id = 7, type = Type.ARRAY)
-  private DataObject seasonProfilePassive;
+  private final DataObject seasonProfilePassive;
 
   @CosemAttribute(id = 8, type = Type.ARRAY)
-  private DataObject weekProfileTablePassive;
+  private final DataObject weekProfileTablePassive;
 
   @CosemAttribute(id = 9, type = Type.ARRAY)
-  private DataObject dayProfileTablePassive;
+  private final DataObject dayProfileTablePassive;
 
   @CosemAttribute(id = 10, type = Type.OCTET_STRING)
-  private DataObject activatePassiveCalendarTime;
+  private final DataObject activatePassiveCalendarTime;
 
   public ActivityCalendar() {
     super("0.0.13.0.0.255");
@@ -58,7 +58,7 @@ public class ActivityCalendar extends CosemInterfaceObject {
     this.activatePassiveCalendarTime = DataObject.newNullData();
   }
 
-  @CosemMethod(id = 1, consumes = Type.DOUBLE_LONG)
+  @CosemMethod(id = 1, consumes = Type.INTEGER)
   public void activatePassiveCalendar(final DataObject param) {
     // No simulation of action at this point.
   }


### PR DESCRIPTION
When activating an activity calendar, the command executor used a parameter with type double-long. The DLMS blue book specifies that this should be an integer instead. The datatype in the simulator is updated as well.

Signed-off-by: stefanermens <stefan.ermens@alliander.com>