### PR TITLE
SMHE-1267 Missing PQ data

### DIFF
--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/monitoring/GetPowerQualityProfileNoSelectiveAccessHandler.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/monitoring/GetPowerQualityProfileNoSelectiveAccessHandler.java
@@ -9,8 +9,8 @@
 package org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.monitoring;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import org.openmuc.jdlms.datatypes.DataObject;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.utils.DlmsHelper;
 import org.opensmartgridplatform.dlms.services.ObjectConfigService;
@@ -31,7 +31,7 @@ public class GetPowerQualityProfileNoSelectiveAccessHandler
   protected List<ProfileEntryValueDto> createProfileEntryValueDto(
       final DataObject profileEntryDataObject,
       final ProfileEntryDto previousProfileEntryDto,
-      final Map<Integer, SelectableObject> selectableCaptureObjects,
+      final LinkedHashMap<Integer, SelectableObject> selectedObjects,
       final int timeInterval) {
 
     final List<ProfileEntryValueDto> result = new ArrayList<>();
@@ -39,13 +39,13 @@ public class GetPowerQualityProfileNoSelectiveAccessHandler
 
     for (int i = 0; i < dataObjects.size(); i++) {
 
-      if (selectableCaptureObjects.containsKey(i)) {
+      // The values are retrieved without selective access, so the meter could have returned more
+      // values than we need. Only the values that are present in the selectedObjects should be
+      // returned.
+      if (selectedObjects.containsKey(i)) {
         final ProfileEntryValueDto currentProfileEntryValueDto =
             this.makeProfileEntryValueDto(
-                dataObjects.get(i),
-                selectableCaptureObjects.get(i),
-                previousProfileEntryDto,
-                timeInterval);
+                dataObjects.get(i), selectedObjects.get(i), previousProfileEntryDto, timeInterval);
         result.add(currentProfileEntryValueDto);
       }
     }

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/monitoring/GetPowerQualityProfileSelectiveAccessHandler.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/monitoring/GetPowerQualityProfileSelectiveAccessHandler.java
@@ -10,8 +10,8 @@ package org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.monitori
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import org.openmuc.jdlms.datatypes.DataObject;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.utils.DlmsHelper;
 import org.opensmartgridplatform.dlms.services.ObjectConfigService;
@@ -32,20 +32,22 @@ public class GetPowerQualityProfileSelectiveAccessHandler
   protected List<ProfileEntryValueDto> createProfileEntryValueDto(
       final DataObject profileEntryDataObject,
       final ProfileEntryDto previousProfileEntryDto,
-      final Map<Integer, SelectableObject> selectableCaptureObjects,
+      final LinkedHashMap<Integer, SelectableObject> selectedObjects,
       final int timeInterval) {
 
     final List<ProfileEntryValueDto> result = new ArrayList<>();
     final List<DataObject> dataObjects = profileEntryDataObject.getValue();
 
-    for (int i = 0; i < dataObjects.size(); i++) {
-      if (selectableCaptureObjects.get(i) != null) {
+    // The values are retrieved using selective access, so we should have the same amount of
+    // selectedObjects. Since we use a LinkedHashMap the selectedObjects are in the right order
+    // and we can simply iterate over them.
+    final var iterator = selectedObjects.entrySet().iterator();
+
+    for (final DataObject dataObject : dataObjects) {
+      if (iterator.hasNext()) {
         final ProfileEntryValueDto currentProfileEntryValueDto =
             super.makeProfileEntryValueDto(
-                dataObjects.get(i),
-                selectableCaptureObjects.get(i),
-                previousProfileEntryDto,
-                timeInterval);
+                dataObject, iterator.next().getValue(), previousProfileEntryDto, timeInterval);
         result.add(currentProfileEntryValueDto);
       }
     }

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/monitoring/GetPowerQualityProfileNoSelectiveAccessHandlerTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/monitoring/GetPowerQualityProfileNoSelectiveAccessHandlerTest.java
@@ -86,7 +86,8 @@ class GetPowerQualityProfileNoSelectiveAccessHandlerTest extends GetPowerQuality
             this.createProfile(PQ_PROFILE_2, "POWER_QUALITY_PROFILE_2", PQ_PROFILE_2_INTERVAL));
     when(this.objectConfigService.getCosemObject(
             PROTOCOL_NAME, PROTOCOL_VERSION, POWER_QUALITY_PROFILE_1))
-        .thenReturn(this.createProfile(PQ_DEFINABLE, "DEFINABLE_LOAD_PROFILE", PQ_DEFINABLE_INTERVAL));
+        .thenReturn(
+            this.createProfile(PQ_DEFINABLE, "DEFINABLE_LOAD_PROFILE", PQ_DEFINABLE_INTERVAL));
     when(this.objectConfigService.getCosemObject(
             PROTOCOL_NAME, PROTOCOL_VERSION, DEFINABLE_LOAD_PROFILE))
         .thenReturn(
@@ -107,7 +108,7 @@ class GetPowerQualityProfileNoSelectiveAccessHandlerTest extends GetPowerQuality
             any(DlmsDevice.class),
             eq("retrieve profile generic buffer"),
             any(AttributeAddress.class)))
-        .thenReturn(this.createProfileEntries());
+        .thenReturn(this.createProfileEntries(false));
 
     // EXECUTE
     final GetPowerQualityProfileNoSelectiveAccessHandler handler =
@@ -144,7 +145,8 @@ class GetPowerQualityProfileNoSelectiveAccessHandlerTest extends GetPowerQuality
             this.createProfile(PQ_PROFILE_2, "POWER_QUALITY_PROFILE_2", PQ_PROFILE_2_INTERVAL));
     when(this.objectConfigService.getCosemObject(
             PROTOCOL_NAME, PROTOCOL_VERSION, POWER_QUALITY_PROFILE_1))
