### PR TITLE
Make use of Artemis jms client library possible

### DIFF
--- a/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/application/config/messaging/OutboundLogItemRequestsMessagingConfig.java
+++ b/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/application/config/messaging/OutboundLogItemRequestsMessagingConfig.java
@@ -9,7 +9,7 @@
 package org.opensmartgridplatform.core.application.config.messaging;
 
 import javax.net.ssl.SSLException;
-import org.apache.activemq.pool.PooledConnectionFactory;
+import org.apache.activemq.jms.pool.PooledConnectionFactory;
 import org.opensmartgridplatform.shared.application.config.messaging.JmsConfiguration;
 import org.opensmartgridplatform.shared.application.config.messaging.JmsConfigurationFactory;
 import org.opensmartgridplatform.shared.application.config.messaging.JmsConfigurationNames;
@@ -25,7 +25,7 @@ public class OutboundLogItemRequestsMessagingConfig {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(OutboundLogItemRequestsMessagingConfig.class);
 
-  private JmsConfigurationFactory jmsConfigurationFactory;
+  private final JmsConfigurationFactory jmsConfigurationFactory;
 
   public OutboundLogItemRequestsMessagingConfig(
       final Environment environment, final JmsConfiguration defaultJmsConfiguration)

--- a/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/infra/jms/ConnectionFactoryRegistry.java
+++ b/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/infra/jms/ConnectionFactoryRegistry.java
@@ -8,7 +8,7 @@
  */
 package org.opensmartgridplatform.core.infra.jms;
 
-import org.apache.activemq.pool.PooledConnectionFactory;
+import org.apache.activemq.jms.pool.PooledConnectionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.DisposableBean;

--- a/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/infra/jms/domain/DefaultDomainJmsConfiguration.java
+++ b/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/infra/jms/domain/DefaultDomainJmsConfiguration.java
@@ -8,10 +8,14 @@
  */
 package org.opensmartgridplatform.core.infra.jms.domain;
 
+import org.opensmartgridplatform.shared.application.config.messaging.JmsBrokerType;
 import org.opensmartgridplatform.shared.application.config.messaging.JmsConfiguration;
 import org.springframework.beans.factory.annotation.Value;
 
 public class DefaultDomainJmsConfiguration implements JmsConfiguration {
+
+  @Value("${jms.domain.default.broker.type:ACTIVE_MQ}")
+  private String jmsDefaultBrokerType;
 
   @Value("${jms.domain.default.broker.url:failover:(tcp://localhost:61616)}")
   private String jmsDefaultBrokerUrl;
@@ -42,6 +46,9 @@ public class DefaultDomainJmsConfiguration implements JmsConfiguration {
 
   @Value("${jms.domain.default.connection.queue.prefetch:1000}")
   private int jmsDefaultConnectionQueuePrefetch;
+
+  @Value("${jms.default.connection.queue.consumer.window.size:1000}")
+  private int jmsDefaultConnectionQueueConsumerWindowSize;
 
   @Value("${jms.domain.default.connection.message.priority.supported:true}")
   private boolean jmsDefaultConnectionMessagePrioritySupported;
@@ -117,6 +124,11 @@ public class DefaultDomainJmsConfiguration implements JmsConfiguration {
   private boolean jmsDefaultExplicitQosEnabled;
 
   @Override
+  public JmsBrokerType getBrokerType() {
+    return JmsBrokerType.valueOf(this.jmsDefaultBrokerType);
+  }
+
+  @Override
   public String getBrokerUrl() {
     return this.jmsDefaultBrokerUrl;
   }
@@ -159,6 +171,11 @@ public class DefaultDomainJmsConfiguration implements JmsConfiguration {
   @Override
   public int getConnectionQueuePrefetch() {
     return this.jmsDefaultConnectionQueuePrefetch;
+  }
+
+  @Override
+  public int getConnectionQueueConsumerWindowSize() {
+    return this.jmsDefaultConnectionQueueConsumerWindowSize;
   }
 
   @Override

--- a/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/infra/jms/domain/inbound/DomainRequestMessageListenerContainerFactory.java
+++ b/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/infra/jms/domain/inbound/DomainRequestMessageListenerContainerFactory.java
@@ -11,7 +11,7 @@ package org.opensmartgridplatform.core.infra.jms.domain.inbound;
 import java.util.ArrayList;
 import java.util.List;
 import javax.net.ssl.SSLException;
-import org.apache.activemq.pool.PooledConnectionFactory;
+import org.apache.activemq.jms.pool.PooledConnectionFactory;
 import org.opensmartgridplatform.core.application.services.DeviceRequestMessageService;
 import org.opensmartgridplatform.core.infra.jms.ConnectionFactoryRegistry;
 import org.opensmartgridplatform.core.infra.jms.MessageListenerContainerRegistry;
@@ -39,11 +39,12 @@ public class DomainRequestMessageListenerContainerFactory
 
   @Autowired private DefaultDomainJmsConfiguration defaultDomainJmsConfiguration;
 
-  private Environment environment;
+  private final Environment environment;
   private final List<DomainInfo> domainInfos;
 
-  private ConnectionFactoryRegistry connectionFactoryRegistry = new ConnectionFactoryRegistry();
-  private MessageListenerContainerRegistry messageListenerContainerRegistry =
+  private final ConnectionFactoryRegistry connectionFactoryRegistry =
+      new ConnectionFactoryRegistry();
+  private final MessageListenerContainerRegistry messageListenerContainerRegistry =
       new MessageListenerContainerRegistry();
 
   public DomainRequestMessageListenerContainerFactory(

--- a/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/infra/jms/domain/inbound/DomainResponseMessageListenerContainerFactory.java
+++ b/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/infra/jms/domain/inbound/DomainResponseMessageListenerContainerFactory.java
@@ -11,7 +11,7 @@ package org.opensmartgridplatform.core.infra.jms.domain.inbound;
 import java.util.ArrayList;
 import java.util.List;
 import javax.net.ssl.SSLException;
-import org.apache.activemq.pool.PooledConnectionFactory;
+import org.apache.activemq.jms.pool.PooledConnectionFactory;
 import org.opensmartgridplatform.core.domain.model.protocol.ProtocolResponseService;
 import org.opensmartgridplatform.core.infra.jms.ConnectionFactoryRegistry;
 import org.opensmartgridplatform.core.infra.jms.MessageListenerContainerRegistry;
@@ -37,12 +37,13 @@ public class DomainResponseMessageListenerContainerFactory
 
   @Autowired private DefaultDomainJmsConfiguration defaultDomainJmsConfiguration;
 
-  private Environment environment;
+  private final Environment environment;
   private final List<DomainInfo> domainInfos;
-  private List<ProtocolInfo> protocolInfos;
+  private final List<ProtocolInfo> protocolInfos;
 
-  private ConnectionFactoryRegistry connectionFactoryRegistry = new ConnectionFactoryRegistry();
-  private MessageListenerContainerRegistry messageListenerRegistry =
+  private final ConnectionFactoryRegistry connectionFactoryRegistry =
+      new ConnectionFactoryRegistry();
+  private final MessageListenerContainerRegistry messageListenerRegistry =
       new MessageListenerContainerRegistry();
 
   public DomainResponseMessageListenerContainerFactory(

--- a/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/infra/jms/domain/outbound/DomainRequestMessageJmsTemplateFactory.java
+++ b/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/infra/jms/domain/outbound/DomainRequestMessageJmsTemplateFactory.java
@@ -11,7 +11,7 @@ package org.opensmartgridplatform.core.infra.jms.domain.outbound;
 import java.util.ArrayList;
 import java.util.List;
 import javax.net.ssl.SSLException;
-import org.apache.activemq.pool.PooledConnectionFactory;
+import org.apache.activemq.jms.pool.PooledConnectionFactory;
 import org.opensmartgridplatform.core.infra.jms.ConnectionFactoryRegistry;
 import org.opensmartgridplatform.core.infra.jms.Registry;
 import org.opensmartgridplatform.core.infra.jms.domain.DefaultDomainJmsConfiguration;
@@ -30,13 +30,14 @@ public class DomainRequestMessageJmsTemplateFactory implements InitializingBean,
   private static final Logger LOGGER =
       LoggerFactory.getLogger(DomainRequestMessageJmsTemplateFactory.class);
 
-  private ConnectionFactoryRegistry connectionFactoryRegistry = new ConnectionFactoryRegistry();
-  private Registry<JmsTemplate> jmsTemplateRegistry = new Registry<>();
+  private final ConnectionFactoryRegistry connectionFactoryRegistry =
+      new ConnectionFactoryRegistry();
+  private final Registry<JmsTemplate> jmsTemplateRegistry = new Registry<>();
 
   @Autowired private DefaultDomainJmsConfiguration defaultDomainJmsConfiguration;
 
-  private Environment environment;
-  private List<DomainInfo> domainInfos;
+  private final Environment environment;
+  private final List<DomainInfo> domainInfos;
 
   public DomainRequestMessageJmsTemplateFactory(
       final Environment environment, final List<DomainInfo> domainInfos) {

--- a/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/infra/jms/domain/outbound/DomainResponseMessageJmsTemplateFactory.java
+++ b/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/infra/jms/domain/outbound/DomainResponseMessageJmsTemplateFactory.java
@@ -11,7 +11,7 @@ package org.opensmartgridplatform.core.infra.jms.domain.outbound;
 import java.util.ArrayList;
 import java.util.List;
 import javax.net.ssl.SSLException;
-import org.apache.activemq.pool.PooledConnectionFactory;
+import org.apache.activemq.jms.pool.PooledConnectionFactory;
 import org.opensmartgridplatform.core.infra.jms.ConnectionFactoryRegistry;
 import org.opensmartgridplatform.core.infra.jms.Registry;
 import org.opensmartgridplatform.core.infra.jms.domain.DefaultDomainJmsConfiguration;
@@ -30,13 +30,14 @@ public class DomainResponseMessageJmsTemplateFactory implements InitializingBean
   private static final Logger LOGGER =
       LoggerFactory.getLogger(DomainResponseMessageJmsTemplateFactory.class);
 
-  private ConnectionFactoryRegistry connectionFactoryRegistry = new ConnectionFactoryRegistry();
-  private Registry<JmsTemplate> jmsTemplateRegistry = new Registry<>();
+  private final ConnectionFactoryRegistry connectionFactoryRegistry =
+      new ConnectionFactoryRegistry();
+  private final Registry<JmsTemplate> jmsTemplateRegistry = new Registry<>();
 
   @Autowired private DefaultDomainJmsConfiguration defaultDomainJmsConfiguration;
 
-  private Environment environment;
-  private List<DomainInfo> domainInfos;
+  private final Environment environment;
+  private final List<DomainInfo> domainInfos;
 
   public DomainResponseMessageJmsTemplateFactory(
       final Environment environment, final List<DomainInfo> domainInfos) {

--- a/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/infra/jms/protocol/DefaultProtocolJmsConfiguration.java
+++ b/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/infra/jms/protocol/DefaultProtocolJmsConfiguration.java
@@ -8,10 +8,14 @@
  */
 package org.opensmartgridplatform.core.infra.jms.protocol;
 
+import org.opensmartgridplatform.shared.application.config.messaging.JmsBrokerType;
 import org.opensmartgridplatform.shared.application.config.messaging.JmsConfiguration;
 import org.springframework.beans.factory.annotation.Value;
 
 public class DefaultProtocolJmsConfiguration implements JmsConfiguration {
+
+  @Value("${jms.protocol.default.broker.type:ACTIVE_MQ}")
+  private String jmsDefaultBrokerType;
 
   @Value("${jms.protocol.default.broker.url:failover:(ssl://localhost:61617)}")
   private String jmsDefaultBrokerUrl;
@@ -42,6 +46,9 @@ public class DefaultProtocolJmsConfiguration implements JmsConfiguration {
 
   @Value("${jms.protocol.default.connection.queue.prefetch:1000}")
   private int jmsDefaultConnectionQueuePrefetch;
+
+  @Value("${jms.default.connection.queue.consumer.window.size:1000}")
+  private int jmsDefaultConnectionQueueConsumerWindowSize;
 
   @Value("${jms.protocol.default.connection.message.priority.supported:true}")
   private boolean jmsDefaultConnectionMessagePrioritySupported;
@@ -118,6 +125,11 @@ public class DefaultProtocolJmsConfiguration implements JmsConfiguration {
   private boolean jmsDefaultExplicitQosEnabled;
 
   @Override
+  public JmsBrokerType getBrokerType() {
+    return JmsBrokerType.valueOf(this.jmsDefaultBrokerType);
+  }
+
+  @Override
   public String getBrokerUrl() {
     return this.jmsDefaultBrokerUrl;
   }
@@ -160,6 +172,11 @@ public class DefaultProtocolJmsConfiguration implements JmsConfiguration {
   @Override
   public int getConnectionQueuePrefetch() {
     return this.jmsDefaultConnectionQueuePrefetch;
+  }
+
+  @Override
+  public int getConnectionQueueConsumerWindowSize() {
+    return this.jmsDefaultConnectionQueueConsumerWindowSize;
   }
 
   @Override

--- a/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/infra/jms/protocol/inbound/ProtocolRequestMessageListenerContainerFactory.java
+++ b/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/infra/jms/protocol/inbound/ProtocolRequestMessageListenerContainerFactory.java
@@ -10,7 +10,7 @@ package org.opensmartgridplatform.core.infra.jms.protocol.inbound;
 
 import java.util.List;
 import javax.net.ssl.SSLException;
-import org.apache.activemq.pool.PooledConnectionFactory;
+import org.apache.activemq.jms.pool.PooledConnectionFactory;
 import org.opensmartgridplatform.core.domain.model.domain.DomainRequestService;
 import org.opensmartgridplatform.core.infra.jms.ConnectionFactoryRegistry;
 import org.opensmartgridplatform.core.infra.jms.MessageListenerContainerRegistry;
@@ -37,14 +37,15 @@ public class ProtocolRequestMessageListenerContainerFactory
 
   @Autowired private DefaultProtocolJmsConfiguration defaultProtocolJmsConfiguration;
 
-  private Environment environment;
-  private List<ProtocolInfo> protocolInfos;
-  private List<DomainInfo> domainInfos;
+  private final Environment environment;
+  private final List<ProtocolInfo> protocolInfos;
+  private final List<DomainInfo> domainInfos;
 
-  private MessageProcessorMap protocolRequestMessageProcessorMap;
+  private final MessageProcessorMap protocolRequestMessageProcessorMap;
 
-  private ConnectionFactoryRegistry connectionFactoryRegistry = new ConnectionFactoryRegistry();
-  private MessageListenerContainerRegistry messageListenerContainerRegistry =
+  private final ConnectionFactoryRegistry connectionFactoryRegistry =
+      new ConnectionFactoryRegistry();
+  private final MessageListenerContainerRegistry messageListenerContainerRegistry =
       new MessageListenerContainerRegistry();
 
   public ProtocolRequestMessageListenerContainerFactory(

--- a/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/infra/jms/protocol/inbound/ProtocolResponseMessageListenerContainerFactory.java
+++ b/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/infra/jms/protocol/inbound/ProtocolResponseMessageListenerContainerFactory.java
@@ -10,7 +10,7 @@ package org.opensmartgridplatform.core.infra.jms.protocol.inbound;
 
 import java.util.List;
 import javax.net.ssl.SSLException;
-import org.apache.activemq.pool.PooledConnectionFactory;
+import org.apache.activemq.jms.pool.PooledConnectionFactory;
 import org.opensmartgridplatform.core.application.services.DeviceResponseMessageService;
 import org.opensmartgridplatform.core.infra.jms.ConnectionFactoryRegistry;
 import org.opensmartgridplatform.core.infra.jms.MessageListenerContainerRegistry;
@@ -35,11 +35,12 @@ public class ProtocolResponseMessageListenerContainerFactory
 
   @Autowired private DefaultProtocolJmsConfiguration defaultProtocolJmsConfiguration;
 
-  private Environment environment;
-  private List<ProtocolInfo> protocolInfos;
+  private final Environment environment;
+  private final List<ProtocolInfo> protocolInfos;
 
-  private ConnectionFactoryRegistry connectionFactoryRegistry = new ConnectionFactoryRegistry();
-  private MessageListenerContainerRegistry messageListenerContainerRegistry =
+  private final ConnectionFactoryRegistry connectionFactoryRegistry =
+      new ConnectionFactoryRegistry();
+  private final MessageListenerContainerRegistry messageListenerContainerRegistry =
       new MessageListenerContainerRegistry();
 
   public ProtocolResponseMessageListenerContainerFactory(

--- a/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/infra/jms/protocol/outbound/ProtocolRequestMessageJmsTemplateFactory.java
+++ b/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/infra/jms/protocol/outbound/ProtocolRequestMessageJmsTemplateFactory.java
@@ -11,7 +11,7 @@ package org.opensmartgridplatform.core.infra.jms.protocol.outbound;
 import java.util.ArrayList;
 import java.util.List;
 import javax.net.ssl.SSLException;
-import org.apache.activemq.pool.PooledConnectionFactory;
+import org.apache.activemq.jms.pool.PooledConnectionFactory;
 import org.opensmartgridplatform.core.infra.jms.ConnectionFactoryRegistry;
 import org.opensmartgridplatform.core.infra.jms.Registry;
 import org.opensmartgridplatform.core.infra.jms.protocol.DefaultProtocolJmsConfiguration;

--- a/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/infra/jms/protocol/outbound/ProtocolResponseMessageJmsTemplateFactory.java
+++ b/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/infra/jms/protocol/outbound/ProtocolResponseMessageJmsTemplateFactory.java
@@ -11,7 +11,7 @@ package org.opensmartgridplatform.core.infra.jms.protocol.outbound;
 import java.util.ArrayList;
 import java.util.List;
 import javax.net.ssl.SSLException;
-import org.apache.activemq.pool.PooledConnectionFactory;
+import org.apache.activemq.jms.pool.PooledConnectionFactory;
 import org.opensmartgridplatform.core.infra.jms.ConnectionFactoryRegistry;
 import org.opensmartgridplatform.core.infra.jms.Registry;
 import org.opensmartgridplatform.core.infra.jms.protocol.DefaultProtocolJmsConfiguration;
@@ -32,11 +32,12 @@ public class ProtocolResponseMessageJmsTemplateFactory implements InitializingBe
 
   @Autowired private DefaultProtocolJmsConfiguration defaultProtocolJmsConfiguration;
 
-  private Environment environment;
-  private List<ProtocolInfo> protocolInfos;
+  private final Environment environment;
+  private final List<ProtocolInfo> protocolInfos;
 
-  private ConnectionFactoryRegistry connectionFactoryRegistry = new ConnectionFactoryRegistry();
-  private Registry<JmsTemplate> jmsTemplateRegistry = new Registry<>();
+  private final ConnectionFactoryRegistry connectionFactoryRegistry =
+      new ConnectionFactoryRegistry();
+  private final Registry<JmsTemplate> jmsTemplateRegistry = new Registry<>();
 
   public ProtocolResponseMessageJmsTemplateFactory(
       final Environment environment, final List<ProtocolInfo> protocolInfos) {

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/config/messaging/InboundOsgpCoreFirmwareFileResponsesMessagingConfig.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/config/messaging/InboundOsgpCoreFirmwareFileResponsesMessagingConfig.java
@@ -12,10 +12,9 @@ package org.opensmartgridplatform.adapter.protocol.dlms.application.config.messa
 
 import java.util.UUID;
 import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
 import javax.jms.MessageListener;
 import javax.net.ssl.SSLException;
-import org.apache.activemq.command.ActiveMQDestination;
-import org.apache.activemq.command.ActiveMQQueue;
 import org.opensmartgridplatform.shared.application.config.messaging.DefaultJmsConfiguration;
 import org.opensmartgridplatform.shared.application.config.messaging.JmsConfigurationFactory;
 import org.slf4j.Logger;
@@ -75,11 +74,11 @@ public class InboundOsgpCoreFirmwareFileResponsesMessagingConfig {
    * to this instance.
    */
   @Bean(name = "protocolDlmsReplyToQueue")
-  public ActiveMQDestination replyToQueue() {
+  public Destination replyToQueue() {
     final String queueName =
         this.createUniqueQueueName(PROPERTY_NAME_FIRMWARE_FILE_RESPONSES_QUEUE);
     LOGGER.info("------> replyToQueue: {}", queueName);
-    return new ActiveMQQueue(queueName);
+    return this.jmsConfigurationFactory.getQueue(queueName);
   }
 
   private String createUniqueQueueName(final String responseQueuePropertyName) {

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/requests/to/core/OsgpRequestMessageSender.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/requests/to/core/OsgpRequestMessageSender.java
@@ -8,10 +8,10 @@
  */
 package org.opensmartgridplatform.adapter.protocol.dlms.infra.messaging.requests.to.core;
 
+import javax.jms.Destination;
 import javax.jms.ObjectMessage;
 import javax.jms.Session;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.activemq.command.ActiveMQDestination;
 import org.opensmartgridplatform.shared.infra.jms.Constants;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.RequestMessage;
@@ -30,7 +30,7 @@ public class OsgpRequestMessageSender {
 
   @Autowired
   @Qualifier("protocolDlmsReplyToQueue")
-  private ActiveMQDestination replyToQueue;
+  private Destination replyToQueue;
 
   public void send(
       final RequestMessage requestMessage,

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/MessagingTestConfiguration.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/MessagingTestConfiguration.java
@@ -11,6 +11,7 @@ package org.opensmartgridplatform.adapter.protocol.dlms.infra.messaging;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
+import javax.jms.Destination;
 import org.apache.activemq.command.ActiveMQDestination;
 import org.mockito.Mockito;
 import org.opensmartgridplatform.adapter.protocol.dlms.application.config.DevicePingConfig;
@@ -114,7 +115,7 @@ public class MessagingTestConfiguration extends AbstractConfig {
   }
 
   @Bean("protocolDlmsReplyToQueue")
-  public ActiveMQDestination replyToQueue() {
+  public Destination replyToQueue() {
     return Mockito.mock(ActiveMQDestination.class);
   }
 

--- a/osgp/shared/shared/pom.xml
+++ b/osgp/shared/shared/pom.xml
@@ -169,6 +169,11 @@
       <groupId>org.apache.activemq</groupId>
       <artifactId>activemq-spring</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>artemis-jms-client-all</artifactId>
+      <version>2.27.1</version>
+    </dependency>
 
     <!-- Hikari connection pooling -->
     <dependency>

--- a/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/messaging/DefaultJmsConfiguration.java
+++ b/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/messaging/DefaultJmsConfiguration.java
@@ -13,6 +13,9 @@ import org.springframework.beans.factory.annotation.Value;
 /** This class provides the default configuration properties used for JMS messaging. */
 public class DefaultJmsConfiguration implements JmsConfiguration {
 
+  @Value("${jms.default.broker.type:ACTIVE_MQ}")
+  private String jmsDefaultBrokerType;
+
   @Value("${jms.default.broker.url:failover:(tcp://localhost:61616)}")
   private String jmsDefaultBrokerUrl;
 
@@ -42,6 +45,9 @@ public class DefaultJmsConfiguration implements JmsConfiguration {
 
   @Value("${jms.default.connection.queue.prefetch:1000}")
   private int jmsDefaultConnectionQueuePrefetch;
+
+  @Value("${jms.default.connection.queue.consumer.window.size:1000}")
+  private int jmsDefaultConnectionQueueConsumerWindowSize;
 
   @Value("${jms.default.connection.message.priority.supported:true}")
   private boolean jmsDefaultConnectionMessagePrioritySupported;
@@ -114,6 +120,11 @@ public class DefaultJmsConfiguration implements JmsConfiguration {
   private boolean jmsDefaultExplicitQosEnabled;
 
   @Override
+  public JmsBrokerType getBrokerType() {
+    return JmsBrokerType.valueOf(this.jmsDefaultBrokerType);
+  }
+
+  @Override
   public String getBrokerUrl() {
     return this.jmsDefaultBrokerUrl;
   }
@@ -156,6 +167,11 @@ public class DefaultJmsConfiguration implements JmsConfiguration {
   @Override
   public int getConnectionQueuePrefetch() {
     return this.jmsDefaultConnectionQueuePrefetch;
+  }
+
+  @Override
+  public int getConnectionQueueConsumerWindowSize() {
+    return this.jmsDefaultConnectionQueueConsumerWindowSize;
   }
 
   @Override

--- a/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/messaging/JmsBroker.java
+++ b/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/messaging/JmsBroker.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023 Alliander N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.opensmartgridplatform.shared.application.config.messaging;
+
+import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
+import javax.net.ssl.SSLException;
+
+public interface JmsBroker {
+
+  JmsBrokerType getBrokerType();
+
+  Destination getQueue();
+
+  ConnectionFactory initConnectionFactory() throws SSLException;
+}

--- a/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/messaging/JmsBroker.java
+++ b/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/messaging/JmsBroker.java
@@ -18,7 +18,7 @@ public interface JmsBroker {
 
   JmsBrokerType getBrokerType();
 
-  Destination getQueue();
+  Destination getQueue(String queueName);
 
   ConnectionFactory initConnectionFactory() throws SSLException;
 

--- a/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/messaging/JmsBroker.java
+++ b/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/messaging/JmsBroker.java
@@ -12,6 +12,7 @@ package org.opensmartgridplatform.shared.application.config.messaging;
 import javax.jms.ConnectionFactory;
 import javax.jms.Destination;
 import javax.net.ssl.SSLException;
+import org.apache.activemq.RedeliveryPolicy;
 
 public interface JmsBroker {
 
@@ -20,4 +21,6 @@ public interface JmsBroker {
   Destination getQueue();
 
   ConnectionFactory initConnectionFactory() throws SSLException;
+
+  RedeliveryPolicy getRedeliveryPolicy();
 }

--- a/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/messaging/JmsBrokerActiveMq.java
+++ b/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/messaging/JmsBrokerActiveMq.java
@@ -47,11 +47,9 @@ public class JmsBrokerActiveMq implements JmsBroker {
   private static final Logger LOGGER = LoggerFactory.getLogger(JmsBrokerActiveMq.class);
 
   private final JmsPropertyReader propertyReader;
-  private final RedeliveryPolicy redeliveryPolicy;
 
   public JmsBrokerActiveMq(final JmsPropertyReader propertyReader) {
     this.propertyReader = propertyReader;
-    this.redeliveryPolicy = this.getRedeliveryPolicy();
   }
 
   @Override
@@ -124,7 +122,7 @@ public class JmsBrokerActiveMq implements JmsBroker {
     LOGGER.debug("Initializing redelivery policy map.");
 
     final RedeliveryPolicyMap redeliveryPolicyMap = new RedeliveryPolicyMap();
-    redeliveryPolicyMap.setDefaultEntry(this.redeliveryPolicy);
+    redeliveryPolicyMap.setDefaultEntry(this.getRedeliveryPolicy());
     return redeliveryPolicyMap;
   }
 

--- a/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/messaging/JmsBrokerActiveMq.java
+++ b/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/messaging/JmsBrokerActiveMq.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2023 Alliander N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.opensmartgridplatform.shared.application.config.messaging;
+
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_BACK_OFF_MULTIPLIER;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_BROKER_CLIENT_KEY_STORE;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_BROKER_CLIENT_KEY_STORE_SECRET;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_BROKER_CLIENT_TRUST_STORE;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_BROKER_CLIENT_TRUST_STORE_SECRET;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_BROKER_SECRET;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_BROKER_URL;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_BROKER_USERNAME;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_CONNECTION_MESSAGE_PRIORITY_SUPPORTED;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_CONNECTION_QUEUE_PREFETCH;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_CONNECTION_SEND_TIMEOUT;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_INITIAL_REDELIVERY_DELAY;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_MAXIMUM_REDELIVERIES;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_MAXIMUM_REDELIVERY_DELAY;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_MAX_THREAD_POOL_SIZE;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_QUEUE;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_REDELIVERY_DELAY;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_TRUSTED_PACKAGES;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_TRUST_ALL_PACKAGES;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_USE_EXPONENTIAL_BACK_OFF;
+
+import java.util.Arrays;
+import java.util.concurrent.ThreadPoolExecutor;
+import javax.jms.Destination;
+import javax.net.ssl.SSLException;
+import org.apache.activemq.ActiveMQPrefetchPolicy;
+import org.apache.activemq.ActiveMQSslConnectionFactory;
+import org.apache.activemq.RedeliveryPolicy;
+import org.apache.activemq.broker.region.policy.RedeliveryPolicyMap;
+import org.apache.activemq.command.ActiveMQQueue;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class JmsBrokerActiveMq implements JmsBroker {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(JmsBrokerActiveMq.class);
+
+  private final JmsPropertyReader propertyReader;
+  private final RedeliveryPolicy redeliveryPolicy;
+
+  public JmsBrokerActiveMq(final JmsPropertyReader propertyReader) {
+    this.propertyReader = propertyReader;
+    this.redeliveryPolicy = this.initRedeliveryPolicy();
+  }
+
+  @Override
+  public JmsBrokerType getBrokerType() {
+    return JmsBrokerType.ACTIVE_MQ;
+  }
+
+  @Override
+  public Destination getQueue() {
+    return new ActiveMQQueue(this.propertyReader.get(PROPERTY_NAME_QUEUE, String.class));
+  }
+
+  @Override
+  public ActiveMQSslConnectionFactory initConnectionFactory() throws SSLException {
+    LOGGER.debug("Initializing connection factory.");
+
+    final ActiveMQPrefetchPolicy activeMQPrefetchPolicy = new ActiveMQPrefetchPolicy();
+    activeMQPrefetchPolicy.setQueuePrefetch(
+        this.propertyReader.get(PROPERTY_NAME_CONNECTION_QUEUE_PREFETCH, int.class));
+
+    final ActiveMQSslConnectionFactory activeMQConnectionFactory =
+        new ActiveMQSslConnectionFactory();
+
+    activeMQConnectionFactory.setRedeliveryPolicyMap(this.getRedeliveryPolicyMap());
+    activeMQConnectionFactory.setBrokerURL(
+        this.propertyReader.get(PROPERTY_NAME_BROKER_URL, String.class));
+    activeMQConnectionFactory.setNonBlockingRedelivery(true);
+    activeMQConnectionFactory.setPrefetchPolicy(activeMQPrefetchPolicy);
+    activeMQConnectionFactory.setSendTimeout(
+        this.propertyReader.get(PROPERTY_NAME_CONNECTION_SEND_TIMEOUT, int.class));
+    final boolean trustAllPackages =
+        this.propertyReader.get(PROPERTY_NAME_TRUST_ALL_PACKAGES, boolean.class);
+    activeMQConnectionFactory.setTrustAllPackages(trustAllPackages);
+    if (!trustAllPackages) {
+      activeMQConnectionFactory.setTrustedPackages(
+          Arrays.asList(
+              this.propertyReader.get(PROPERTY_NAME_TRUSTED_PACKAGES, String.class).split(",")));
+    }
+
+    // Thread management
+    activeMQConnectionFactory.setMaxThreadPoolSize(
+        this.propertyReader.get(PROPERTY_NAME_MAX_THREAD_POOL_SIZE, int.class));
+    activeMQConnectionFactory.setRejectedTaskHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+
+    // Add optional user name/password configuration.
+    final String username = this.propertyReader.get(PROPERTY_NAME_BROKER_USERNAME, String.class);
+    final String password = this.propertyReader.get(PROPERTY_NAME_BROKER_SECRET, String.class);
+    if (!StringUtils.isEmpty(username) && !StringUtils.isEmpty(password)) {
+      activeMQConnectionFactory.setUserName(username);
+      activeMQConnectionFactory.setPassword(password);
+    }
+
+    final JmsBrokerSslSettings jmsBrokerSslSettings =
+        new JmsBrokerSslSettings(
+            this.propertyReader.get(PROPERTY_NAME_BROKER_CLIENT_KEY_STORE, String.class),
+            this.propertyReader.get(PROPERTY_NAME_BROKER_CLIENT_KEY_STORE_SECRET, String.class),
+            this.propertyReader.get(PROPERTY_NAME_BROKER_CLIENT_TRUST_STORE, String.class),
+            this.propertyReader.get(PROPERTY_NAME_BROKER_CLIENT_TRUST_STORE_SECRET, String.class));
+    jmsBrokerSslSettings.applyToFactory(activeMQConnectionFactory);
+
+    // Enable message priority
+    activeMQConnectionFactory.setMessagePrioritySupported(
+        this.propertyReader.get(
+            PROPERTY_NAME_CONNECTION_MESSAGE_PRIORITY_SUPPORTED, boolean.class));
+
+    return activeMQConnectionFactory;
+  }
+
+  private RedeliveryPolicyMap getRedeliveryPolicyMap() {
+    LOGGER.debug("Initializing redelivery policy map.");
+
+    final RedeliveryPolicyMap redeliveryPolicyMap = new RedeliveryPolicyMap();
+    redeliveryPolicyMap.setDefaultEntry(this.redeliveryPolicy);
+    return redeliveryPolicyMap;
+  }
+
+  private RedeliveryPolicy initRedeliveryPolicy() {
+    LOGGER.debug("Initializing redelivery policy.");
+
+    final RedeliveryPolicy policy = new RedeliveryPolicy();
+    policy.setUseExponentialBackOff(
+        this.propertyReader.get(PROPERTY_NAME_USE_EXPONENTIAL_BACK_OFF, boolean.class));
+    policy.setBackOffMultiplier(
+        this.propertyReader.get(PROPERTY_NAME_BACK_OFF_MULTIPLIER, double.class));
+
+    policy.setMaximumRedeliveries(
+        this.propertyReader.get(PROPERTY_NAME_MAXIMUM_REDELIVERIES, int.class));
+    policy.setInitialRedeliveryDelay(
+        this.propertyReader.get(PROPERTY_NAME_INITIAL_REDELIVERY_DELAY, long.class));
+    policy.setRedeliveryDelay(this.propertyReader.get(PROPERTY_NAME_REDELIVERY_DELAY, long.class));
+    policy.setMaximumRedeliveryDelay(
+        this.propertyReader.get(PROPERTY_NAME_MAXIMUM_REDELIVERY_DELAY, long.class));
+    return policy;
+  }
+}

--- a/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/messaging/JmsBrokerActiveMq.java
+++ b/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/messaging/JmsBrokerActiveMq.java
@@ -52,7 +52,7 @@ public class JmsBrokerActiveMq implements JmsBroker {
 
   public JmsBrokerActiveMq(final JmsPropertyReader propertyReader) {
     this.propertyReader = propertyReader;
-    this.redeliveryPolicy = this.initRedeliveryPolicy();
+    this.redeliveryPolicy = this.getRedeliveryPolicy();
   }
 
   @Override
@@ -129,7 +129,8 @@ public class JmsBrokerActiveMq implements JmsBroker {
     return redeliveryPolicyMap;
   }
 
-  private RedeliveryPolicy initRedeliveryPolicy() {
+  @Override
+  public RedeliveryPolicy getRedeliveryPolicy() {
     LOGGER.debug("Initializing redelivery policy.");
 
     final RedeliveryPolicy policy = new RedeliveryPolicy();

--- a/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/messaging/JmsBrokerActiveMq.java
+++ b/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/messaging/JmsBrokerActiveMq.java
@@ -24,7 +24,6 @@ import static org.opensmartgridplatform.shared.application.config.messaging.JmsP
 import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_MAXIMUM_REDELIVERIES;
 import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_MAXIMUM_REDELIVERY_DELAY;
 import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_MAX_THREAD_POOL_SIZE;
-import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_QUEUE;
 import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_REDELIVERY_DELAY;
 import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_TRUSTED_PACKAGES;
 import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_TRUST_ALL_PACKAGES;
@@ -61,8 +60,8 @@ public class JmsBrokerActiveMq implements JmsBroker {
   }
 
   @Override
-  public Destination getQueue() {
-    return new ActiveMQQueue(this.propertyReader.get(PROPERTY_NAME_QUEUE, String.class));
+  public Destination getQueue(final String queueName) {
+    return new ActiveMQQueue(queueName);
   }
 
   @Override

--- a/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/messaging/JmsBrokerArtemis.java
+++ b/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/messaging/JmsBrokerArtemis.java
@@ -92,7 +92,7 @@ public class JmsBrokerArtemis implements JmsBroker {
 
     if (StringUtils.isEmpty(clientKeyStore)) {
       LOGGER.debug(
-          "No " + PROPERTY_NAME_BROKER_CLIENT_KEY_STORE + " found, use brokerUrl: " + brokerUrl);
+          "No {} found, use brokerUrl: {}", PROPERTY_NAME_BROKER_CLIENT_KEY_STORE, brokerUrl);
       return brokerUrl;
     }
 
@@ -110,7 +110,7 @@ public class JmsBrokerArtemis implements JmsBroker {
             trustKeyStorePwd,
             clientKeyStore,
             clientKeyStorePwd);
-    LOGGER.info("Using brokerUrl: " + sslBrokerUrl);
+    LOGGER.info("Using brokerUrl: {}", sslBrokerUrl);
     return sslBrokerUrl;
   }
 }

--- a/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/messaging/JmsBrokerArtemis.java
+++ b/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/messaging/JmsBrokerArtemis.java
@@ -90,7 +90,7 @@ public class JmsBrokerArtemis implements JmsBroker {
     final String trustKeyStorePwd =
         this.propertyReader.get(PROPERTY_NAME_BROKER_CLIENT_TRUST_STORE_SECRET, String.class);
 
-    if (clientKeyStore == null) {
+    if (StringUtils.isEmpty(clientKeyStore)) {
       LOGGER.debug(
           "No " + PROPERTY_NAME_BROKER_CLIENT_KEY_STORE + " found, use brokerUrl: " + brokerUrl);
       return brokerUrl;

--- a/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/messaging/JmsBrokerArtemis.java
+++ b/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/messaging/JmsBrokerArtemis.java
@@ -22,8 +22,10 @@ import static org.opensmartgridplatform.shared.application.config.messaging.JmsP
 
 import javax.jms.Destination;
 import javax.net.ssl.SSLException;
+import org.apache.activemq.RedeliveryPolicy;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.apache.activemq.artemis.jms.client.ActiveMQQueue;
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,6 +48,11 @@ public class JmsBrokerArtemis implements JmsBroker {
   @Override
   public Destination getQueue() {
     return new ActiveMQQueue(this.propertyReader.get(PROPERTY_NAME_QUEUE, String.class));
+  }
+
+  @Override
+  public RedeliveryPolicy getRedeliveryPolicy() {
+    throw new NotImplementedException("RedeliveryPolicy should be implemented in broker.xml");
   }
 
   @Override

--- a/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/messaging/JmsBrokerArtemis.java
+++ b/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/messaging/JmsBrokerArtemis.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
 
 /** This class provides the basic components used for JMS messaging. */
 public class JmsBrokerArtemis implements JmsBroker {
-  private static final Logger LOGGER = LoggerFactory.getLogger(JmsBrokerActiveMq.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(JmsBrokerArtemis.class);
 
   private final JmsPropertyReader propertyReader;
 

--- a/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/messaging/JmsBrokerArtemis.java
+++ b/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/messaging/JmsBrokerArtemis.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2023 Alliander N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.opensmartgridplatform.shared.application.config.messaging;
+
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_BROKER_CLIENT_KEY_STORE;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_BROKER_CLIENT_KEY_STORE_SECRET;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_BROKER_CLIENT_TRUST_STORE;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_BROKER_CLIENT_TRUST_STORE_SECRET;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_BROKER_SECRET;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_BROKER_URL;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_BROKER_USERNAME;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_CONNECTION_QUEUE_CONSUMER_WINDOW_SIZE;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_MAX_THREAD_POOL_SIZE;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_QUEUE;
+
+import javax.jms.Destination;
+import javax.net.ssl.SSLException;
+import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
+import org.apache.activemq.artemis.jms.client.ActiveMQQueue;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** This class provides the basic components used for JMS messaging. */
+public class JmsBrokerArtemis implements JmsBroker {
+  private static final Logger LOGGER = LoggerFactory.getLogger(JmsBrokerActiveMq.class);
+
+  private final JmsPropertyReader propertyReader;
+
+  public JmsBrokerArtemis(final JmsPropertyReader propertyReader) {
+    this.propertyReader = propertyReader;
+  }
+
+  @Override
+  public JmsBrokerType getBrokerType() {
+    return JmsBrokerType.ARTEMIS;
+  }
+
+  @Override
+  public Destination getQueue() {
+    return new ActiveMQQueue(this.propertyReader.get(PROPERTY_NAME_QUEUE, String.class));
+  }
+
+  @Override
+  public ActiveMQConnectionFactory initConnectionFactory() throws SSLException {
+    LOGGER.debug("Initializing connection factory.");
+
+    final ActiveMQConnectionFactory activeMQConnectionFactory =
+        new ActiveMQConnectionFactory(this.initBrokerUrl());
+
+    activeMQConnectionFactory.setConsumerWindowSize(
+        this.propertyReader.get(PROPERTY_NAME_CONNECTION_QUEUE_CONSUMER_WINDOW_SIZE, int.class));
+
+    // Thread management
+    activeMQConnectionFactory.setThreadPoolMaxSize(
+        this.propertyReader.get(PROPERTY_NAME_MAX_THREAD_POOL_SIZE, int.class));
+
+    // Add optional user name/password configuration.
+    final String username = this.propertyReader.get(PROPERTY_NAME_BROKER_USERNAME, String.class);
+    final String password = this.propertyReader.get(PROPERTY_NAME_BROKER_SECRET, String.class);
+    if (!StringUtils.isEmpty(username) && !StringUtils.isEmpty(password)) {
+      activeMQConnectionFactory.setUser(username);
+      activeMQConnectionFactory.setPassword(password);
+    }
+
+    return activeMQConnectionFactory;
+  }
+
+  private String initBrokerUrl() {
+    final String brokerUrl = this.propertyReader.get(PROPERTY_NAME_BROKER_URL, String.class);
+    final String clientKeyStore =
+        this.propertyReader.get(PROPERTY_NAME_BROKER_CLIENT_KEY_STORE, String.class);
+    final String clientKeyStorePwd =
+        this.propertyReader.get(PROPERTY_NAME_BROKER_CLIENT_KEY_STORE_SECRET, String.class);
+    final String trustKeyStore =
+        this.propertyReader.get(PROPERTY_NAME_BROKER_CLIENT_TRUST_STORE, String.class);
+    final String trustKeyStorePwd =
+        this.propertyReader.get(PROPERTY_NAME_BROKER_CLIENT_TRUST_STORE_SECRET, String.class);
+
+    if (clientKeyStore == null) {
+      LOGGER.debug(
+          "No " + PROPERTY_NAME_BROKER_CLIENT_KEY_STORE + " found, use brokerUrl: " + brokerUrl);
+      return brokerUrl;
+    }
+
+    final String sslBrokerUrl =
+        String.format(
+            "%s%s"
+                + "sslEnabled=true"
+                + "&trustStorePath=%s"
+                + "&trustStorePassword=%s"
+                + "&keyStorePath=%s"
+                + "&keyStorePassword=%s",
+            brokerUrl,
+            brokerUrl.contains("?") ? "&" : "?",
+            trustKeyStore,
+            trustKeyStorePwd,
+            clientKeyStore,
+            clientKeyStorePwd);
+    LOGGER.info("Using brokerUrl: " + sslBrokerUrl);
+    return sslBrokerUrl;
+  }
+}

--- a/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/messaging/JmsBrokerArtemis.java
+++ b/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/messaging/JmsBrokerArtemis.java
@@ -18,7 +18,6 @@ import static org.opensmartgridplatform.shared.application.config.messaging.JmsP
 import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_BROKER_USERNAME;
 import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_CONNECTION_QUEUE_CONSUMER_WINDOW_SIZE;
 import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_MAX_THREAD_POOL_SIZE;
-import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_QUEUE;
 
 import javax.jms.Destination;
 import javax.net.ssl.SSLException;
@@ -46,8 +45,8 @@ public class JmsBrokerArtemis implements JmsBroker {
   }
 
   @Override
-  public Destination getQueue() {
-    return new ActiveMQQueue(this.propertyReader.get(PROPERTY_NAME_QUEUE, String.class));
+  public Destination getQueue(final String queueName) {
+    return new ActiveMQQueue(queueName);
   }
 
   @Override

--- a/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/messaging/JmsBrokerFactory.java
+++ b/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/messaging/JmsBrokerFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 Alliander N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.opensmartgridplatform.shared.application.config.messaging;
+
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class JmsBrokerFactory {
+  private final Map<JmsBrokerType, JmsBroker> jmsBrokerMap;
+
+  public JmsBrokerFactory(final JmsPropertyReader propertyReader) {
+    this.jmsBrokerMap =
+        Stream.of(new JmsBrokerActiveMq(propertyReader), new JmsBrokerArtemis(propertyReader))
+            .collect(Collectors.toMap(JmsBroker::getBrokerType, Function.identity()));
+  }
+
+  public JmsBroker getBroker(final JmsBrokerType jmsBrokerType) {
+    if (!this.jmsBrokerMap.containsKey(jmsBrokerType)) {
+      throw new IllegalArgumentException("Unknown broker type: " + jmsBrokerType);
+    }
+    return this.jmsBrokerMap.get(jmsBrokerType);
+  }
+}

--- a/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/messaging/JmsBrokerType.java
+++ b/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/messaging/JmsBrokerType.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2023 Alliander N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.opensmartgridplatform.shared.application.config.messaging;
+
+public enum JmsBrokerType {
+  ACTIVE_MQ,
+  ARTEMIS
+}

--- a/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/messaging/JmsConfiguration.java
+++ b/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/messaging/JmsConfiguration.java
@@ -11,6 +11,8 @@ package org.opensmartgridplatform.shared.application.config.messaging;
 
 public interface JmsConfiguration {
 
+  JmsBrokerType getBrokerType();
+
   String getBrokerUrl();
 
   int getConnectionPoolSize();
@@ -30,6 +32,8 @@ public interface JmsConfiguration {
   int getConnectionPoolIdleTimeout();
 
   int getConnectionQueuePrefetch();
+
+  int getConnectionQueueConsumerWindowSize();
 
   boolean isConnectionMessagePrioritySupported();
 

--- a/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/messaging/JmsConfigurationFactory.java
+++ b/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/messaging/JmsConfigurationFactory.java
@@ -29,6 +29,7 @@ import javax.jms.ConnectionFactory;
 import javax.jms.Destination;
 import javax.jms.MessageListener;
 import javax.net.ssl.SSLException;
+import org.apache.activemq.RedeliveryPolicy;
 import org.apache.activemq.pool.PooledConnectionFactory;
 import org.opensmartgridplatform.shared.infra.jms.OsgpJmsTemplate;
 import org.slf4j.Logger;
@@ -193,12 +194,7 @@ public class JmsConfigurationFactory {
     return connectionFactory;
   }
 
-  protected JmsBrokerType getBrokerType() {
-    final String brokerType = this.getPropertyReader().get(PROPERTY_NAME_BROKER_TYPE, String.class);
-    try {
-      return JmsBrokerType.valueOf(brokerType);
-    } catch (final IllegalArgumentException e) {
-      throw new IllegalArgumentException("Unknown broker type: " + brokerType, e);
-    }
+  public RedeliveryPolicy getRedeliveryPolicy() {
+    return this.jmsBroker.getRedeliveryPolicy();
   }
 }

--- a/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/messaging/JmsConfigurationFactory.java
+++ b/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/messaging/JmsConfigurationFactory.java
@@ -20,6 +20,7 @@ import static org.opensmartgridplatform.shared.application.config.messaging.JmsP
 import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_DELIVERY_PERSISTENT;
 import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_EXPLICIT_QOS_ENABLED;
 import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_MAX_CONCURRENT_CONSUMERS;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_QUEUE;
 import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_TIME_TO_LIVE;
 
 import javax.jms.ConnectionFactory;
@@ -27,7 +28,7 @@ import javax.jms.Destination;
 import javax.jms.MessageListener;
 import javax.net.ssl.SSLException;
 import org.apache.activemq.RedeliveryPolicy;
-import org.apache.activemq.pool.PooledConnectionFactory;
+import org.apache.activemq.jms.pool.PooledConnectionFactory;
 import org.opensmartgridplatform.shared.infra.jms.OsgpJmsTemplate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -65,8 +66,8 @@ public class JmsConfigurationFactory {
     return jmsBrokerFactory.getBroker(jmsBrokerType);
   }
 
-  private Destination getQueue() {
-    return this.jmsBroker.getQueue();
+  public Destination getQueue(final String queueName) {
+    return this.jmsBroker.getQueue(queueName);
   }
 
   private ConnectionFactory initConnectionFactory() throws SSLException {
@@ -80,7 +81,7 @@ public class JmsConfigurationFactory {
   public JmsTemplate initJmsTemplate() {
     LOGGER.debug("Initializing JMS template.");
 
-    final Destination destination = this.getQueue();
+    final Destination destination = this.getQueue(this.getQueueName());
     return this.initJmsTemplate(destination);
   }
 
@@ -101,8 +102,12 @@ public class JmsConfigurationFactory {
       final MessageListener messageListener) {
     LOGGER.debug(
         "Initializing message listener container for message listener: {}.", messageListener);
-    final Destination destination = this.getQueue();
+    final Destination destination = this.getQueue(this.getQueueName());
     return this.initMessageListenerContainer(messageListener, destination);
+  }
+
+  private String getQueueName() {
+    return this.propertyReader.get(PROPERTY_NAME_QUEUE, String.class);
   }
 
   public DefaultMessageListenerContainer initMessageListenerContainer(

--- a/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/messaging/JmsConfigurationFactory.java
+++ b/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/messaging/JmsConfigurationFactory.java
@@ -59,23 +59,16 @@ public class JmsConfigurationFactory {
     this.consumerConnectionFactory = this.initConnectionFactory();
   }
 
-  private JmsBroker getBroker() {
-    final JmsBrokerType jmsBrokerType =
-        this.propertyReader.get(PROPERTY_NAME_BROKER_TYPE, JmsBrokerType.class);
-    final JmsBrokerFactory jmsBrokerFactory = new JmsBrokerFactory(this.propertyReader);
-    return jmsBrokerFactory.getBroker(jmsBrokerType);
-  }
-
   public Destination getQueue(final String queueName) {
     return this.jmsBroker.getQueue(queueName);
   }
 
-  private ConnectionFactory initConnectionFactory() throws SSLException {
-    return this.jmsBroker.initConnectionFactory();
-  }
-
   public PooledConnectionFactory getPooledConnectionFactory() {
     return this.pooledConnectionFactory;
+  }
+
+  public ConnectionFactory getConsumerConnectionFactory() {
+    return this.consumerConnectionFactory;
   }
 
   public JmsTemplate initJmsTemplate() {
@@ -106,10 +99,6 @@ public class JmsConfigurationFactory {
     return this.initMessageListenerContainer(messageListener, destination);
   }
 
-  private String getQueueName() {
-    return this.propertyReader.get(PROPERTY_NAME_QUEUE, String.class);
-  }
-
   public DefaultMessageListenerContainer initMessageListenerContainer(
       final MessageListener messageListener, final Destination destination) {
     LOGGER.debug(
@@ -122,6 +111,25 @@ public class JmsConfigurationFactory {
     messageListenerContainer.setDestination(destination);
     messageListenerContainer.setMessageListener(messageListener);
     return messageListenerContainer;
+  }
+
+  public RedeliveryPolicy getRedeliveryPolicy() {
+    return this.jmsBroker.getRedeliveryPolicy();
+  }
+
+  private ConnectionFactory initConnectionFactory() throws SSLException {
+    return this.jmsBroker.initConnectionFactory();
+  }
+
+  private JmsBroker getBroker() {
+    final JmsBrokerType jmsBrokerType =
+        this.propertyReader.get(PROPERTY_NAME_BROKER_TYPE, JmsBrokerType.class);
+    final JmsBrokerFactory jmsBrokerFactory = new JmsBrokerFactory(this.propertyReader);
+    return jmsBrokerFactory.getBroker(jmsBrokerType);
+  }
+
+  private String getQueueName() {
+    return this.propertyReader.get(PROPERTY_NAME_QUEUE, String.class);
   }
 
   private DefaultMessageListenerContainer initMessageListenerContainer() {
@@ -165,9 +173,5 @@ public class JmsConfigurationFactory {
             PROPERTY_NAME_CONNECTION_POOL_TIME_BETWEEN_EXPIRATION_CHECK_MILLIS, long.class));
 
     return connectionFactory;
-  }
-
-  public RedeliveryPolicy getRedeliveryPolicy() {
-    return this.jmsBroker.getRedeliveryPolicy();
   }
 }

--- a/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/messaging/JmsConfigurationFactory.java
+++ b/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/messaging/JmsConfigurationFactory.java
@@ -8,16 +8,8 @@
  */
 package org.opensmartgridplatform.shared.application.config.messaging;
 
-import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_BACK_OFF_MULTIPLIER;
-import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_BROKER_CLIENT_KEY_STORE;
-import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_BROKER_CLIENT_KEY_STORE_SECRET;
-import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_BROKER_CLIENT_TRUST_STORE;
-import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_BROKER_CLIENT_TRUST_STORE_SECRET;
-import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_BROKER_SECRET;
-import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_BROKER_URL;
-import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_BROKER_USERNAME;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_BROKER_TYPE;
 import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_CONCURRENT_CONSUMERS;
-import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_CONNECTION_MESSAGE_PRIORITY_SUPPORTED;
 import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_CONNECTION_POOL_BLOCK_IF_SESSION_POOL_IS_FULL;
 import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_CONNECTION_POOL_BLOCK_IF_SESSION_POOL_IS_FULL_TIMEOUT;
 import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_CONNECTION_POOL_EXPIRY_TIMEOUT;
@@ -25,34 +17,19 @@ import static org.opensmartgridplatform.shared.application.config.messaging.JmsP
 import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_CONNECTION_POOL_MAX_ACTIVE_SESSIONS;
 import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_CONNECTION_POOL_SIZE;
 import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_CONNECTION_POOL_TIME_BETWEEN_EXPIRATION_CHECK_MILLIS;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_CONNECTION_QUEUE_CONSUMER_WINDOW_SIZE;
 import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_CONNECTION_QUEUE_PREFETCH;
-import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_CONNECTION_SEND_TIMEOUT;
 import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_DELIVERY_PERSISTENT;
 import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_EXPLICIT_QOS_ENABLED;
-import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_INITIAL_REDELIVERY_DELAY;
-import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_MAXIMUM_REDELIVERIES;
-import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_MAXIMUM_REDELIVERY_DELAY;
 import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_MAX_CONCURRENT_CONSUMERS;
-import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_MAX_THREAD_POOL_SIZE;
 import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_QUEUE;
-import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_REDELIVERY_DELAY;
 import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_TIME_TO_LIVE;
-import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_TRUSTED_PACKAGES;
-import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_TRUST_ALL_PACKAGES;
-import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_USE_EXPONENTIAL_BACK_OFF;
 
-import java.util.Arrays;
-import java.util.concurrent.ThreadPoolExecutor;
+import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
 import javax.jms.MessageListener;
 import javax.net.ssl.SSLException;
-import org.apache.activemq.ActiveMQPrefetchPolicy;
-import org.apache.activemq.ActiveMQSslConnectionFactory;
-import org.apache.activemq.RedeliveryPolicy;
-import org.apache.activemq.broker.region.policy.RedeliveryPolicyMap;
-import org.apache.activemq.command.ActiveMQDestination;
-import org.apache.activemq.command.ActiveMQQueue;
 import org.apache.activemq.pool.PooledConnectionFactory;
-import org.apache.commons.lang3.StringUtils;
 import org.opensmartgridplatform.shared.infra.jms.OsgpJmsTemplate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,7 +44,8 @@ public class JmsConfigurationFactory {
 
   private final JmsPropertyReader propertyReader;
   private final PooledConnectionFactory pooledConnectionFactory;
-  private final RedeliveryPolicy redeliveryPolicy;
+  private final ConnectionFactory consumerConnectionFactory;
+  private final JmsBroker jmsBroker;
 
   public JmsConfigurationFactory(
       final Environment environment,
@@ -77,27 +55,67 @@ public class JmsConfigurationFactory {
     LOGGER.info("Initializing JmsConfigurationFactory with propertyPrefix \"{}\".", propertyPrefix);
     this.propertyReader =
         new JmsPropertyReader(environment, propertyPrefix, defaultJmsConfiguration);
-    this.redeliveryPolicy = this.initRedeliveryPolicy();
+    this.jmsBroker = this.getBroker();
     this.pooledConnectionFactory = this.initPooledConnectionFactory();
+    if (this.hasCustomPrefetchOrConsumerWindowSize(defaultJmsConfiguration)) {
+      LOGGER.info(
+          "Not using PooledConnectionFactory for consumers, because prefetch/customer.window.size property has been set for queue \"{}\" (see https://activemq.apache.org/what-is-the-prefetch-limit-for).",
+          this.propertyReader.get(PROPERTY_NAME_QUEUE, String.class));
+      this.consumerConnectionFactory = this.initConnectionFactory();
+    } else {
+      this.consumerConnectionFactory = this.pooledConnectionFactory;
+    }
   }
 
-  public RedeliveryPolicy getRedeliveryPolicy() {
-    return this.redeliveryPolicy;
+  private boolean hasCustomPrefetchOrConsumerWindowSize(
+      final JmsConfiguration defaultJmsConfiguration) {
+    final JmsBrokerType jmsBrokerType =
+        this.propertyReader.get(PROPERTY_NAME_BROKER_TYPE, JmsBrokerType.class);
+    switch (jmsBrokerType) {
+      case ACTIVE_MQ -> {
+        return this.propertyReader.get(PROPERTY_NAME_CONNECTION_QUEUE_PREFETCH, int.class)
+            != defaultJmsConfiguration.getConnectionQueuePrefetch();
+      }
+      case ARTEMIS -> {
+        return this.propertyReader.get(
+                PROPERTY_NAME_CONNECTION_QUEUE_CONSUMER_WINDOW_SIZE, int.class)
+            != defaultJmsConfiguration.getConnectionQueueConsumerWindowSize();
+      }
+      default -> throw new IllegalArgumentException("Unknown broker type: " + jmsBrokerType);
+    }
+  }
+
+  private JmsBroker getBroker() {
+    final JmsBrokerType jmsBrokerType =
+        this.propertyReader.get(PROPERTY_NAME_BROKER_TYPE, JmsBrokerType.class);
+    final JmsBrokerFactory jmsBrokerFactory = new JmsBrokerFactory(this.propertyReader);
+    return jmsBrokerFactory.getBroker(jmsBrokerType);
+  }
+
+  private Destination getQueue() {
+    return this.jmsBroker.getQueue();
+  }
+
+  private ConnectionFactory initConnectionFactory() throws SSLException {
+    return this.jmsBroker.initConnectionFactory();
   }
 
   public PooledConnectionFactory getPooledConnectionFactory() {
     return this.pooledConnectionFactory;
   }
 
+  public JmsPropertyReader getPropertyReader() {
+    return this.propertyReader;
+  }
+
   public JmsTemplate initJmsTemplate() {
     LOGGER.debug("Initializing JMS template.");
 
-    final ActiveMQDestination destination =
-        new ActiveMQQueue(this.propertyReader.get(PROPERTY_NAME_QUEUE, String.class));
+    final Destination destination = this.getQueue();
     return this.initJmsTemplate(destination);
   }
 
-  public JmsTemplate initJmsTemplate(final ActiveMQDestination destination) {
+  public JmsTemplate initJmsTemplate(final Destination destination) {
     LOGGER.debug("Initializing JMS template for destination {}", destination);
     final OsgpJmsTemplate jmsTemplate = new OsgpJmsTemplate();
     jmsTemplate.setDefaultDestination(destination);
@@ -114,13 +132,12 @@ public class JmsConfigurationFactory {
       final MessageListener messageListener) {
     LOGGER.debug(
         "Initializing message listener container for message listener: {}.", messageListener);
-    final ActiveMQDestination destination =
-        new ActiveMQQueue(this.propertyReader.get(PROPERTY_NAME_QUEUE, String.class));
+    final Destination destination = this.getQueue();
     return this.initMessageListenerContainer(messageListener, destination);
   }
 
   public DefaultMessageListenerContainer initMessageListenerContainer(
-      final MessageListener messageListener, final ActiveMQDestination destination) {
+      final MessageListener messageListener, final Destination destination) {
     LOGGER.debug(
         "Initializing message listener container for message listener: {}, and destination {}.",
         messageListener,
@@ -138,7 +155,7 @@ public class JmsConfigurationFactory {
 
     final DefaultMessageListenerContainer defaultMessageListenerContainer =
         new DefaultMessageListenerContainer();
-    defaultMessageListenerContainer.setConnectionFactory(this.pooledConnectionFactory);
+    defaultMessageListenerContainer.setConnectionFactory(this.consumerConnectionFactory);
     defaultMessageListenerContainer.setConcurrentConsumers(
         this.propertyReader.get(PROPERTY_NAME_CONCURRENT_CONSUMERS, int.class));
     defaultMessageListenerContainer.setMaxConcurrentConsumers(
@@ -176,85 +193,12 @@ public class JmsConfigurationFactory {
     return connectionFactory;
   }
 
-  private ActiveMQSslConnectionFactory initConnectionFactory() throws SSLException {
-    LOGGER.debug("Initializing connection factory.");
-
-    final ActiveMQPrefetchPolicy activeMQPrefetchPolicy = new ActiveMQPrefetchPolicy();
-    activeMQPrefetchPolicy.setQueuePrefetch(
-        this.propertyReader.get(PROPERTY_NAME_CONNECTION_QUEUE_PREFETCH, int.class));
-
-    final ActiveMQSslConnectionFactory activeMQConnectionFactory =
-        new ActiveMQSslConnectionFactory();
-
-    activeMQConnectionFactory.setRedeliveryPolicyMap(this.initRedeliveryPolicyMap());
-    activeMQConnectionFactory.setBrokerURL(
-        this.propertyReader.get(PROPERTY_NAME_BROKER_URL, String.class));
-    activeMQConnectionFactory.setNonBlockingRedelivery(true);
-    activeMQConnectionFactory.setPrefetchPolicy(activeMQPrefetchPolicy);
-    activeMQConnectionFactory.setSendTimeout(
-        this.propertyReader.get(PROPERTY_NAME_CONNECTION_SEND_TIMEOUT, int.class));
-    final boolean trustAllPackages =
-        this.propertyReader.get(PROPERTY_NAME_TRUST_ALL_PACKAGES, boolean.class);
-    activeMQConnectionFactory.setTrustAllPackages(trustAllPackages);
-    if (!trustAllPackages) {
-      activeMQConnectionFactory.setTrustedPackages(
-          Arrays.asList(
-              this.propertyReader.get(PROPERTY_NAME_TRUSTED_PACKAGES, String.class).split(",")));
+  protected JmsBrokerType getBrokerType() {
+    final String brokerType = this.getPropertyReader().get(PROPERTY_NAME_BROKER_TYPE, String.class);
+    try {
+      return JmsBrokerType.valueOf(brokerType);
+    } catch (final IllegalArgumentException e) {
+      throw new IllegalArgumentException("Unknown broker type: " + brokerType, e);
     }
-
-    // Thread management
-    activeMQConnectionFactory.setMaxThreadPoolSize(
-        this.propertyReader.get(PROPERTY_NAME_MAX_THREAD_POOL_SIZE, int.class));
-    activeMQConnectionFactory.setRejectedTaskHandler(new ThreadPoolExecutor.CallerRunsPolicy());
-
-    // Add optional user name/password configuration.
-    final String username = this.propertyReader.get(PROPERTY_NAME_BROKER_USERNAME, String.class);
-    final String password = this.propertyReader.get(PROPERTY_NAME_BROKER_SECRET, String.class);
-    if (!StringUtils.isEmpty(username) && !StringUtils.isEmpty(password)) {
-      activeMQConnectionFactory.setUserName(username);
-      activeMQConnectionFactory.setPassword(password);
-    }
-
-    final JmsBrokerSslSettings jmsBrokerSslSettings =
-        new JmsBrokerSslSettings(
-            this.propertyReader.get(PROPERTY_NAME_BROKER_CLIENT_KEY_STORE, String.class),
-            this.propertyReader.get(PROPERTY_NAME_BROKER_CLIENT_KEY_STORE_SECRET, String.class),
-            this.propertyReader.get(PROPERTY_NAME_BROKER_CLIENT_TRUST_STORE, String.class),
-            this.propertyReader.get(PROPERTY_NAME_BROKER_CLIENT_TRUST_STORE_SECRET, String.class));
-    jmsBrokerSslSettings.applyToFactory(activeMQConnectionFactory);
-
-    // Enable message priority
-    activeMQConnectionFactory.setMessagePrioritySupported(
-        this.propertyReader.get(
-            PROPERTY_NAME_CONNECTION_MESSAGE_PRIORITY_SUPPORTED, boolean.class));
-
-    return activeMQConnectionFactory;
-  }
-
-  private RedeliveryPolicyMap initRedeliveryPolicyMap() {
-    LOGGER.debug("Initializing redelivery policy map.");
-
-    final RedeliveryPolicyMap redeliveryPolicyMap = new RedeliveryPolicyMap();
-    redeliveryPolicyMap.setDefaultEntry(this.redeliveryPolicy);
-    return redeliveryPolicyMap;
-  }
-
-  private RedeliveryPolicy initRedeliveryPolicy() {
-    LOGGER.debug("Initializing redelivery policy.");
-
-    final RedeliveryPolicy policy = new RedeliveryPolicy();
-    policy.setUseExponentialBackOff(
-        this.propertyReader.get(PROPERTY_NAME_USE_EXPONENTIAL_BACK_OFF, boolean.class));
-    policy.setBackOffMultiplier(
-        this.propertyReader.get(PROPERTY_NAME_BACK_OFF_MULTIPLIER, double.class));
-
-    policy.setMaximumRedeliveries(
-        this.propertyReader.get(PROPERTY_NAME_MAXIMUM_REDELIVERIES, int.class));
-    policy.setInitialRedeliveryDelay(
-        this.propertyReader.get(PROPERTY_NAME_INITIAL_REDELIVERY_DELAY, long.class));
-    policy.setRedeliveryDelay(this.propertyReader.get(PROPERTY_NAME_REDELIVERY_DELAY, long.class));
-    policy.setMaximumRedeliveryDelay(
-        this.propertyReader.get(PROPERTY_NAME_MAXIMUM_REDELIVERY_DELAY, long.class));
-    return policy;
   }
 }

--- a/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/messaging/JmsPropertyNames.java
+++ b/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/messaging/JmsPropertyNames.java
@@ -29,7 +29,7 @@ public final class JmsPropertyNames {
       "connection.pool.time.between.expiration.check.millis";
   public static final String PROPERTY_NAME_CONNECTION_POOL_IDLE_TIMEOUT =
       "connection.pool.idle.timeout";
-  public static String PROPERTY_NAME_CONNECTION_QUEUE_CONSUMER_WINDOW_SIZE =
+  public static final String PROPERTY_NAME_CONNECTION_QUEUE_CONSUMER_WINDOW_SIZE =
       "connection.queue.consumer.window.size";
   public static final String PROPERTY_NAME_CONNECTION_QUEUE_PREFETCH = "connection.queue.prefetch";
   public static final String PROPERTY_NAME_CONNECTION_MESSAGE_PRIORITY_SUPPORTED =

--- a/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/messaging/JmsPropertyNames.java
+++ b/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/application/config/messaging/JmsPropertyNames.java
@@ -11,6 +11,7 @@ package org.opensmartgridplatform.shared.application.config.messaging;
 /** Common property names for JMS configuration classes. */
 public final class JmsPropertyNames {
 
+  public static final String PROPERTY_NAME_BROKER_TYPE = "broker.type";
   public static final String PROPERTY_NAME_BROKER_URL = "broker.url";
   public static final String PROPERTY_NAME_QUEUE = "queue";
 
@@ -28,6 +29,8 @@ public final class JmsPropertyNames {
       "connection.pool.time.between.expiration.check.millis";
   public static final String PROPERTY_NAME_CONNECTION_POOL_IDLE_TIMEOUT =
       "connection.pool.idle.timeout";
+  public static String PROPERTY_NAME_CONNECTION_QUEUE_CONSUMER_WINDOW_SIZE =
+      "connection.queue.consumer.window.size";
   public static final String PROPERTY_NAME_CONNECTION_QUEUE_PREFETCH = "connection.queue.prefetch";
   public static final String PROPERTY_NAME_CONNECTION_MESSAGE_PRIORITY_SUPPORTED =
       "connection.message.priority.supported";

--- a/osgp/shared/shared/src/test/java/org/opensmartgridplatform/shared/application/config/messaging/JmsConfigurationFactoryTest.java
+++ b/osgp/shared/shared/src/test/java/org/opensmartgridplatform/shared/application/config/messaging/JmsConfigurationFactoryTest.java
@@ -1,0 +1,375 @@
+/*
+ * Copyright 2023 Alliander N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.opensmartgridplatform.shared.application.config.messaging;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_BACK_OFF_MULTIPLIER;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_BROKER_CLIENT_KEY_STORE;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_BROKER_CLIENT_KEY_STORE_SECRET;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_BROKER_CLIENT_TRUST_STORE;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_BROKER_CLIENT_TRUST_STORE_SECRET;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_BROKER_SECRET;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_BROKER_TYPE;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_BROKER_URL;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_BROKER_USERNAME;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_CONCURRENT_CONSUMERS;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_CONNECTION_MESSAGE_PRIORITY_SUPPORTED;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_CONNECTION_QUEUE_CONSUMER_WINDOW_SIZE;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_CONNECTION_QUEUE_PREFETCH;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_CONNECTION_SEND_TIMEOUT;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_DELIVERY_PERSISTENT;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_EXPLICIT_QOS_ENABLED;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_INITIAL_REDELIVERY_DELAY;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_MAXIMUM_REDELIVERIES;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_MAXIMUM_REDELIVERY_DELAY;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_MAX_CONCURRENT_CONSUMERS;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_MAX_THREAD_POOL_SIZE;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_QUEUE;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_REDELIVERY_DELAY;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_TIME_TO_LIVE;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_TRUST_ALL_PACKAGES;
+import static org.opensmartgridplatform.shared.application.config.messaging.JmsPropertyNames.PROPERTY_NAME_USE_EXPONENTIAL_BACK_OFF;
+
+import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
+import javax.jms.MessageListener;
+import javax.net.ssl.SSLException;
+import org.apache.activemq.ActiveMQSslConnectionFactory;
+import org.apache.activemq.RedeliveryPolicy;
+import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
+import org.apache.activemq.artemis.jms.client.ActiveMQQueue;
+import org.apache.activemq.jms.pool.PooledConnectionFactory;
+import org.apache.commons.lang3.NotImplementedException;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.env.Environment;
+import org.springframework.jms.core.JmsTemplate;
+import org.springframework.jms.listener.DefaultMessageListenerContainer;
+
+@ExtendWith(MockitoExtension.class)
+public class JmsConfigurationFactoryTest {
+
+  @Mock private Environment environment;
+  @Mock private DefaultJmsConfiguration defaultJmsConfiguration;
+  private final String propertyPrefix = "test.prefix";
+
+  @ParameterizedTest
+  @EnumSource(JmsBrokerType.class)
+  void testGetQueue(final JmsBrokerType jmsBrokerType) throws ClassNotFoundException {
+    final String queueName = "blabla";
+    final JmsConfigurationFactory jmsConfigurationFactory =
+        this.createConnectionFactory(jmsBrokerType);
+
+    final Destination destination = jmsConfigurationFactory.getQueue(queueName);
+
+    final String expectedClassName =
+        jmsBrokerType == JmsBrokerType.ARTEMIS
+            ? "org.apache.activemq.artemis.jms.client.ActiveMQQueue"
+            : "org.apache.activemq.command.ActiveMQQueue";
+
+    assertThat(destination).isInstanceOf(Class.forName(expectedClassName));
+  }
+
+  @ParameterizedTest
+  @EnumSource(JmsBrokerType.class)
+  void testGetPooledConnectionFactory(final JmsBrokerType jmsBrokerType) {
+    final JmsConfigurationFactory jmsConfigurationFactory =
+        this.createConnectionFactory(jmsBrokerType);
+
+    final PooledConnectionFactory pooledConnectionFactory =
+        jmsConfigurationFactory.getPooledConnectionFactory();
+
+    assertThat(pooledConnectionFactory).isInstanceOf(PooledConnectionFactory.class);
+  }
+
+  @ParameterizedTest
+  @EnumSource(JmsBrokerType.class)
+  void testGetConsumerConnectionFactory(final JmsBrokerType jmsBrokerType) {
+    final JmsConfigurationFactory jmsConfigurationFactory =
+        this.createConnectionFactory(jmsBrokerType);
+
+    final ConnectionFactory consumerConnectionFactory =
+        jmsConfigurationFactory.getConsumerConnectionFactory();
+
+    if (jmsBrokerType == JmsBrokerType.ARTEMIS) {
+      assertThat(consumerConnectionFactory).isInstanceOf(ActiveMQConnectionFactory.class);
+    } else if (jmsBrokerType == JmsBrokerType.ACTIVE_MQ) {
+      assertThat(consumerConnectionFactory).isInstanceOf(ActiveMQSslConnectionFactory.class);
+    }
+  }
+
+  @ParameterizedTest
+  @EnumSource(JmsBrokerType.class)
+  void testInitJmsTemplate(final JmsBrokerType jmsBrokerType) throws ClassNotFoundException {
+    final JmsConfigurationFactory jmsConfigurationFactory =
+        this.createConnectionFactory(jmsBrokerType);
+
+    when(this.environment.getProperty(
+            this.propertyPrefix + "." + PROPERTY_NAME_QUEUE, String.class))
+        .thenReturn("queue-name");
+
+    final JmsTemplate jmsTemplate = jmsConfigurationFactory.initJmsTemplate();
+
+    final String expectedClassName =
+        jmsBrokerType == JmsBrokerType.ARTEMIS
+            ? "org.apache.activemq.artemis.jms.client.ActiveMQQueue"
+            : "org.apache.activemq.command.ActiveMQQueue";
+
+    assertThat(jmsTemplate.getDefaultDestination()).isInstanceOf(Class.forName(expectedClassName));
+    assertThat(jmsTemplate.getConnectionFactory())
+        .isEqualTo(jmsConfigurationFactory.getPooledConnectionFactory());
+  }
+
+  @ParameterizedTest
+  @EnumSource(JmsBrokerType.class)
+  void testInitJmsTemplateWithDestination(final JmsBrokerType jmsBrokerType)
+      throws ClassNotFoundException {
+    final JmsConfigurationFactory jmsConfigurationFactory =
+        this.createConnectionFactory(jmsBrokerType);
+
+    final Destination destination =
+        jmsBrokerType == JmsBrokerType.ARTEMIS
+            ? new ActiveMQQueue("xxx")
+            : new org.apache.activemq.command.ActiveMQQueue("xxx");
+
+    when(this.environment.getProperty(
+            this.propertyPrefix + "." + PROPERTY_NAME_EXPLICIT_QOS_ENABLED, boolean.class))
+        .thenReturn(true);
+    when(this.environment.getProperty(
+            this.propertyPrefix + "." + PROPERTY_NAME_TIME_TO_LIVE, long.class))
+        .thenReturn(666l);
+    when(this.environment.getProperty(
+            this.propertyPrefix + "." + PROPERTY_NAME_DELIVERY_PERSISTENT, boolean.class))
+        .thenReturn(false);
+
+    final JmsTemplate jmsTemplate = jmsConfigurationFactory.initJmsTemplate(destination);
+
+    final String expectedClassName =
+        jmsBrokerType == JmsBrokerType.ARTEMIS
+            ? "org.apache.activemq.artemis.jms.client.ActiveMQQueue"
+            : "org.apache.activemq.command.ActiveMQQueue";
+
+    assertThat(jmsTemplate.getDefaultDestination()).isInstanceOf(Class.forName(expectedClassName));
+    assertThat(jmsTemplate.getConnectionFactory())
+        .isEqualTo(jmsConfigurationFactory.getPooledConnectionFactory());
+  }
+
+  @ParameterizedTest
+  @EnumSource(JmsBrokerType.class)
+  void testInitMessageListenerContainer(final JmsBrokerType jmsBrokerType)
+      throws ClassNotFoundException {
+    final JmsConfigurationFactory jmsConfigurationFactory =
+        this.createConnectionFactory(jmsBrokerType);
+
+    when(this.environment.getProperty(
+            this.propertyPrefix + "." + PROPERTY_NAME_QUEUE, String.class))
+        .thenReturn("queue-name");
+
+    when(this.environment.getProperty(
+            this.propertyPrefix + "." + PROPERTY_NAME_CONCURRENT_CONSUMERS, int.class))
+        .thenReturn(9);
+    when(this.environment.getProperty(
+            this.propertyPrefix + "." + PROPERTY_NAME_MAX_CONCURRENT_CONSUMERS, int.class))
+        .thenReturn(19);
+
+    final MessageListener messageListener = mock(MessageListener.class);
+
+    final DefaultMessageListenerContainer defaultMessageListenerContainer =
+        jmsConfigurationFactory.initMessageListenerContainer(messageListener);
+
+    final String expectedClassName =
+        jmsBrokerType == JmsBrokerType.ARTEMIS
+            ? "org.apache.activemq.artemis.jms.client.ActiveMQQueue"
+            : "org.apache.activemq.command.ActiveMQQueue";
+
+    assertThat(defaultMessageListenerContainer.getDestination())
+        .isInstanceOf(Class.forName(expectedClassName));
+    assertThat(defaultMessageListenerContainer.getMessageListener()).isEqualTo(messageListener);
+    assertThat(defaultMessageListenerContainer.getConnectionFactory())
+        .isEqualTo(jmsConfigurationFactory.getConsumerConnectionFactory());
+  }
+
+  @ParameterizedTest
+  @EnumSource(JmsBrokerType.class)
+  void testInitMessageListenerContainerWithDestination(final JmsBrokerType jmsBrokerType)
+      throws ClassNotFoundException {
+    final JmsConfigurationFactory jmsConfigurationFactory =
+        this.createConnectionFactory(jmsBrokerType);
+
+    when(this.environment.getProperty(
+            this.propertyPrefix + "." + PROPERTY_NAME_CONCURRENT_CONSUMERS, int.class))
+        .thenReturn(9);
+    when(this.environment.getProperty(
+            this.propertyPrefix + "." + PROPERTY_NAME_MAX_CONCURRENT_CONSUMERS, int.class))
+        .thenReturn(19);
+
+    final MessageListener messageListener = mock(MessageListener.class);
+    final Destination destination =
+        jmsBrokerType == JmsBrokerType.ARTEMIS
+            ? new ActiveMQQueue("xxx")
+            : new org.apache.activemq.command.ActiveMQQueue("xxx");
+
+    final DefaultMessageListenerContainer defaultMessageListenerContainer =
+        jmsConfigurationFactory.initMessageListenerContainer(messageListener, destination);
+
+    verify(this.environment, never())
+        .getProperty(this.propertyPrefix + "." + PROPERTY_NAME_QUEUE, String.class);
+
+    assertThat(defaultMessageListenerContainer.getDestination()).isEqualTo(destination);
+    assertThat(defaultMessageListenerContainer.getMessageListener()).isEqualTo(messageListener);
+    assertThat(defaultMessageListenerContainer.getConnectionFactory())
+        .isEqualTo(jmsConfigurationFactory.getConsumerConnectionFactory());
+  }
+
+  @ParameterizedTest
+  @EnumSource(JmsBrokerType.class)
+  void testGetRedeliveryPolicy(final JmsBrokerType jmsBrokerType) {
+    final JmsConfigurationFactory jmsConfigurationFactory =
+        this.createConnectionFactory(jmsBrokerType);
+
+    if (jmsBrokerType == JmsBrokerType.ARTEMIS) {
+      assertThrows(NotImplementedException.class, jmsConfigurationFactory::getRedeliveryPolicy);
+    } else if (jmsBrokerType == JmsBrokerType.ACTIVE_MQ) {
+      when(this.environment.getProperty(
+              this.propertyPrefix + "." + PROPERTY_NAME_USE_EXPONENTIAL_BACK_OFF, boolean.class))
+          .thenReturn(false);
+      when(this.environment.getProperty(
+              this.propertyPrefix + "." + PROPERTY_NAME_BACK_OFF_MULTIPLIER, double.class))
+          .thenReturn(2.1);
+      when(this.environment.getProperty(
+              this.propertyPrefix + "." + PROPERTY_NAME_MAXIMUM_REDELIVERIES, int.class))
+          .thenReturn(2);
+      when(this.environment.getProperty(
+              this.propertyPrefix + "." + PROPERTY_NAME_INITIAL_REDELIVERY_DELAY, long.class))
+          .thenReturn(3L);
+      when(this.environment.getProperty(
+              this.propertyPrefix + "." + PROPERTY_NAME_REDELIVERY_DELAY, long.class))
+          .thenReturn(7L);
+      when(this.environment.getProperty(
+              this.propertyPrefix + "." + PROPERTY_NAME_MAXIMUM_REDELIVERY_DELAY, long.class))
+          .thenReturn(8L);
+
+      final RedeliveryPolicy redeliveryPolicy = jmsConfigurationFactory.getRedeliveryPolicy();
+      assertThat(redeliveryPolicy.isUseExponentialBackOff()).isFalse();
+      assertThat(redeliveryPolicy.getBackOffMultiplier()).isEqualTo(2.1);
+      assertThat(redeliveryPolicy.getMaximumRedeliveries()).isEqualTo(2);
+      assertThat(redeliveryPolicy.getInitialRedeliveryDelay()).isEqualTo(3L);
+      assertThat(redeliveryPolicy.getRedeliveryDelay()).isEqualTo(7L);
+      assertThat(redeliveryPolicy.getMaximumRedeliveryDelay()).isEqualTo(8L);
+    }
+  }
+
+  private JmsConfigurationFactory createConnectionFactory(final JmsBrokerType jmsBrokerType) {
+    when(this.environment.getProperty(
+            this.propertyPrefix + "." + PROPERTY_NAME_BROKER_TYPE, JmsBrokerType.class))
+        .thenReturn(jmsBrokerType);
+    when(this.environment.getProperty(
+            this.propertyPrefix + "." + PROPERTY_NAME_BROKER_URL, String.class))
+        .thenReturn("tcp://localhost:61616");
+
+    when(this.environment.getProperty(
+            this.propertyPrefix + "." + PROPERTY_NAME_BROKER_CLIENT_KEY_STORE, String.class))
+        .thenReturn("key_store");
+    when(this.environment.getProperty(
+            this.propertyPrefix + "." + PROPERTY_NAME_BROKER_CLIENT_KEY_STORE_SECRET, String.class))
+        .thenReturn("key_store_secret");
+    when(this.environment.getProperty(
+            this.propertyPrefix + "." + PROPERTY_NAME_BROKER_CLIENT_TRUST_STORE, String.class))
+        .thenReturn("trust_store");
+    when(this.environment.getProperty(
+            this.propertyPrefix + "." + PROPERTY_NAME_BROKER_CLIENT_TRUST_STORE_SECRET,
+            String.class))
+        .thenReturn("trust_store_secret");
+
+    if (jmsBrokerType == JmsBrokerType.ACTIVE_MQ) {
+      this.setupActiveMq();
+    } else if (jmsBrokerType == JmsBrokerType.ARTEMIS) {
+      this.setupArtemis();
+    }
+
+    try {
+      return new JmsConfigurationFactory(
+          this.environment, this.defaultJmsConfiguration, this.propertyPrefix);
+    } catch (final SSLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private void setupArtemis() {
+    when(this.environment.getProperty(
+            this.propertyPrefix + "." + PROPERTY_NAME_CONNECTION_QUEUE_CONSUMER_WINDOW_SIZE,
+            int.class))
+        .thenReturn(1);
+    when(this.environment.getProperty(
+            this.propertyPrefix + "." + PROPERTY_NAME_MAX_THREAD_POOL_SIZE, int.class))
+        .thenReturn(3);
+
+    when(this.environment.getProperty(
+            this.propertyPrefix + "." + PROPERTY_NAME_BROKER_USERNAME, String.class))
+        .thenReturn("user");
+    when(this.environment.getProperty(
+            this.propertyPrefix + "." + PROPERTY_NAME_BROKER_SECRET, String.class))
+        .thenReturn("pass");
+  }
+
+  private void setupActiveMq() {
+    when(this.environment.getProperty(
+            this.propertyPrefix + "." + PROPERTY_NAME_CONNECTION_QUEUE_PREFETCH, int.class))
+        .thenReturn(1);
+    when(this.environment.getProperty(
+            this.propertyPrefix + "." + PROPERTY_NAME_CONNECTION_SEND_TIMEOUT, int.class))
+        .thenReturn(2);
+    when(this.environment.getProperty(
+            this.propertyPrefix + "." + PROPERTY_NAME_TRUST_ALL_PACKAGES, boolean.class))
+        .thenReturn(true);
+    when(this.environment.getProperty(
+            this.propertyPrefix + "." + PROPERTY_NAME_MAX_THREAD_POOL_SIZE, int.class))
+        .thenReturn(3);
+
+    when(this.environment.getProperty(
+            this.propertyPrefix + "." + PROPERTY_NAME_BROKER_USERNAME, String.class))
+        .thenReturn("user");
+    when(this.environment.getProperty(
+            this.propertyPrefix + "." + PROPERTY_NAME_BROKER_SECRET, String.class))
+        .thenReturn("pass");
+
+    when(this.environment.getProperty(
+            this.propertyPrefix + "." + PROPERTY_NAME_CONNECTION_MESSAGE_PRIORITY_SUPPORTED,
+            boolean.class))
+        .thenReturn(true);
+
+    when(this.environment.getProperty(
+            this.propertyPrefix + "." + PROPERTY_NAME_USE_EXPONENTIAL_BACK_OFF, boolean.class))
+        .thenReturn(true);
+    when(this.environment.getProperty(
+            this.propertyPrefix + "." + PROPERTY_NAME_BACK_OFF_MULTIPLIER, double.class))
+        .thenReturn(2.0);
+    when(this.environment.getProperty(
+            this.propertyPrefix + "." + PROPERTY_NAME_MAXIMUM_REDELIVERIES, int.class))
+        .thenReturn(6);
+    when(this.environment.getProperty(
+            this.propertyPrefix + "." + PROPERTY_NAME_INITIAL_REDELIVERY_DELAY, long.class))
+        .thenReturn(8l);
+    when(this.environment.getProperty(
+            this.propertyPrefix + "." + PROPERTY_NAME_REDELIVERY_DELAY, long.class))
+        .thenReturn(9l);
+    when(this.environment.getProperty(
+            this.propertyPrefix + "." + PROPERTY_NAME_MAXIMUM_REDELIVERY_DELAY, long.class))
+        .thenReturn(10l);
+  }
+}

--- a/osgp/shared/shared/src/test/java/org/opensmartgridplatform/shared/application/config/messaging/JmsConfigurationFactoryTest.java
+++ b/osgp/shared/shared/src/test/java/org/opensmartgridplatform/shared/application/config/messaging/JmsConfigurationFactoryTest.java
@@ -63,7 +63,7 @@ import org.springframework.jms.core.JmsTemplate;
 import org.springframework.jms.listener.DefaultMessageListenerContainer;
 
 @ExtendWith(MockitoExtension.class)
-public class JmsConfigurationFactoryTest {
+class JmsConfigurationFactoryTest {
 
   @Mock private Environment environment;
   @Mock private DefaultJmsConfiguration defaultJmsConfiguration;
@@ -116,13 +116,13 @@ public class JmsConfigurationFactoryTest {
       final ActiveMQConnectionFactory connectionFactory =
           (ActiveMQConnectionFactory) pooledConnectionFactory.getConnectionFactory();
       final Map<String, Object> params = connectionFactory.getStaticConnectors()[0].getParams();
-      assertThat(params.get("host")).isEqualTo("localhost");
-      assertThat(params.get("port")).isEqualTo("61616");
-      assertThat(params.get("sslEnabled")).isEqualTo("true");
-      assertThat(params.get("keyStorePath")).isEqualTo("key_store");
-      assertThat(params.get("keyStorePassword")).isEqualTo("key_store_secret");
-      assertThat(params.get("trustStorePath")).isEqualTo("trust_store");
-      assertThat(params.get("trustStorePassword")).isEqualTo("trust_store_secret");
+      assertThat(params).hasFieldOrPropertyWithValue("host", "localhost");
+      assertThat(params).hasFieldOrPropertyWithValue("port", "61616");
+      assertThat(params).hasFieldOrPropertyWithValue("sslEnabled", "true");
+      assertThat(params).hasFieldOrPropertyWithValue("keyStorePath", "key_store");
+      assertThat(params).hasFieldOrPropertyWithValue("keyStorePassword", "key_store_secret");
+      assertThat(params).hasFieldOrPropertyWithValue("trustStorePath", "trust_store");
+      assertThat(params).hasFieldOrPropertyWithValue("trustStorePassword", "trust_store_secret");
     } else if (jmsBrokerType == JmsBrokerType.ACTIVE_MQ) {
       final String expectedBrokerUrl =
           String.format(


### PR DESCRIPTION
We had the problem: high-prio messages are not always processed quick.
The reason is that we are using PooledConnectionFactory in combination with prefetch.

https://activemq.apache.org/what-is-the-prefetch-limit-for
`
Consuming messages from a pool of consumers an be problematic due to prefetch. Unconsumed prefetched messages are only released when a consumer is closed, but with a pooled consumer the close is deferred (for reuse) till the consumer pool closes. This leaves prefetched messages unconsumed till the consumer is reused. This feature can be desirable from a performance perspective. However, it can lead to out-of-order message delivery when there is more than one consumer in the pool. For this reason, the org.apache.activemq.pool.PooledConnectionFactory does not pool consumers.
`

Solution is not using a PooledConnectionFactory when a prefetch is configured, and also we are using a Artimis jms client.
In the solution we tried to implement this with backwards compatibility. So the changes are not breaking existing implementations:

Changes required in properties to make use of this solution:
jms.default.broker.type=ARTEMIS
jms.default.broker.url=failover:(tcp://localhost:61617) -> (tcp://localhost:61617)
jms.default.connection.queue.consumer.window.size=0

Redelivery properties should be set in broker.xml

PooledConnectionFactory is not used anymore for Listeners/Consumers. 
Consumers should not use ConnectionPooling: https://activemq.apache.org/maven/apidocs/org/apache/activemq/jms/pool/PooledConnectionFactory.html
 