### PR TITLE
SMHE-1190-pending-scheduled-tasks-are-never-cleaned-up

### DIFF
--- a/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/application/config/ScheduledTaskExecutorJobConfig.java
+++ b/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/application/config/ScheduledTaskExecutorJobConfig.java
@@ -30,11 +30,19 @@ public class ScheduledTaskExecutorJobConfig {
   @Value("${scheduling.task.page.size}")
   private int scheduledTaskPageSize;
 
+  @Value("${scheduling.task.pending.duration.max.seconds:3600}")
+  private int scheduledTaskPendingDurationMaxSeconds;
+
   @Autowired private OsgpScheduler osgpScheduler;
 
   @Bean
   public int scheduledTaskPageSize() {
     return this.scheduledTaskPageSize;
+  }
+
+  @Bean
+  public long scheduledTaskPendingDurationMaxSeconds() {
+    return this.scheduledTaskPendingDurationMaxSeconds;
   }
 
   @PostConstruct

--- a/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/application/tasks/ScheduledTaskExecutorService.java
+++ b/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/application/tasks/ScheduledTaskExecutorService.java
@@ -9,7 +9,11 @@
 package org.opensmartgridplatform.core.application.tasks;
 
 import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.opensmartgridplatform.core.application.config.ScheduledTaskExecutorJobConfig;
 import org.opensmartgridplatform.core.application.services.DeviceRequestMessageService;
 import org.opensmartgridplatform.domain.core.entities.Device;
@@ -41,11 +45,47 @@ public class ScheduledTaskExecutorService {
   @Autowired private ScheduledTaskExecutorJobConfig scheduledTaskExecutorJobConfig;
 
   public void processScheduledTasks() {
+    this.processStrandedScheduledTasks();
     this.processScheduledTasks(ScheduledTaskStatusType.NEW);
     this.processScheduledTasks(ScheduledTaskStatusType.RETRY);
   }
 
+  private void processStrandedScheduledTasks() {
+    final List<ScheduledTask> scheduledTasks =
+        this.getScheduledTasks(ScheduledTaskStatusType.PENDING);
+    final List<ScheduledTask> strandedScheduledTasks =
+        scheduledTasks.stream()
+            .filter(
+                st ->
+                    st.getModificationTimeInstant()
+                        .isBefore(
+                            Instant.now()
+                                .minus(
+                                    this.scheduledTaskExecutorJobConfig
+                                        .scheduledTaskPendingDurationMaxSeconds(),
+                                    ChronoUnit.SECONDS)))
+            .collect(Collectors.toList());
+    strandedScheduledTasks.forEach(
+        sst -> {
+          if (this.maxScheduledTimeNotExceeded(sst)) {
+            sst.retryOn(new Date());
+          } else {
+            sst.setFailed("No response receive for scheduled task");
+          }
+          this.scheduledTaskRepository.save(sst);
+        });
+  }
+
+  private boolean maxScheduledTimeNotExceeded(final ScheduledTask sst) {
+    return sst.getMaxScheduleTime() == null
+        || sst.getMaxScheduleTime().getTime() > System.currentTimeMillis();
+  }
+
   private void processScheduledTasks(final ScheduledTaskStatusType type) {
+    /*
+     * Fetch scheduled tasks for given scheduledTaskStatusTypes: NEW and RETRY. The processed tasks
+     * are set to PENDING, so they will not be fetched by this method.
+     */
     List<ScheduledTask> scheduledTasks = this.getScheduledTasks(type);
 
     while (!scheduledTasks.isEmpty()) {
@@ -70,9 +110,6 @@ public class ScheduledTaskExecutorService {
   }
 
   /**
-   * Fetch scheduled tasks for given scheduledTaskStatusTypes: NEW and RETRY. The processed tasks
-   * are set to PENDING, so they will not be fetched by this method.
-   *
    * @param type ScheduledTaskStatusType (NEW, PENDING, COMPLETE, FAILED, RETRY)
    * @return List of ScheduledTasks, paged
    */

--- a/osgp/platform/osgp-core/src/test/java/org/opensmartgridplatform/core/application/tasks/ScheduledTaskExecutorServiceTest.java
+++ b/osgp/platform/osgp-core/src/test/java/org/opensmartgridplatform/core/application/tasks/ScheduledTaskExecutorServiceTest.java
@@ -154,7 +154,7 @@ public class ScheduledTaskExecutorServiceTest {
 
   private MessageMetadata createMessageMetadata() {
     return this.createMessageMetadataBuilder()
-        .withDeviceIdentification("deviceId-retryabl")
+        .withDeviceIdentification("deviceId-retryable")
         .build();
   }
 

--- a/osgp/platform/osgp-core/src/test/java/org/opensmartgridplatform/core/application/tasks/ScheduledTaskExecutorServiceTest.java
+++ b/osgp/platform/osgp-core/src/test/java/org/opensmartgridplatform/core/application/tasks/ScheduledTaskExecutorServiceTest.java
@@ -142,7 +142,7 @@ public class ScheduledTaskExecutorServiceTest {
     assertThat(savedScheduledTasks.get(0).getDeviceIdentification()).isEqualTo("deviceId-expired");
 
     assertThat(savedScheduledTasks.get(1).getStatus()).isEqualTo(ScheduledTaskStatusType.RETRY);
-    assertThat(savedScheduledTasks.get(1).getDeviceIdentification()).isEqualTo("deviceId-retryabl");
+    assertThat(savedScheduledTasks.get(1).getDeviceIdentification()).isEqualTo("deviceId-retryable");
   }
 
   private MessageMetadata createExpiredMessageMetadata() {

--- a/osgp/platform/osgp-core/src/test/java/org/opensmartgridplatform/core/application/tasks/ScheduledTaskExecutorServiceTest.java
+++ b/osgp/platform/osgp-core/src/test/java/org/opensmartgridplatform/core/application/tasks/ScheduledTaskExecutorServiceTest.java
@@ -79,7 +79,7 @@ public class ScheduledTaskExecutorServiceTest {
   void testRunFunctionalException()
       throws FunctionalException, UnknownHostException, JobExecutionException {
     final List<ScheduledTask> scheduledTasks = new ArrayList<>();
-    final Timestamp scheduledTime = new Timestamp(Calendar.getInstance().getTime().getTime());
+    final Timestamp scheduledTime = new Timestamp(System.currentTimeMillis());
     final ScheduledTask scheduledTask =
         new ScheduledTask(this.createMessageMetadata(), DOMAIN, DOMAIN, DATA_OBJECT, scheduledTime);
     scheduledTasks.add(scheduledTask);

--- a/osgp/platform/osgp-core/src/test/java/org/opensmartgridplatform/core/application/tasks/ScheduledTaskExecutorServiceTest.java
+++ b/osgp/platform/osgp-core/src/test/java/org/opensmartgridplatform/core/application/tasks/ScheduledTaskExecutorServiceTest.java
@@ -76,7 +76,7 @@ public class ScheduledTaskExecutorServiceTest {
    * @throws JobExecutionException
    */
   @Test
-  public void testRunFunctionalException()
+  void testRunFunctionalException()
       throws FunctionalException, UnknownHostException, JobExecutionException {
     final List<ScheduledTask> scheduledTasks = new ArrayList<>();
     final Timestamp scheduledTime = new Timestamp(Calendar.getInstance().getTime().getTime());
@@ -106,7 +106,7 @@ public class ScheduledTaskExecutorServiceTest {
   }
 
   @Test
-  public void testRetryStrandedPendingTask() {
+  void testRetryStrandedPendingTask() {
 
     final List<ScheduledTask> scheduledTasks = new ArrayList<>();
     final Timestamp scheduledTime = new Timestamp(Calendar.getInstance().getTime().getTime());


### PR DESCRIPTION
_ScheduledTask_ s in **PENDING** state which will for some reason not receive response remain in state PENDING forever. By setting the state to **RETRY** with immediate schedule time _ScheduledTask_ s will be processed again. The state will be reset after a configurable duration (_scheduling.task.pending.duration.max.seconds:3600_). If the _MaxScheduledTime_ has been exceeded the _ScheduledTask_'s state will be reset to **FAILED**

Signed-off-by: Harry Middelburg <harry.middelburg@alliander.com>