-        .thenReturn(this.createProfile(PQ_DEFINABLE, "DEFINABLE_LOAD_PROFILE", PQ_DEFINABLE_INTERVAL));
+        .thenReturn(
+            this.createProfile(PQ_DEFINABLE, "DEFINABLE_LOAD_PROFILE", PQ_DEFINABLE_INTERVAL));
     when(this.objectConfigService.getCosemObject(
             PROTOCOL_NAME, PROTOCOL_VERSION, DEFINABLE_LOAD_PROFILE))
         .thenReturn(

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/monitoring/GetPowerQualityProfileNoSelectiveAccessHandlerTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/monitoring/GetPowerQualityProfileNoSelectiveAccessHandlerTest.java
@@ -10,15 +10,19 @@ package org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.monitori
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
-import static org.opensmartgridplatform.dlms.objectconfig.DlmsObjectType.*;
+import static org.opensmartgridplatform.dlms.objectconfig.DlmsObjectType.DEFINABLE_LOAD_PROFILE;
+import static org.opensmartgridplatform.dlms.objectconfig.DlmsObjectType.POWER_QUALITY_PROFILE_1;
+import static org.opensmartgridplatform.dlms.objectconfig.DlmsObjectType.POWER_QUALITY_PROFILE_2;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -28,53 +32,42 @@ import org.openmuc.jdlms.AttributeAddress;
 import org.openmuc.jdlms.GetResult;
 import org.openmuc.jdlms.datatypes.DataObject;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.testutil.GetResultImpl;
-import org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.testutil.ObjectConfigServiceHelper;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.utils.DlmsHelper;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.entities.DlmsDevice;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.factories.DlmsConnectionManager;
 import org.opensmartgridplatform.adapter.protocol.dlms.exceptions.ProtocolAdapterException;
 import org.opensmartgridplatform.dlms.exceptions.ObjectConfigException;
-import org.opensmartgridplatform.dlms.objectconfig.*;
+import org.opensmartgridplatform.dlms.objectconfig.CosemObject;
+import org.opensmartgridplatform.dlms.objectconfig.PowerQualityProfile;
 import org.opensmartgridplatform.dlms.services.ObjectConfigService;
-import org.opensmartgridplatform.dto.valueobjects.smartmetering.CaptureObjectDto;
 import org.opensmartgridplatform.dto.valueobjects.smartmetering.GetPowerQualityProfileRequestDataDto;
 import org.opensmartgridplatform.dto.valueobjects.smartmetering.GetPowerQualityProfileResponseDto;
-import org.opensmartgridplatform.dto.valueobjects.smartmetering.PowerQualityProfileDataDto;
 
 @ExtendWith(MockitoExtension.class)
-class GetPowerQualityProfileNoSelectiveAccessHandlerTest extends ObjectConfigServiceHelper {
-
-  private static final String PROTOCOL_NAME = "SMR";
-  private static final String PROTOCOL_VERSION = "5.0.0";
-  private static final int CLASS_ID_DATA = 1;
-  private static final int CLASS_ID_REGISTER = 3;
-  private static final String OBIS_PRIVATE = "0.1.94.31.6.255";
-  private static final String OBIS_PROFILE = "0.1.99.1.1.255";
-  private static final String OBIS_CLOCK = "0.0.1.0.0.255";
-  private static final String OBIS_INSTANTANEOUS_VOLTAGE_L1 = "1.0.32.7.0.255";
-  private static final String UNIT_UNDEFINED = "UNDEFINED";
-  private static final String UNIT_VOLT = "V";
-
+class GetPowerQualityProfileNoSelectiveAccessHandlerTest extends GetPowerQualityProfileTest {
   @Mock private DlmsHelper dlmsHelper;
   @Mock private DlmsConnectionManager conn;
   @Mock private DlmsDevice dlmsDevice;
   @Mock private ObjectConfigService objectConfigService;
+
+  @BeforeEach
+  public void init() {
+    when(this.dlmsDevice.getProtocolName()).thenReturn(PROTOCOL_NAME);
+    when(this.dlmsDevice.getProtocolVersion()).thenReturn(PROTOCOL_VERSION);
+  }
 
   @ParameterizedTest
   @EnumSource(PowerQualityProfile.class)
   void testHandlePublicOrPrivateProfileWithoutSelectiveAccessWithPartialNonAllowedObjects(
       final PowerQualityProfile profile) throws ProtocolAdapterException, ObjectConfigException {
 
-    final boolean polyPhase = true;
-    final List<CosemObject> allPqObjectsForThisMeter = this.getObjects(polyPhase, profile.name());
+    final List<CosemObject> allPqObjectsForThisMeter = this.getObjects(true, profile.name());
     final GetPowerQualityProfileRequestDataDto requestDto =
         new GetPowerQualityProfileRequestDataDto(
             profile.name(),
             Date.from(Instant.now().minus(2, ChronoUnit.DAYS)),
             new Date(),
             new ArrayList<>());
-    when(this.dlmsDevice.getProtocolName()).thenReturn(PROTOCOL_NAME);
-    when(this.dlmsDevice.getProtocolVersion()).thenReturn(PROTOCOL_VERSION);
     when(this.dlmsHelper.readLogicalName(any(DataObject.class), any(String.class)))
         .thenCallRealMethod();
     when(this.dlmsHelper.readObjectDefinition(any(DataObject.class), any(String.class)))
@@ -82,27 +75,22 @@ class GetPowerQualityProfileNoSelectiveAccessHandlerTest extends ObjectConfigSer
     when(this.dlmsHelper.readLongNotNull(any(DataObject.class), any(String.class)))
         .thenCallRealMethod();
     when(this.dlmsHelper.readLong(any(DataObject.class), any(String.class))).thenCallRealMethod();
+    when(this.dlmsHelper.getScaledMeterValueWithScalerUnit(
+            any(DataObject.class), any(String.class), any(String.class)))
+        .thenCallRealMethod();
+    when(this.dlmsHelper.convertDataObjectToDateTime(any(DataObject.class))).thenCallRealMethod();
+    when(this.dlmsHelper.fromDateTimeValue(any())).thenCallRealMethod();
     when(this.objectConfigService.getCosemObject(
             PROTOCOL_NAME, PROTOCOL_VERSION, POWER_QUALITY_PROFILE_2))
         .thenReturn(
-            this.createObjectWithProperties(
-                7,
-                "0.1.99.1.2.255",
-                "POWER_QUALITY_PROFILE_2",
-                null,
-                polyPhase,
-                profile.name(),
-                true));
+            this.createProfile(PQ_PROFILE_2, "POWER_QUALITY_PROFILE_2", PQ_PROFILE_2_INTERVAL));
     when(this.objectConfigService.getCosemObject(
             PROTOCOL_NAME, PROTOCOL_VERSION, POWER_QUALITY_PROFILE_1))
-        .thenReturn(
-            this.createObjectWithProperties(
-                7, OBIS_PRIVATE, "POWER_QUALITY_PROFILE_1", null, polyPhase, profile.name(), true));
+        .thenReturn(this.createProfile(PQ_DEFINABLE, "DEFINABLE_LOAD_PROFILE", PQ_DEFINABLE_INTERVAL));
     when(this.objectConfigService.getCosemObject(
             PROTOCOL_NAME, PROTOCOL_VERSION, DEFINABLE_LOAD_PROFILE))
         .thenReturn(
-            this.createObjectWithProperties(
-                7, OBIS_PROFILE, "DEFINABLE_LOAD_PROFILE", null, polyPhase, profile.name(), true));
+            this.createProfile(PQ_PROFILE_1, "POWER_QUALITY_PROFILE_1", PQ_PROFILE_1_INTERVAL));
     when(this.objectConfigService.getCosemObjects(
             PROTOCOL_NAME, PROTOCOL_VERSION, this.getPropertyObjects()))
         .thenReturn(allPqObjectsForThisMeter);
@@ -110,13 +98,16 @@ class GetPowerQualityProfileNoSelectiveAccessHandlerTest extends ObjectConfigSer
     when(this.dlmsHelper.getAndCheck(
             any(DlmsConnectionManager.class),
             any(DlmsDevice.class),
-            any(String.class),
+            eq("retrieve profile generic capture objects"),
             any(AttributeAddress.class)))
-        .thenReturn(
-            this.createPartialNotAllowedCaptureObjects(),
-            this.createProfileEntries(),
-            this.createPartialNotAllowedCaptureObjects(),
-            this.createProfileEntries());
+        .thenReturn(this.createPartialNotAllowedCaptureObjects());
+
+    when(this.dlmsHelper.getAndCheck(
+            any(DlmsConnectionManager.class),
+            any(DlmsDevice.class),
+            eq("retrieve profile generic buffer"),
+            any(AttributeAddress.class)))
+        .thenReturn(this.createProfileEntries());
 
     // EXECUTE
     final GetPowerQualityProfileNoSelectiveAccessHandler handler =
@@ -127,17 +118,9 @@ class GetPowerQualityProfileNoSelectiveAccessHandlerTest extends ObjectConfigSer
 
     assertThat(responseDto.getPowerQualityProfileResponseDatas()).hasSize(3);
 
-    Optional<PowerQualityProfileDataDto> profileData =
-        responseDto.getPowerQualityProfileResponseDatas().stream()
-            .filter(data -> data.getLogicalName().toString().equals(OBIS_PROFILE))
-            .findFirst();
-
-    assertTrue(profileData.isPresent());
-    assertThat(profileData.get().getCaptureObjects()).hasSize(1);
-
-    CaptureObjectDto captureObject = profileData.get().getCaptureObjects().get(0);
-    assertThat(captureObject.getLogicalName()).isEqualTo(OBIS_INSTANTANEOUS_VOLTAGE_L1);
-    assertThat(captureObject.getUnit()).isEqualTo(UNIT_VOLT);
+    this.verifyResponseData(responseDto, PQ_PROFILE_1, PQ_PROFILE_1_INTERVAL);
+    this.verifyResponseData(responseDto, PQ_PROFILE_2, PQ_PROFILE_2_INTERVAL);
+    this.verifyResponseData(responseDto, PQ_DEFINABLE, PQ_DEFINABLE_INTERVAL);
   }
 
   @ParameterizedTest
@@ -153,31 +136,19 @@ class GetPowerQualityProfileNoSelectiveAccessHandlerTest extends ObjectConfigSer
             Date.from(Instant.now().minus(2, ChronoUnit.DAYS)),
             new Date(),
             new ArrayList<>());
