### PR TITLE
Add keys for cucumber test for LLS1 and disable tests

### DIFF
--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/database/device/DlmsDeviceSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/database/device/DlmsDeviceSteps.java
@@ -705,6 +705,12 @@ public class DlmsDeviceSteps {
         && "true".equals(inputSettings.get(PlatformSmartmeteringKeys.LLS1_ACTIVE))) {
       secretBuilders.add(
           this.getAppropriateSecretBuilder(PlatformSmartmeteringKeys.PASSWORD, inputSettings));
+      secretBuilders.add(this.getAppropriateSecretBuilder(KEY_DEVICE_ENCRYPTIONKEY, inputSettings));
+      secretBuilders.add(
+          this.getAppropriateSecretBuilder(
+              PlatformSmartmeteringKeys.KEY_DEVICE_MASTERKEY, inputSettings));
+      secretBuilders.add(
+          this.getAppropriateSecretBuilder(KEY_DEVICE_AUTHENTICATIONKEY, inputSettings));
     } else if (this.isGasSmartMeter(deviceType)) {
       secretBuilders.add(this.getAppropriateSecretBuilder(MBUS_DEFAULT_KEY, inputSettings));
       /*

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/ConnectionSecurity.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/ConnectionSecurity.feature
@@ -5,6 +5,7 @@ Feature: SmartMetering Connection security
   So the transferred data is as secure as possible
 
   # Needs a DlmsDevice simulator with security.enabled=false on port 1025
+  @Skip
   Scenario: Communicate with LLS1 encryption without sn and hdlc
     Given a dlms device
       | DeviceIdentification | TEST1025000000001 |
@@ -22,6 +23,7 @@ Feature: SmartMetering Connection security
       | DeviceIdentification | TEST1025000000001 |
 
   # Needs a DlmsDevice simulator with security.enabled=false on port 1025
+  @Skip
   Scenario: Communicate unencrypted
     Given a dlms device
       | DeviceIdentification | TEST1025000000001 |


### PR DESCRIPTION
 Disable tests because simulator doesn't support LLS1 with encryption.