### PR TITLE
Move output setting to device table

### DIFF
--- a/osgp/platform/osgp-domain-core/src/main/java/org/opensmartgridplatform/domain/core/entities/Device.java
+++ b/osgp/platform/osgp-domain-core/src/main/java/org/opensmartgridplatform/domain/core/entities/Device.java
@@ -24,7 +24,9 @@ import java.util.TreeSet;
 import java.util.stream.Collectors;
 import javax.persistence.AttributeOverride;
 import javax.persistence.CascadeType;
+import javax.persistence.CollectionTable;
 import javax.persistence.Column;
+import javax.persistence.ElementCollection;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -36,6 +38,8 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Transient;
+import org.hibernate.annotations.LazyCollection;
+import org.hibernate.annotations.LazyCollectionOption;
 import org.hibernate.annotations.SortNatural;
 import org.hibernate.annotations.Type;
 import org.opensmartgridplatform.domain.core.valueobjects.Address;
@@ -95,6 +99,15 @@ public class Device extends AbstractEntity {
   @Column(length = 50)
   @Type(type = "org.opensmartgridplatform.shared.hibernate.InetAddressUserType")
   protected InetAddress networkAddress;
+
+  /**
+   * The output settings are only used in the ssld table but in the database it is linked to the
+   * Device Table.
+   */
+  @LazyCollection(LazyCollectionOption.FALSE)
+  @ElementCollection()
+  @CollectionTable(name = "device_output_setting", joinColumns = @JoinColumn(name = "device_id"))
+  protected List<DeviceOutputSetting> outputSettings = new ArrayList<>();
 
   /** Cell ID on a Base Transceiver Station. */
   @Column private Integer cellId;

--- a/osgp/platform/osgp-domain-core/src/main/java/org/opensmartgridplatform/domain/core/entities/Ssld.java
+++ b/osgp/platform/osgp-domain-core/src/main/java/org/opensmartgridplatform/domain/core/entities/Ssld.java
@@ -15,9 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import javax.persistence.CascadeType;
-import javax.persistence.CollectionTable;
 import javax.persistence.Column;
-import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
@@ -55,11 +53,6 @@ public class Ssld extends Device {
       orphanRemoval = true)
   @LazyCollection(LazyCollectionOption.FALSE)
   private final List<Ean> eans = new ArrayList<>();
-
-  @LazyCollection(LazyCollectionOption.FALSE)
-  @ElementCollection()
-  @CollectionTable(name = "device_output_setting", joinColumns = @JoinColumn(name = "device_id"))
-  private List<DeviceOutputSetting> outputSettings = new ArrayList<>();
 
   @OneToMany(
       mappedBy = "device",


### PR DESCRIPTION
The database doesn't match the JPA model that was created. This may cause issues when deleting ssld's or devices.
The real solution would be to refactor the database but this is a first step to have the jpa model match the database.

![Schema](https://user-images.githubusercontent.com/15668493/215426490-c1079275-a35a-4cbb-bbe5-d56abf25c21b.png)