-    when(this.dlmsDevice.getProtocolName()).thenReturn(PROTOCOL_NAME);
-    when(this.dlmsDevice.getProtocolVersion()).thenReturn(PROTOCOL_VERSION);
     when(this.dlmsHelper.readObjectDefinition(any(DataObject.class), any(String.class)))
         .thenCallRealMethod();
     when(this.objectConfigService.getCosemObject(
             PROTOCOL_NAME, PROTOCOL_VERSION, POWER_QUALITY_PROFILE_2))
         .thenReturn(
-            this.createObjectWithProperties(
-                7,
-                "0.1.99.1.2.255",
-                "POWER_QUALITY_PROFILE_2",
-                null,
-                polyPhase,
-                profile.name(),
-                true));
+            this.createProfile(PQ_PROFILE_2, "POWER_QUALITY_PROFILE_2", PQ_PROFILE_2_INTERVAL));
     when(this.objectConfigService.getCosemObject(
             PROTOCOL_NAME, PROTOCOL_VERSION, POWER_QUALITY_PROFILE_1))
-        .thenReturn(
-            this.createObjectWithProperties(
-                7, OBIS_PRIVATE, "POWER_QUALITY_PROFILE_1", null, polyPhase, profile.name(), true));
+        .thenReturn(this.createProfile(PQ_DEFINABLE, "DEFINABLE_LOAD_PROFILE", PQ_DEFINABLE_INTERVAL));
     when(this.objectConfigService.getCosemObject(
             PROTOCOL_NAME, PROTOCOL_VERSION, DEFINABLE_LOAD_PROFILE))
         .thenReturn(
-            this.createObjectWithProperties(
-                7, OBIS_PROFILE, "DEFINABLE_LOAD_PROFILE", null, polyPhase, profile.name(), true));
+            this.createProfile(PQ_PROFILE_1, "POWER_QUALITY_PROFILE_1", PQ_PROFILE_1_INTERVAL));
     when(this.objectConfigService.getCosemObjects(
             PROTOCOL_NAME, PROTOCOL_VERSION, this.getPropertyObjects()))
         .thenReturn(allPqObjectsForThisMeter);
@@ -187,11 +158,7 @@ class GetPowerQualityProfileNoSelectiveAccessHandlerTest extends ObjectConfigSer
             any(DlmsDevice.class),
             any(String.class),
             any(AttributeAddress.class)))
-        .thenReturn(
-            this.createInvalidCaptureObjects(),
-            this.createProfileEntries(),
-            this.createInvalidCaptureObjects(),
-            this.createProfileEntries());
+        .thenReturn(this.createInvalidCaptureObjects());
     final GetPowerQualityProfileNoSelectiveAccessHandler handler =
         new GetPowerQualityProfileNoSelectiveAccessHandler(
             this.dlmsHelper, this.objectConfigService);
@@ -203,7 +170,7 @@ class GetPowerQualityProfileNoSelectiveAccessHandlerTest extends ObjectConfigSer
 
   @ParameterizedTest
   @EnumSource(PowerQualityProfile.class)
-  void testInvalidProfileThrowsIllegalArgumentException(PowerQualityProfile profile)
+  void testInvalidProfileThrowsIllegalArgumentException(final PowerQualityProfile profile)
       throws ObjectConfigException {
     final GetPowerQualityProfileRequestDataDto requestDto =
         new GetPowerQualityProfileRequestDataDto(
@@ -211,8 +178,6 @@ class GetPowerQualityProfileNoSelectiveAccessHandlerTest extends ObjectConfigSer
             Date.from(Instant.now().minus(2, ChronoUnit.DAYS)),
             new Date(),
             new ArrayList<>());
-    when(this.dlmsDevice.getProtocolName()).thenReturn(PROTOCOL_NAME);
-    when(this.dlmsDevice.getProtocolVersion()).thenReturn(PROTOCOL_VERSION);
     when(this.objectConfigService.getCosemObject(
             PROTOCOL_NAME, PROTOCOL_VERSION, DEFINABLE_LOAD_PROFILE))
         .thenThrow(new IllegalArgumentException("IllegalArgumentException"));
@@ -228,7 +193,7 @@ class GetPowerQualityProfileNoSelectiveAccessHandlerTest extends ObjectConfigSer
 
   @ParameterizedTest
   @EnumSource(PowerQualityProfile.class)
-  void testInvalidProfileThrowsObjectConfigException(PowerQualityProfile profile)
+  void testInvalidProfileThrowsObjectConfigException(final PowerQualityProfile profile)
       throws ObjectConfigException {
     final GetPowerQualityProfileRequestDataDto requestDto =
         new GetPowerQualityProfileRequestDataDto(
@@ -236,8 +201,6 @@ class GetPowerQualityProfileNoSelectiveAccessHandlerTest extends ObjectConfigSer
             Date.from(Instant.now().minus(2, ChronoUnit.DAYS)),
             new Date(),
             new ArrayList<>());
-    when(this.dlmsDevice.getProtocolName()).thenReturn(PROTOCOL_NAME);
-    when(this.dlmsDevice.getProtocolVersion()).thenReturn(PROTOCOL_VERSION);
     when(this.objectConfigService.getCosemObject(
             PROTOCOL_NAME, PROTOCOL_VERSION, DEFINABLE_LOAD_PROFILE))
         .thenThrow(new ObjectConfigException("exception"));
@@ -251,178 +214,6 @@ class GetPowerQualityProfileNoSelectiveAccessHandlerTest extends ObjectConfigSer
         () -> handler.handle(this.conn, this.dlmsDevice, requestDto));
   }
 
-  private List<CosemObject> getObjects(final boolean polyphase, final String publicOrPrivate) {
-    final CosemObject dataObject =
-        this.createObjectWithProperties(
-            CLASS_ID_DATA,
-            "1.0.0.0.0.1",
-            NUMBER_OF_VOLTAGE_SAGS_FOR_L2.name(),
-            null,
-            polyphase,
-            publicOrPrivate,
-            false);
-
-    final CosemObject registerVoltObject =
-        this.createObjectWithProperties(
-            CLASS_ID_REGISTER,
-            OBIS_INSTANTANEOUS_VOLTAGE_L1,
-            INSTANTANEOUS_VOLTAGE_L1.name(),
-            "0, " + UNIT_VOLT,
-            polyphase,
-            publicOrPrivate,
-            false);
-
-    final CosemObject registerAmpereObject =
-        this.createObjectWithProperties(
-            CLASS_ID_REGISTER,
-            "3.0.0.0.0.2",
-            AVERAGE_CURRENT_L1.name(),
-            "-1, A",
-            polyphase,
-            publicOrPrivate,
-            false);
-
-    final CosemObject registerVarObject =
-        this.createObjectWithProperties(
-            CLASS_ID_REGISTER,
-            "3.0.0.0.0.3",
-            AVERAGE_REACTIVE_POWER_IMPORT_L1.name(),
-            "2, VAR",
-            polyphase,
-            publicOrPrivate,
-            false);
-
-    return new ArrayList<>(
-        Arrays.asList(dataObject, registerVoltObject, registerAmpereObject, registerVarObject));
-  }
-
-  private List<GetResult> createProfileEntries() {
-    final DataObject allowedCaptureObjectClock =
-        DataObject.newStructureData(
-            DataObject.newUInteger32Data(8),
-            DataObject.newOctetStringData(new byte[] {0, 0, 1, 0, 0, (byte) 255}),
-            DataObject.newInteger32Data(2),
-            DataObject.newUInteger32Data(0));
-
-    final DataObject allowedCaptureObjectINSTANTANEOUS_VOLTAGE_L1 =
-        DataObject.newStructureData(
-            DataObject.newUInteger32Data(1),
-            DataObject.newOctetStringData(new byte[] {1, 0, 32, 7, 0, (byte) 255}),
-            DataObject.newInteger32Data(2),
-            DataObject.newUInteger32Data(0));
-
-    final DataObject nonAllowedCaptureObject1 =
-        DataObject.newStructureData(
-            DataObject.newUInteger32Data(1),
-            DataObject.newOctetStringData(new byte[] {80, 0, 32, 32, 0, (byte) 255}),
-            DataObject.newInteger32Data(2),
-            DataObject.newUInteger32Data(0));
-    final DataObject nonAllowedCaptureObject2 =
-        DataObject.newStructureData(
-            DataObject.newUInteger32Data(1),
-            DataObject.newOctetStringData(new byte[] {1, 0, 52, 32, 0, (byte) 255}),
-            DataObject.newInteger32Data(2),
-            DataObject.newUInteger32Data(0));
-
-    final GetResult getResult =
-        new GetResultImpl(
-            DataObject.newArrayData(
-                Arrays.asList(
-                    allowedCaptureObjectClock,
-                    allowedCaptureObjectINSTANTANEOUS_VOLTAGE_L1,
-                    nonAllowedCaptureObject1,
-                    nonAllowedCaptureObject2)));
-
-    return Collections.singletonList(getResult);
-  }
-
-  private List<GetResult> createPartialNotAllowedCaptureObjects() {
-    final DataObject allowedCaptureObjectClock =
-        DataObject.newStructureData(
-            DataObject.newUInteger32Data(8),
-            DataObject.newOctetStringData(new byte[] {0, 0, 1, 0, 0, (byte) 255}),
-            DataObject.newInteger32Data(2),
-            DataObject.newUInteger32Data(0));
-
-    final DataObject allowedCaptureObjectINSTANTANEOUS_VOLTAGE_L1 =
-        DataObject.newStructureData(
-            DataObject.newUInteger32Data(1),
-            DataObject.newOctetStringData(new byte[] {1, 0, 32, 7, 0, (byte) 255}),
-            DataObject.newInteger32Data(2),
-            DataObject.newUInteger32Data(0));
-
-    final DataObject nonAllowedCaptureObject1 =
-        DataObject.newStructureData(
-            DataObject.newUInteger32Data(1),
-            DataObject.newOctetStringData(new byte[] {80, 0, 32, 32, 0, (byte) 255}),
-            DataObject.newInteger32Data(2),
-            DataObject.newUInteger32Data(0));
-    final DataObject nonAllowedCaptureObject2 =
-        DataObject.newStructureData(
-            DataObject.newUInteger32Data(1),
-            DataObject.newOctetStringData(new byte[] {1, 0, 52, 32, 0, (byte) 255}),
-            DataObject.newInteger32Data(2),
-            DataObject.newUInteger32Data(0));
-
-    final GetResult getResult =
-        new GetResultImpl(
-            DataObject.newArrayData(
-                Arrays.asList(
-                    allowedCaptureObjectClock,
-                    allowedCaptureObjectINSTANTANEOUS_VOLTAGE_L1,
-                    nonAllowedCaptureObject1,
-                    nonAllowedCaptureObject2)));
-
-    return Collections.singletonList(getResult);
-  }
-
-  private CosemObject createObjectWithProperties(
-      final int classId,
-      final String obis,
-      final String tag,
-      final String scalerUnitValue,
-      final boolean polyphase,
-      final String publicOrPrivate,
-      final boolean addAttributes) {
-
-    final CosemObject object = this.createObject(classId, obis, tag, scalerUnitValue, polyphase);
-
-    Map<ObjectProperty, Object> properties = new HashMap<>();
-    List<String> stringProperties =
-        this.getPropertyObjects().stream()
-            .map(DlmsObjectType::toString)
-            .collect(Collectors.toList());
-    properties.put(ObjectProperty.SELECTABLE_OBJECTS, stringProperties);
-    properties.put(ObjectProperty.PQ_PROFILE, publicOrPrivate);
-    object.setProperties(properties);
-
-    if (addAttributes) {
-      List<Attribute> attributeList = new ArrayList<>();
-      Attribute attribute = new Attribute();
-      attribute.setId(3);
-      attribute.setValue("1");
-      attributeList.add(attribute);
-      Attribute attributeInterval = new Attribute();
-      attributeInterval.setId(4);
-      attributeInterval.setValue("15");
-      attributeList.add(attributeInterval);
-      object.setAttributes(attributeList);
-    }
-
-    return object;
-  }
-
-  private List<DlmsObjectType> getPropertyObjects() {
-    List<DlmsObjectType> objects = new ArrayList<>();
-    objects.add(CLOCK);
-    objects.add(INSTANTANEOUS_VOLTAGE_L1);
-    objects.add(NUMBER_OF_VOLTAGE_SAGS_FOR_L1);
-    objects.add(NUMBER_OF_VOLTAGE_SAGS_FOR_L2);
-    objects.add(AVERAGE_CURRENT_L1);
-    objects.add(AVERAGE_REACTIVE_POWER_IMPORT_L1);
-    return objects;
-  }
-
   private List<GetResult> createInvalidCaptureObjects() {
     final DataObject invalidObject =
         DataObject.newStructureData(
@@ -430,9 +221,8 @@ class GetPowerQualityProfileNoSelectiveAccessHandlerTest extends ObjectConfigSer
             DataObject.newInteger32Data(2),
             DataObject.newUInteger32Data(0));
 
-    final GetResult getResult =
-        new GetResultImpl(DataObject.newArrayData(Arrays.asList(invalidObject)));
+    final GetResult getResult = new GetResultImpl(DataObject.newArrayData(List.of(invalidObject)));
 
-    return Collections.singletonList(getResult);
+    return List.of(getResult);
   }
 }

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/monitoring/GetPowerQualityProfileSelectiveAccessHandlerTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/monitoring/GetPowerQualityProfileSelectiveAccessHandlerTest.java
@@ -70,6 +70,7 @@ class GetPowerQualityProfileSelectiveAccessHandlerTest extends GetPowerQualityPr
     when(this.dlmsHelper.getScaledMeterValueWithScalerUnit(
             any(DataObject.class), any(String.class), any(String.class)))
         .thenCallRealMethod();
+
     when(this.dlmsHelper.convertDataObjectToDateTime(any(DataObject.class))).thenCallRealMethod();
     when(this.dlmsHelper.fromDateTimeValue(any())).thenCallRealMethod();
     when(this.objectConfigService.getCosemObject(
@@ -100,7 +101,7 @@ class GetPowerQualityProfileSelectiveAccessHandlerTest extends GetPowerQualityPr
             any(DlmsDevice.class),
             eq("retrieve profile generic buffer"),
             any(AttributeAddress.class)))
-        .thenReturn(this.createProfileEntries());
+        .thenReturn(this.createProfileEntries(true));
 
     // EXECUTE
     final GetPowerQualityProfileSelectiveAccessHandler handler =

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/monitoring/GetPowerQualityProfileSelectiveAccessHandlerTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/monitoring/GetPowerQualityProfileSelectiveAccessHandlerTest.java
@@ -9,48 +9,38 @@
 package org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.monitoring;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
-import static org.opensmartgridplatform.dlms.objectconfig.DlmsObjectType.*;
+import static org.opensmartgridplatform.dlms.objectconfig.DlmsObjectType.DEFINABLE_LOAD_PROFILE;
+import static org.opensmartgridplatform.dlms.objectconfig.DlmsObjectType.POWER_QUALITY_PROFILE_1;
+import static org.opensmartgridplatform.dlms.objectconfig.DlmsObjectType.POWER_QUALITY_PROFILE_2;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.openmuc.jdlms.AttributeAddress;
-import org.openmuc.jdlms.GetResult;
 import org.openmuc.jdlms.datatypes.DataObject;
-import org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.testutil.GetResultImpl;
-import org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.testutil.ObjectConfigServiceHelper;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.utils.DlmsHelper;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.entities.DlmsDevice;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.factories.DlmsConnectionManager;
 import org.opensmartgridplatform.adapter.protocol.dlms.exceptions.ProtocolAdapterException;
 import org.opensmartgridplatform.dlms.exceptions.ObjectConfigException;
-import org.opensmartgridplatform.dlms.objectconfig.*;
+import org.opensmartgridplatform.dlms.objectconfig.CosemObject;
+import org.opensmartgridplatform.dlms.objectconfig.PowerQualityProfile;
 import org.opensmartgridplatform.dlms.services.ObjectConfigService;
-import org.opensmartgridplatform.dto.valueobjects.smartmetering.CaptureObjectDto;
 import org.opensmartgridplatform.dto.valueobjects.smartmetering.GetPowerQualityProfileRequestDataDto;
 import org.opensmartgridplatform.dto.valueobjects.smartmetering.GetPowerQualityProfileResponseDto;
-import org.opensmartgridplatform.dto.valueobjects.smartmetering.PowerQualityProfileDataDto;
 
 @ExtendWith(MockitoExtension.class)
-class GetPowerQualityProfileSelectiveAccessHandlerTest extends ObjectConfigServiceHelper {
-  private static final String PROTOCOL_NAME = "SMR";
-  private static final String PROTOCOL_VERSION = "5.0.0";
-  private static final int CLASS_ID_DATA = 1;
-  private static final int CLASS_ID_REGISTER = 3;
-  private static final String OBIS_PRIVATE = "0.1.94.31.6.255";
-  private static final String OBIS_PROFILE = "0.1.99.1.1.255";
-  private static final String OBIS_INSTANTANEOUS_VOLTAGE_L1 = "1.0.32.7.0.255";
-  private static final String UNIT_VOLT = "V";
-
+class GetPowerQualityProfileSelectiveAccessHandlerTest extends GetPowerQualityProfileTest {
   @Mock private DlmsHelper dlmsHelper;
   @Mock private DlmsConnectionManager conn;
   @Mock private DlmsDevice dlmsDevice;
@@ -58,11 +48,10 @@ class GetPowerQualityProfileSelectiveAccessHandlerTest extends ObjectConfigServi
 
   @ParameterizedTest
   @EnumSource(PowerQualityProfile.class)
-  void testHandlePublicOrPrivateProfileWithoutSelectiveAccessWithPartialNonAllowedObjects(
+  void testHandlePublicOrPrivateProfileWithSelectiveAccessWithPartialNonAllowedObjects(
       final PowerQualityProfile profile) throws ProtocolAdapterException, ObjectConfigException {
 
-    final boolean polyPhase = true;
-    final List<CosemObject> allPqObjectsForThisMeter = this.getObjects(polyPhase, profile.name());
+    final List<CosemObject> allPqObjectsForThisMeter = this.getObjects(true, profile.name());
     final GetPowerQualityProfileRequestDataDto requestDto =
         new GetPowerQualityProfileRequestDataDto(
             profile.name(),
@@ -78,27 +67,23 @@ class GetPowerQualityProfileSelectiveAccessHandlerTest extends ObjectConfigServi
     when(this.dlmsHelper.readLongNotNull(any(DataObject.class), any(String.class)))
         .thenCallRealMethod();
     when(this.dlmsHelper.readLong(any(DataObject.class), any(String.class))).thenCallRealMethod();
+    when(this.dlmsHelper.getScaledMeterValueWithScalerUnit(
+            any(DataObject.class), any(String.class), any(String.class)))
+        .thenCallRealMethod();
+    when(this.dlmsHelper.convertDataObjectToDateTime(any(DataObject.class))).thenCallRealMethod();
+    when(this.dlmsHelper.fromDateTimeValue(any())).thenCallRealMethod();
     when(this.objectConfigService.getCosemObject(
             PROTOCOL_NAME, PROTOCOL_VERSION, POWER_QUALITY_PROFILE_2))
         .thenReturn(
-            this.createObjectWithProperties(
-                7,
-                "0.1.99.1.2.255",
-                "POWER_QUALITY_PROFILE_2",
-                null,
-                polyPhase,
-                profile.name(),
-                true));
+            this.createProfile(PQ_PROFILE_2, "POWER_QUALITY_PROFILE_2", PQ_PROFILE_2_INTERVAL));
     when(this.objectConfigService.getCosemObject(
             PROTOCOL_NAME, PROTOCOL_VERSION, POWER_QUALITY_PROFILE_1))
         .thenReturn(
-            this.createObjectWithProperties(
-                7, OBIS_PRIVATE, "POWER_QUALITY_PROFILE_1", null, polyPhase, profile.name(), true));
+            this.createProfile(PQ_PROFILE_1, "POWER_QUALITY_PROFILE_1", PQ_PROFILE_1_INTERVAL));
     when(this.objectConfigService.getCosemObject(
             PROTOCOL_NAME, PROTOCOL_VERSION, DEFINABLE_LOAD_PROFILE))
         .thenReturn(
-            this.createObjectWithProperties(
-                7, OBIS_PROFILE, "DEFINABLE_LOAD_PROFILE", null, polyPhase, profile.name(), true));
+            this.createProfile(PQ_DEFINABLE, "DEFINABLE_LOAD_PROFILE", PQ_DEFINABLE_INTERVAL));
     when(this.objectConfigService.getCosemObjects(
             PROTOCOL_NAME, PROTOCOL_VERSION, this.getPropertyObjects()))
         .thenReturn(allPqObjectsForThisMeter);
@@ -106,13 +91,16 @@ class GetPowerQualityProfileSelectiveAccessHandlerTest extends ObjectConfigServi
     when(this.dlmsHelper.getAndCheck(
             any(DlmsConnectionManager.class),
             any(DlmsDevice.class),
-            any(String.class),
+            eq("retrieve profile generic capture objects"),
             any(AttributeAddress.class)))
-        .thenReturn(
-            this.createPartialNotAllowedCaptureObjects(),
-            this.createProfileEntries(),
-            this.createPartialNotAllowedCaptureObjects(),
-            this.createProfileEntries());
+        .thenReturn(this.createPartialNotAllowedCaptureObjects());
+
+    when(this.dlmsHelper.getAndCheck(
+            any(DlmsConnectionManager.class),
+            any(DlmsDevice.class),
+            eq("retrieve profile generic buffer"),
+            any(AttributeAddress.class)))
+        .thenReturn(this.createProfileEntries());
 
     // EXECUTE
     final GetPowerQualityProfileSelectiveAccessHandler handler =
@@ -122,200 +110,8 @@ class GetPowerQualityProfileSelectiveAccessHandlerTest extends ObjectConfigServi
 
     assertThat(responseDto.getPowerQualityProfileResponseDatas()).hasSize(3);
 
-    Optional<PowerQualityProfileDataDto> profileData =
-        responseDto.getPowerQualityProfileResponseDatas().stream()
-            .filter(data -> data.getLogicalName().toString().equals(OBIS_PROFILE))
-            .findFirst();
-
-    assertTrue(profileData.isPresent());
-    assertThat(profileData.get().getCaptureObjects()).hasSize(1);
-
-    CaptureObjectDto captureObject = profileData.get().getCaptureObjects().get(0);
-    assertThat(captureObject.getLogicalName()).isEqualTo(OBIS_INSTANTANEOUS_VOLTAGE_L1);
-    assertThat(captureObject.getUnit()).isEqualTo(UNIT_VOLT);
-  }
-
-  private List<CosemObject> getObjects(final boolean polyphase, final String publicOrPrivate) {
-    final CosemObject dataObject =
-        this.createObjectWithProperties(
-            CLASS_ID_DATA,
-            "1.0.0.0.0.1",
-            NUMBER_OF_VOLTAGE_SAGS_FOR_L2.name(),
-            null,
-            polyphase,
-            publicOrPrivate,
-            false);
-
-    final CosemObject registerVoltObject =
-        this.createObjectWithProperties(
-            CLASS_ID_REGISTER,
-            OBIS_INSTANTANEOUS_VOLTAGE_L1,
-            INSTANTANEOUS_VOLTAGE_L1.name(),
-            "0, " + UNIT_VOLT,
-            polyphase,
-            publicOrPrivate,
-            false);
-
-    final CosemObject registerAmpereObject =
-        this.createObjectWithProperties(
-            CLASS_ID_REGISTER,
-            "3.0.0.0.0.2",
-            AVERAGE_CURRENT_L1.name(),
-            "-1, A",
-            polyphase,
-            publicOrPrivate,
-            false);
-
-    final CosemObject registerVarObject =
-        this.createObjectWithProperties(
-            CLASS_ID_REGISTER,
-            "3.0.0.0.0.3",
-            AVERAGE_REACTIVE_POWER_IMPORT_L1.name(),
-            "2, VAR",
-            polyphase,
-            publicOrPrivate,
-            false);
-
-    return new ArrayList<>(
-        Arrays.asList(dataObject, registerVoltObject, registerAmpereObject, registerVarObject));
-  }
-
-  private List<GetResult> createProfileEntries() {
-    final DataObject allowedCaptureObjectClock =
-        DataObject.newStructureData(
-            DataObject.newUInteger32Data(8),
-            DataObject.newOctetStringData(new byte[] {0, 0, 1, 0, 0, (byte) 255}),
-            DataObject.newInteger32Data(2),
-            DataObject.newUInteger32Data(0));
-
-    final DataObject allowedCaptureObjectINSTANTANEOUS_VOLTAGE_L1 =
-        DataObject.newStructureData(
-            DataObject.newUInteger32Data(1),
-            DataObject.newOctetStringData(new byte[] {1, 0, 32, 7, 0, (byte) 255}),
-            DataObject.newInteger32Data(2),
-            DataObject.newUInteger32Data(0));
-
-    final DataObject nonAllowedCaptureObject1 =
-        DataObject.newStructureData(
-            DataObject.newUInteger32Data(1),
-            DataObject.newOctetStringData(new byte[] {80, 0, 32, 32, 0, (byte) 255}),
-            DataObject.newInteger32Data(2),
-            DataObject.newUInteger32Data(0));
-    final DataObject nonAllowedCaptureObject2 =
-        DataObject.newStructureData(
-            DataObject.newUInteger32Data(1),
-            DataObject.newOctetStringData(new byte[] {1, 0, 52, 32, 0, (byte) 255}),
-            DataObject.newInteger32Data(2),
-            DataObject.newUInteger32Data(0));
-
-    final GetResult getResult =
-        new GetResultImpl(
-            DataObject.newArrayData(
-                Arrays.asList(
-                    allowedCaptureObjectClock,
-                    allowedCaptureObjectINSTANTANEOUS_VOLTAGE_L1,
-                    nonAllowedCaptureObject1,
-                    nonAllowedCaptureObject2)));
-
-    return Collections.singletonList(getResult);
-  }
-
-  private List<GetResult> createPartialNotAllowedCaptureObjects() {
-    final DataObject allowedCaptureObjectClock =
-        DataObject.newStructureData(
-            DataObject.newUInteger32Data(8),
-            DataObject.newOctetStringData(new byte[] {0, 0, 1, 0, 0, (byte) 255}),
-            DataObject.newInteger32Data(2),
-            DataObject.newUInteger32Data(0));
-
-    final DataObject allowedCaptureObjectINSTANTANEOUS_VOLTAGE_L1 =
-        DataObject.newStructureData(
-            DataObject.newUInteger32Data(1),
-            DataObject.newOctetStringData(new byte[] {1, 0, 32, 7, 0, (byte) 255}),
-            DataObject.newInteger32Data(2),
-            DataObject.newUInteger32Data(0));
-
-    final DataObject nonAllowedCaptureObject1 =
-        DataObject.newStructureData(
-            DataObject.newUInteger32Data(1),
-            DataObject.newOctetStringData(new byte[] {80, 0, 32, 32, 0, (byte) 255}),
-            DataObject.newInteger32Data(2),
-            DataObject.newUInteger32Data(0));
-    final DataObject nonAllowedCaptureObject2 =
-        DataObject.newStructureData(
-            DataObject.newUInteger32Data(1),
-            DataObject.newOctetStringData(new byte[] {1, 0, 52, 32, 0, (byte) 255}),
-            DataObject.newInteger32Data(2),
-            DataObject.newUInteger32Data(0));
-
-    final GetResult getResult =
-        new GetResultImpl(
-            DataObject.newArrayData(
-                Arrays.asList(
-                    allowedCaptureObjectClock,
-                    allowedCaptureObjectINSTANTANEOUS_VOLTAGE_L1,
-                    nonAllowedCaptureObject1,
-                    nonAllowedCaptureObject2)));
-
-    return Collections.singletonList(getResult);
-  }
-
-  private CosemObject createObjectWithProperties(
-      final int classId,
-      final String obis,
-      final String tag,
-      final String scalerUnitValue,
-      final boolean polyphase,
-      final String publicOrPrivate,
-      final boolean addAttributes) {
-
-    final CosemObject object = this.createObject(classId, obis, tag, scalerUnitValue, polyphase);
-
-    Map<ObjectProperty, Object> properties = new HashMap<>();
-    List<String> stringProperties =
-        this.getPropertyObjects().stream()
-            .map(DlmsObjectType::toString)
-            .collect(Collectors.toList());
-    properties.put(ObjectProperty.SELECTABLE_OBJECTS, stringProperties);
-    properties.put(ObjectProperty.PQ_PROFILE, publicOrPrivate);
-    object.setProperties(properties);
-
-    if (addAttributes) {
-      List<Attribute> attributeList = new ArrayList<>();
-      Attribute attribute = new Attribute();
-      attribute.setId(3);
-      attribute.setValue("1");
-      attributeList.add(attribute);
-      Attribute attributeInterval = new Attribute();
-      attributeInterval.setId(4);
-      attributeInterval.setValue("15");
-      attributeList.add(attributeInterval);
-      object.setAttributes(attributeList);
-    }
-    return object;
-  }
-
-  private List<DlmsObjectType> getPropertyObjects() {
-    List<DlmsObjectType> objects = new ArrayList<>();
-    objects.add(CLOCK);
-    objects.add(INSTANTANEOUS_VOLTAGE_L1);
-    objects.add(NUMBER_OF_VOLTAGE_SAGS_FOR_L1);
-    objects.add(NUMBER_OF_VOLTAGE_SAGS_FOR_L2);
-    objects.add(AVERAGE_CURRENT_L1);
-    objects.add(AVERAGE_REACTIVE_POWER_IMPORT_L1);
-    return objects;
-  }
-
-  private List<GetResult> createInvalidCaptureObjects() {
-    final DataObject invalidObject =
-        DataObject.newStructureData(
-            DataObject.newNullData(),
-            DataObject.newInteger32Data(2),
-            DataObject.newUInteger32Data(0));
-
-    final GetResult getResult =
-        new GetResultImpl(DataObject.newArrayData(Arrays.asList(invalidObject)));
-
-    return Collections.singletonList(getResult);
+    this.verifyResponseData(responseDto, PQ_PROFILE_1, PQ_PROFILE_1_INTERVAL);
+    this.verifyResponseData(responseDto, PQ_PROFILE_2, PQ_PROFILE_2_INTERVAL);
+    this.verifyResponseData(responseDto, PQ_DEFINABLE, PQ_DEFINABLE_INTERVAL);
   }
 }

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/monitoring/GetPowerQualityProfileTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/monitoring/GetPowerQualityProfileTest.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright 2022 Alliander N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ */
+package org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.monitoring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.opensmartgridplatform.dlms.objectconfig.DlmsObjectType.AVERAGE_CURRENT_L1;
+import static org.opensmartgridplatform.dlms.objectconfig.DlmsObjectType.AVERAGE_REACTIVE_POWER_IMPORT_L1;
+import static org.opensmartgridplatform.dlms.objectconfig.DlmsObjectType.CLOCK;
+import static org.opensmartgridplatform.dlms.objectconfig.DlmsObjectType.INSTANTANEOUS_VOLTAGE_L1;
+import static org.opensmartgridplatform.dlms.objectconfig.DlmsObjectType.NUMBER_OF_VOLTAGE_SAGS_FOR_L1;
+import static org.opensmartgridplatform.dlms.objectconfig.DlmsObjectType.NUMBER_OF_VOLTAGE_SAGS_FOR_L2;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.openmuc.jdlms.GetResult;
+import org.openmuc.jdlms.datatypes.DataObject;
+import org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.testutil.GetResultImpl;
+import org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.testutil.ObjectConfigServiceHelper;
+import org.opensmartgridplatform.dlms.objectconfig.Attribute;
+import org.opensmartgridplatform.dlms.objectconfig.CosemObject;
+import org.opensmartgridplatform.dlms.objectconfig.DlmsObjectType;
+import org.opensmartgridplatform.dlms.objectconfig.ObjectProperty;
+import org.opensmartgridplatform.dto.valueobjects.smartmetering.CaptureObjectDto;
+import org.opensmartgridplatform.dto.valueobjects.smartmetering.GetPowerQualityProfileResponseDto;
+import org.opensmartgridplatform.dto.valueobjects.smartmetering.PowerQualityProfileDataDto;
+import org.opensmartgridplatform.dto.valueobjects.smartmetering.ProfileEntryDto;
+import org.opensmartgridplatform.dto.valueobjects.smartmetering.ProfileEntryValueDto;
+
+public abstract class GetPowerQualityProfileTest {
+  protected static final String PROTOCOL_NAME = "SMR";
+  protected static final String PROTOCOL_VERSION = "5.0.0";
+  protected static final String PQ_DEFINABLE = "0.1.94.31.6.255";
+  protected static final String PQ_PROFILE_1 = "0.1.99.1.1.255";
+  protected static final String PQ_PROFILE_2 = "0.1.99.1.2.255";
+  protected static final int PQ_DEFINABLE_INTERVAL = 15;
+  protected static final int PQ_PROFILE_1_INTERVAL = 15;
+  protected static final int PQ_PROFILE_2_INTERVAL = 10;
+  private static final int CLASS_ID_DATA = 1;
+  private static final int CLASS_ID_REGISTER = 3;
+  private static final int CLASS_ID_PROFILE = 7;
+  private static final int CLASS_ID_CLOCK = 8;
+  private static final int PROFILE_CAPTURE_OBJECTS_ATTR_ID = 3;
+  private static final int PROFILE_INTERVAL_ATTR_ID = 4;
+  private static final int SECONDS_PER_MINUTE = 60;
+  private static final String OBIS_INSTANTANEOUS_VOLTAGE_L1 = "1.0.32.7.0.255";
+  private static final String OBIS_CLOCK = "0.0.1.0.0.255";
+  private static final String UNIT_VOLT = "V";
+  private static final String UNIT_UNDEFINED = "UNDEFINED";
+
+  public static CosemObject createObject(
+      final int classId,
+      final String obis,
+      final String tag,
+      final String scalerUnitValue,
+      final boolean polyphase,
+      final String publicOrPrivate) {
+
+    final CosemObject object =
+        ObjectConfigServiceHelper.createObject(classId, obis, tag, scalerUnitValue, polyphase);
+
+    final Map<ObjectProperty, Object> properties = new HashMap<>();
+    properties.put(ObjectProperty.PQ_PROFILE, publicOrPrivate);
+    object.setProperties(properties);
+
+    return object;
+  }
+
+  protected CosemObject createProfile(
+      final String obis, final String tag, final int intervalInMinutes) {
+
+    final CosemObject object =
+        ObjectConfigServiceHelper.createObject(CLASS_ID_PROFILE, obis, tag, null, true);
+
+    final Map<ObjectProperty, Object> properties = new HashMap<>();
+    final List<String> stringProperties =
+        this.getPropertyObjects().stream()
+            .map(DlmsObjectType::toString)
+            .collect(Collectors.toList());
+    properties.put(ObjectProperty.SELECTABLE_OBJECTS, stringProperties);
+    object.setProperties(properties);
+
+    final List<Attribute> attributeList = new ArrayList<>();
+    final Attribute attribute = new Attribute();
+    attribute.setId(PROFILE_CAPTURE_OBJECTS_ATTR_ID);
+    attribute.setValue("1");
+    attributeList.add(attribute);
+    final Attribute attributeInterval = new Attribute();
+    attributeInterval.setId(PROFILE_INTERVAL_ATTR_ID);
+    attributeInterval.setValue(String.valueOf(intervalInMinutes * SECONDS_PER_MINUTE));
+    attributeList.add(attributeInterval);
+    object.setAttributes(attributeList);
+
+    return object;
+  }
+
+  protected List<CosemObject> getObjects(final boolean polyphase, final String publicOrPrivate) {
+    final CosemObject clockObject =
+        createObject(CLASS_ID_CLOCK, OBIS_CLOCK, CLOCK.name(), null, true, publicOrPrivate);
+
+    final CosemObject dataObject =
+        createObject(
+            CLASS_ID_DATA,
+            "1.0.0.0.0.1",
+            NUMBER_OF_VOLTAGE_SAGS_FOR_L2.name(),
+            null,
+            polyphase,
+            publicOrPrivate);
+
+    final CosemObject registerVoltObject =
+        createObject(
+            CLASS_ID_REGISTER,
+            OBIS_INSTANTANEOUS_VOLTAGE_L1,
+            INSTANTANEOUS_VOLTAGE_L1.name(),
+            "0, " + UNIT_VOLT,
+            polyphase,
+            publicOrPrivate);
+
+    final CosemObject registerAmpereObject =
+        createObject(
+            CLASS_ID_REGISTER,
+            "3.0.0.0.0.2",
+            AVERAGE_CURRENT_L1.name(),
+            "-1, A",
+            polyphase,
+            publicOrPrivate);
+
+    final CosemObject registerVarObject =
+        createObject(
+            CLASS_ID_REGISTER,
+            "3.0.0.0.0.3",
+            AVERAGE_REACTIVE_POWER_IMPORT_L1.name(),
+            "2, VAR",
+            polyphase,
+            publicOrPrivate);
+
+    return new ArrayList<>(
+        Arrays.asList(
+            clockObject, dataObject, registerVoltObject, registerAmpereObject, registerVarObject));
+  }
+
+  protected void verifyResponseData(
+      final GetPowerQualityProfileResponseDto response,
+      final String obis,
+      final int intervalInMinutes) {
+    final Optional<PowerQualityProfileDataDto> profileData =
+        response.getPowerQualityProfileResponseDatas().stream()
+            .filter(data -> data.getLogicalName().toString().equals(obis))
+            .findFirst();
+
+    assertTrue(profileData.isPresent());
+    assertThat(profileData.get().getCaptureObjects()).hasSize(2);
+
+    final CaptureObjectDto captureObjectClock = profileData.get().getCaptureObjects().get(0);
+    assertThat(captureObjectClock.getLogicalName()).isEqualTo(OBIS_CLOCK);
+    assertThat(captureObjectClock.getUnit()).isEqualTo(UNIT_UNDEFINED);
+
+    final CaptureObjectDto captureObject = profileData.get().getCaptureObjects().get(1);
+    assertThat(captureObject.getLogicalName()).isEqualTo(OBIS_INSTANTANEOUS_VOLTAGE_L1);
+    assertThat(captureObject.getUnit()).isEqualTo(UNIT_VOLT);
+
+    final List<ProfileEntryDto> entries = profileData.get().getProfileEntries();
+    assertThat(entries).hasSize(4);
+
+    for (int index = 0; index < 4; index++) {
+      this.verifyProfileEntry(entries.get(index), index, intervalInMinutes);
+    }
+  }
+
+  private void verifyProfileEntry(
+      final ProfileEntryDto entry, final int index, final long intervalInMinutes) {
+    final List<ProfileEntryValueDto> values = entry.getProfileEntryValues();
+    assertThat(values).hasSize(2);
+    assertThat((Date) values.get(0).getValue())
+        .isEqualTo(
+            Date.from(
+                new GregorianCalendar(2023, Calendar.JANUARY, 12)
+                    .getTime()
+                    .toInstant()
+                    .plusSeconds(index * intervalInMinutes * SECONDS_PER_MINUTE)));
+    assertThat((BigDecimal) values.get(1).getValue()).isEqualTo(BigDecimal.valueOf(index));
+  }
+
+  protected List<DlmsObjectType> getPropertyObjects() {
+    final List<DlmsObjectType> objects = new ArrayList<>();
+    objects.add(CLOCK);
+    objects.add(INSTANTANEOUS_VOLTAGE_L1);
+    objects.add(NUMBER_OF_VOLTAGE_SAGS_FOR_L1);
+    objects.add(NUMBER_OF_VOLTAGE_SAGS_FOR_L2);
+    objects.add(AVERAGE_CURRENT_L1);
+    objects.add(AVERAGE_REACTIVE_POWER_IMPORT_L1);
+    return objects;
+  }
+
+  protected List<GetResult> createProfileEntries() {
+    final DataObject entry1 =
+        DataObject.newStructureData(
+            DataObject.newOctetStringData(
+                new byte[] {
+                  (byte) 0x07,
+                  (byte) 0xE7,
+                  (byte) 0x01,
+                  (byte) 0x0C,
+                  (byte) 0x04,
+                  (byte) 0x00,
+                  (byte) 0x00,
+                  (byte) 0x00,
+                  (byte) 0x00,
+                  (byte) 0xFF,
+                  (byte) 0xC4,
+                  (byte) 0x00
+                }),
+            DataObject.newUInteger8Data((short) 0),
+            DataObject.newUInteger16Data(2335),
+            DataObject.newUInteger16Data(0));
+
+    final DataObject entry2 =
+        DataObject.newStructureData(
+            DataObject.newNullData(),
+            DataObject.newUInteger8Data((short) 1),
+            DataObject.newUInteger16Data(2336),
+            DataObject.newUInteger16Data(2));
+
+    final DataObject entry3 =
+        DataObject.newStructureData(
+            DataObject.newNullData(),
+            DataObject.newUInteger8Data((short) 2),
+            DataObject.newUInteger16Data(2337),
+            DataObject.newUInteger16Data(4));
+
+    final DataObject entry4 =
+        DataObject.newStructureData(
+            DataObject.newNullData(),
+            DataObject.newUInteger8Data((short) 3),
+            DataObject.newUInteger16Data(2338),
+            DataObject.newUInteger16Data(6));
+
+    final GetResult getResult =
+        new GetResultImpl(DataObject.newArrayData(List.of(entry1, entry2, entry3, entry4)));
+
+    return List.of(getResult);
+  }
+
+  protected List<GetResult> createPartialNotAllowedCaptureObjects() {
+    final DataObject allowedCaptureObjectClock =
+        DataObject.newStructureData(
+            DataObject.newUInteger32Data(8),
+            DataObject.newOctetStringData(new byte[] {0, 0, 1, 0, 0, (byte) 255}),
+            DataObject.newInteger32Data(2),
+            DataObject.newUInteger32Data(0));
+
+    final DataObject allowedCaptureObjectINSTANTANEOUS_VOLTAGE_L1 =
+        DataObject.newStructureData(
+            DataObject.newUInteger32Data(1),
+            DataObject.newOctetStringData(new byte[] {1, 0, 32, 7, 0, (byte) 255}),
+            DataObject.newInteger32Data(2),
+            DataObject.newUInteger32Data(0));
+
+    final DataObject nonAllowedCaptureObject1 =
+        DataObject.newStructureData(
+            DataObject.newUInteger32Data(1),
+            DataObject.newOctetStringData(new byte[] {80, 0, 32, 32, 0, (byte) 255}),
+            DataObject.newInteger32Data(2),
+            DataObject.newUInteger32Data(0));
+    final DataObject nonAllowedCaptureObject2 =
+        DataObject.newStructureData(
+            DataObject.newUInteger32Data(1),
+            DataObject.newOctetStringData(new byte[] {1, 0, 52, 32, 0, (byte) 255}),
+            DataObject.newInteger32Data(2),
+            DataObject.newUInteger32Data(0));
+
+    final GetResult getResult =
+        new GetResultImpl(
+            DataObject.newArrayData(
+                List.of(
+                    allowedCaptureObjectClock,
+                    allowedCaptureObjectINSTANTANEOUS_VOLTAGE_L1,
+                    nonAllowedCaptureObject1,
+                    nonAllowedCaptureObject2)));
+
+    return List.of(getResult);
+  }
+}

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/monitoring/GetPowerQualityProfileTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/monitoring/GetPowerQualityProfileTest.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.openmuc.jdlms.GetResult;
 import org.openmuc.jdlms.datatypes.DataObject;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.testutil.GetResultImpl;
@@ -189,7 +190,9 @@ public abstract class GetPowerQualityProfileTest {
     assertThat(values).hasSize(2);
     assertThat((Date) values.get(0).getValue())
         .isEqualTo(
-            new DateTime(2023, 1, 12, 0, 0, 0).plusMinutes(index * intervalInMinutes).toDate());
+            new DateTime(2023, 1, 12, 0, 0, 0, DateTimeZone.forID("Europe/Amsterdam"))
+                .plusMinutes(index * intervalInMinutes)
+                .toDate());
     assertThat((BigDecimal) values.get(1).getValue()).isEqualTo(BigDecimal.valueOf(index));
   }
 

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/testutil/ObjectConfigServiceHelper.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/testutil/ObjectConfigServiceHelper.java
@@ -12,19 +12,15 @@ package org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.testutil
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.EnumMap;
 import java.util.List;
-import java.util.stream.Collectors;
-import org.openmuc.jdlms.AttributeAddress;
-import org.opensmartgridplatform.dlms.objectconfig.*;
+import org.opensmartgridplatform.dlms.objectconfig.Attribute;
+import org.opensmartgridplatform.dlms.objectconfig.CosemObject;
+import org.opensmartgridplatform.dlms.objectconfig.MeterType;
 
 public class ObjectConfigServiceHelper {
-  private static final int ATTRIBUTE_ID_VALUE = 2;
   private static final int ATTRIBUTE_ID_SCALER_UNIT = 3;
-  private static final String OBIS_CODE_CLOCK = "0.0.1.0.0.255";
-  private static final int CLASS_ID_CLOCK = 8;
 
-  public CosemObject createObject(
+  public static CosemObject createObject(
       final int classId,
       final String obis,
       final String tag,
@@ -35,55 +31,25 @@ public class ObjectConfigServiceHelper {
     object.setObis(obis);
     object.setTag(tag);
     if (scalerUnitValue != null) {
-      object.setAttributes(this.createScalerUnitAttributeList(scalerUnitValue));
+      object.setAttributes(createScalerUnitAttributeList(scalerUnitValue));
     }
-    object.setMeterTypes(this.getMeterTypes(polyphase));
+    object.setMeterTypes(getMeterTypes(polyphase));
 
     return object;
   }
 
-  private List<Attribute> createScalerUnitAttributeList(final String value) {
+  private static List<Attribute> createScalerUnitAttributeList(final String value) {
     final Attribute scalerUnitAttribute = new Attribute();
     scalerUnitAttribute.setId(ATTRIBUTE_ID_SCALER_UNIT);
     scalerUnitAttribute.setValue(value);
     return Collections.singletonList(scalerUnitAttribute);
   }
 
-  private List<MeterType> getMeterTypes(final boolean polyphase) {
+  private static List<MeterType> getMeterTypes(final boolean polyphase) {
     if (polyphase) {
       return Collections.singletonList(MeterType.PP);
     } else {
       return Arrays.asList(MeterType.PP, MeterType.SP);
     }
-  }
-
-  public EnumMap<ObjectProperty, List<Object>> getObjectProperties(
-      final String profile, final PowerQualityRequest powerQualityRequest) {
-    // Create map with the required properties and values for the power quality objects
-    final EnumMap<ObjectProperty, List<Object>> pqProperties = new EnumMap<>(ObjectProperty.class);
-    pqProperties.put(ObjectProperty.PQ_PROFILE, Collections.singletonList(profile));
-    pqProperties.put(
-        ObjectProperty.PQ_REQUEST,
-        Arrays.asList(powerQualityRequest.name(), PowerQualityRequest.BOTH.name()));
-
-    return pqProperties;
-  }
-
-  public List<AttributeAddress> getAttributeAddresses(final List<CosemObject> objects) {
-    return objects.stream()
-        .map(
-            object ->
-                new AttributeAddress(object.getClassId(), object.getObis(), ATTRIBUTE_ID_VALUE))
-        .collect(Collectors.toList());
-  }
-
-  public static CosemObject getClockObject() {
-
-    final CosemObject clock = new CosemObject();
-    clock.setClassId(CLASS_ID_CLOCK);
-    clock.setObis(OBIS_CODE_CLOCK);
-    clock.setTag(DlmsObjectType.CLOCK.name());
-
-    return clock;
   }
 }


### PR DESCRIPTION
This PR solves the problem with retrieving PQ data for polyphase meters where the values for phase 2 and 3 were missing. This was caused by the order of the capture objects returned by the meter. In some cases the handler for selective access didn't handle the values correctly. This is solved by taking the order of the objects into account.
In this PR the unit tests are also refactored to make sure a more realistic scenario is correctly tested.