### PR TITLE
Add delay for Artemis instance

### DIFF
--- a/osgp/platform/osgp-adapter-domain-core/src/main/java/org/opensmartgridplatform/adapter/domain/core/application/config/MessagingConfig.java
+++ b/osgp/platform/osgp-adapter-domain-core/src/main/java/org/opensmartgridplatform/adapter/domain/core/application/config/MessagingConfig.java
@@ -16,6 +16,7 @@ import org.opensmartgridplatform.adapter.domain.core.application.config.messagin
 import org.opensmartgridplatform.adapter.domain.core.application.config.messaging.OutboundWebServiceResponsesMessagingConfig;
 import org.opensmartgridplatform.shared.application.config.AbstractConfig;
 import org.opensmartgridplatform.shared.application.config.messaging.DefaultJmsConfiguration;
+import org.opensmartgridplatform.shared.infra.jms.JmsMessageCreator;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -39,5 +40,10 @@ public class MessagingConfig extends AbstractConfig {
   @Bean
   public DefaultJmsConfiguration defaultJmsConfiguration() {
     return new DefaultJmsConfiguration();
+  }
+
+  @Bean
+  JmsMessageCreator jmsMessageCreator(final DefaultJmsConfiguration defaultJmsConfiguration) {
+    return new JmsMessageCreator(defaultJmsConfiguration.getBrokerType());
   }
 }

--- a/osgp/platform/osgp-adapter-domain-core/src/test/java/org/opensmartgridplatform/adapter/domain/core/infra/jms/core/OsgpCoreRequestMessageSenderTest.java
+++ b/osgp/platform/osgp-adapter-domain-core/src/test/java/org/opensmartgridplatform/adapter/domain/core/infra/jms/core/OsgpCoreRequestMessageSenderTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2023 Alliander N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package org.opensmartgridplatform.adapter.domain.core.infra.jms.core;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.ObjectMessage;
+import javax.jms.Session;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
+import org.opensmartgridplatform.shared.infra.jms.Constants;
+import org.opensmartgridplatform.shared.infra.jms.JmsMessageCreator;
+import org.opensmartgridplatform.shared.infra.jms.RequestMessage;
+import org.springframework.jms.core.JmsTemplate;
+import org.springframework.jms.core.MessageCreator;
+
+@ExtendWith(MockitoExtension.class)
+class OsgpCoreRequestMessageSenderTest {
+
+  @Mock private JmsTemplate jmsTemplate;
+  @Mock private Session session;
+  @Mock private ObjectMessage objectMessage;
+
+  @Mock private JmsMessageCreator jmsMessageCreator;
+
+  @InjectMocks private OsgpCoreRequestMessageSender osgpCoreRequestMessageSender;
+
+  @Test
+  void testSend() throws JMSException {
+    final RequestMessage requestMessage = mock(RequestMessage.class);
+    final String messageType = "MESSAGE_TYPE";
+    final int messagePriority = 8;
+    final String ipAddress = "127.0.0.1";
+    final Long delay = 123L;
+    final String correlationUid = "CORR_UID";
+    final String organisationIdentification = "ORG_ID";
+    final String deviceIdentification = "DEVICE_ID";
+
+    when(requestMessage.getCorrelationUid()).thenReturn(correlationUid);
+    when(requestMessage.getOrganisationIdentification()).thenReturn(organisationIdentification);
+    when(requestMessage.getDeviceIdentification()).thenReturn(deviceIdentification);
+
+    when(this.jmsMessageCreator.createObjectMessage(this.session, delay))
+        .thenReturn(this.objectMessage);
+
+    doAnswer(
+            (Answer<Message>)
+                invocation -> {
+                  final Object[] args = invocation.getArguments();
+                  final MessageCreator arg = (MessageCreator) args[0];
+                  return arg.createMessage(this.session);
+                })
+        .when(this.jmsTemplate)
+        .send(any(MessageCreator.class));
+
+    this.osgpCoreRequestMessageSender.sendWithDelay(
+        requestMessage, messageType, messagePriority, ipAddress, delay);
+
+    verify(this.jmsTemplate).send(any(MessageCreator.class));
+    verify(this.objectMessage).setJMSType(messageType);
+    verify(this.objectMessage).setJMSPriority(messagePriority);
+    verify(this.objectMessage).setJMSCorrelationID(correlationUid);
+    verify(this.objectMessage)
+        .setStringProperty(Constants.ORGANISATION_IDENTIFICATION, organisationIdentification);
+    verify(this.objectMessage)
+        .setStringProperty(Constants.DEVICE_IDENTIFICATION, deviceIdentification);
+    verify(this.objectMessage).setStringProperty(Constants.IP_ADDRESS, ipAddress);
+    verify(this.objectMessage).setObject(requestMessage.getRequest());
+  }
+}

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/config/MessagingConfig.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/config/MessagingConfig.java
@@ -15,6 +15,7 @@ import org.opensmartgridplatform.adapter.protocol.dlms.application.config.messag
 import org.opensmartgridplatform.adapter.protocol.dlms.application.config.messaging.OutboundOsgpCoreResponsesMessagingConfig;
 import org.opensmartgridplatform.shared.application.config.AbstractConfig;
 import org.opensmartgridplatform.shared.application.config.messaging.DefaultJmsConfiguration;
+import org.opensmartgridplatform.shared.infra.jms.JmsMessageCreator;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -38,5 +39,10 @@ public class MessagingConfig extends AbstractConfig {
   @Bean
   public DefaultJmsConfiguration defaultJmsConfiguration() {
     return new DefaultJmsConfiguration();
+  }
+
+  @Bean
+  JmsMessageCreator jmsMessageCreator(final DefaultJmsConfiguration defaultJmsConfiguration) {
+    return new JmsMessageCreator(defaultJmsConfiguration.getBrokerType());
   }
 }

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/DeviceRequestMessageProcessor.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/DeviceRequestMessageProcessor.java
@@ -115,6 +115,13 @@ public abstract class DeviceRequestMessageProcessor extends DlmsConnectionMessag
        * Throttling permit for network access not granted, send the request back to the queue to be
        * picked up again a little later by the message listener for device requests.
        */
+      log.info(
+          "Throttling permit was denied for deviceIdentification {} for network segment ({}, {}) for {}. retry message in {} ms",
+          messageMetadata.getDeviceIdentification(),
+          exception.getBaseTransceiverStationId(),
+          exception.getCellId(),
+          exception.getConfigurationName(),
+          this.throttlingClientConfig.permitRejectedDelay().toMillis());
       this.deviceRequestMessageSender.send(
           messageObject, messageMetadata, this.throttlingClientConfig.permitRejectedDelay());
 

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/DeviceRequestMessageSender.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/DeviceRequestMessageSender.java
@@ -12,7 +12,7 @@ package org.opensmartgridplatform.adapter.protocol.dlms.infra.messaging;
 import java.io.Serializable;
 import java.time.Duration;
 import javax.jms.ObjectMessage;
-import org.apache.activemq.ScheduledMessage;
+import org.opensmartgridplatform.shared.infra.jms.JmsMessageCreator;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -26,14 +26,16 @@ public class DeviceRequestMessageSender {
   @Qualifier("protocolDlmsDeviceRequestMessageSenderJmsTemplate")
   private JmsTemplate jmsTemplate;
 
+  @Autowired private JmsMessageCreator jmsMessageCreator;
+
   public void send(
       final Serializable payload, final MessageMetadata messageMetadata, final Duration delay) {
 
     this.jmsTemplate.send(
         session -> {
-          final ObjectMessage objectMessage = session.createObjectMessage(payload);
+          final ObjectMessage objectMessage =
+              this.jmsMessageCreator.createObjectMessage(session, payload, delay.toMillis());
           messageMetadata.applyTo(objectMessage);
-          objectMessage.setLongProperty(ScheduledMessage.AMQ_SCHEDULED_DELAY, delay.toMillis());
           return objectMessage;
         });
   }

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/DeviceRequestMessageSenderTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/DeviceRequestMessageSenderTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023 Alliander N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package org.opensmartgridplatform.adapter.protocol.dlms.infra.messaging;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.Serializable;
+import java.time.Duration;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.ObjectMessage;
+import javax.jms.Session;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
+import org.opensmartgridplatform.shared.infra.jms.JmsMessageCreator;
+import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
+import org.springframework.jms.core.JmsTemplate;
+import org.springframework.jms.core.MessageCreator;
+
+@ExtendWith(MockitoExtension.class)
+class DeviceRequestMessageSenderTest {
+
+  @Mock private JmsTemplate jmsTemplate;
+  @Mock private Session session;
+  @Mock private ObjectMessage objectMessage;
+
+  @Mock private JmsMessageCreator jmsMessageCreator;
+
+  @InjectMocks private DeviceRequestMessageSender deviceRequestMessageSender;
+
+  @Test
+  void testSend() throws JMSException {
+    final Serializable payload = "1234567789";
+    final MessageMetadata messageMetadata = MessageMetadata.newBuilder().build();
+    final Duration delay = Duration.ofSeconds(5);
+
+    when(this.jmsMessageCreator.createObjectMessage(this.session, payload, delay.toMillis()))
+        .thenReturn(this.objectMessage);
+
+    doAnswer(
+            (Answer<Message>)
+                invocation -> {
+                  final Object[] args = invocation.getArguments();
+                  final MessageCreator arg = (MessageCreator) args[0];
+                  return arg.createMessage(this.session);
+                })
+        .when(this.jmsTemplate)
+        .send(any(MessageCreator.class));
+
+    this.deviceRequestMessageSender.send(payload, messageMetadata, delay);
+
+    verify(this.jmsTemplate).send(any(MessageCreator.class));
+  }
+}

--- a/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/infra/jms/JmsMessageCreator.java
+++ b/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/infra/jms/JmsMessageCreator.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2023 Alliander N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.opensmartgridplatform.shared.infra.jms;
+
+import static org.apache.activemq.artemis.api.core.Message.HDR_SCHEDULED_DELIVERY_TIME;
+
+import java.io.Serializable;
+import javax.jms.JMSException;
+import javax.jms.ObjectMessage;
+import javax.jms.Session;
+import org.apache.activemq.ScheduledMessage;
+import org.opensmartgridplatform.shared.application.config.messaging.JmsBrokerType;
+
+public class JmsMessageCreator {
+  private final JmsBrokerType jmsBrokerType;
+
+  public JmsMessageCreator(final JmsBrokerType jmsBrokerType) {
+    this.jmsBrokerType = jmsBrokerType;
+  }
+
+  public ObjectMessage createObjectMessage(
+      final Session session, final Serializable payload, final Long delay) throws JMSException {
+    final ObjectMessage objectMessage = session.createObjectMessage(payload);
+    this.addDelayProperty(objectMessage, delay);
+    return objectMessage;
+  }
+
+  public ObjectMessage createObjectMessage(final Session session, final Long delay)
+      throws JMSException {
+    final ObjectMessage objectMessage = session.createObjectMessage();
+    this.addDelayProperty(objectMessage, delay);
+    return objectMessage;
+  }
+
+  private void addDelayProperty(final ObjectMessage objectMessage, final Long delay)
+      throws JMSException {
+    if (delay == null || delay <= 0) {
+      return;
+    }
+
+    if (this.jmsBrokerType == JmsBrokerType.ACTIVE_MQ) {
+      // Active MQ requires property AMQ_SCHEDULED_DELAY
+      objectMessage.setLongProperty(ScheduledMessage.AMQ_SCHEDULED_DELAY, delay);
+    } else {
+      // Artemis requires property _AMQ_SCHED_DELIVERY
+      objectMessage.setLongProperty(
+          HDR_SCHEDULED_DELIVERY_TIME.toString(), System.currentTimeMillis() + delay);
+    }
+  }
+}

--- a/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/infra/jms/JmsMessageCreator.java
+++ b/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/infra/jms/JmsMessageCreator.java
@@ -13,6 +13,7 @@ import static org.apache.activemq.artemis.api.core.Message.HDR_SCHEDULED_DELIVER
 
 import java.io.Serializable;
 import javax.jms.JMSException;
+import javax.jms.Message;
 import javax.jms.ObjectMessage;
 import javax.jms.Session;
 import org.apache.activemq.ScheduledMessage;
@@ -23,6 +24,12 @@ public class JmsMessageCreator {
 
   public JmsMessageCreator(final JmsBrokerType jmsBrokerType) {
     this.jmsBrokerType = jmsBrokerType;
+  }
+
+  public Message createMessage(final Session session, final Long delay) throws JMSException {
+    final Message message = session.createMessage();
+    this.addDelayProperty(message, delay);
+    return message;
   }
 
   public ObjectMessage createObjectMessage(
@@ -39,18 +46,17 @@ public class JmsMessageCreator {
     return objectMessage;
   }
 
-  private void addDelayProperty(final ObjectMessage objectMessage, final Long delay)
-      throws JMSException {
+  private void addDelayProperty(final Message message, final Long delay) throws JMSException {
     if (delay == null || delay <= 0) {
       return;
     }
 
     if (this.jmsBrokerType == JmsBrokerType.ACTIVE_MQ) {
       // Active MQ requires property AMQ_SCHEDULED_DELAY
-      objectMessage.setLongProperty(ScheduledMessage.AMQ_SCHEDULED_DELAY, delay);
+      message.setLongProperty(ScheduledMessage.AMQ_SCHEDULED_DELAY, delay);
     } else {
       // Artemis requires property _AMQ_SCHED_DELIVERY
-      objectMessage.setLongProperty(
+      message.setLongProperty(
           HDR_SCHEDULED_DELIVERY_TIME.toString(), System.currentTimeMillis() + delay);
     }
   }

--- a/osgp/shared/shared/src/test/java/org/opensmartgridplatform/shared/infra/jms/JmsMessageCreatorTest.java
+++ b/osgp/shared/shared/src/test/java/org/opensmartgridplatform/shared/infra/jms/JmsMessageCreatorTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2023 Alliander N.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package org.opensmartgridplatform.shared.infra.jms;
+
+import static org.apache.activemq.ScheduledMessage.AMQ_SCHEDULED_DELAY;
+import static org.apache.activemq.artemis.api.core.Message.HDR_SCHEDULED_DELIVERY_TIME;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.Serializable;
+import javax.jms.JMSException;
+import javax.jms.ObjectMessage;
+import javax.jms.Session;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensmartgridplatform.shared.application.config.messaging.JmsBrokerType;
+
+@ExtendWith(MockitoExtension.class)
+class JmsMessageCreatorTest {
+
+  @Mock private Session session;
+  @Spy private ObjectMessage message;
+
+  @Captor ArgumentCaptor<String> nameCaptor;
+  @Captor ArgumentCaptor<Long> valueCaptor;
+
+  @ParameterizedTest
+  @EnumSource(JmsBrokerType.class)
+  void shouldNotSetDelayOnNullValue(final JmsBrokerType jmsBrokerType) throws JMSException {
+    final JmsMessageCreator jmsMessageCreator = new JmsMessageCreator(jmsBrokerType);
+
+    when(this.session.createObjectMessage()).thenReturn(this.message);
+
+    final ObjectMessage createdMessage = jmsMessageCreator.createObjectMessage(this.session, null);
+    assertThat(createdMessage).isEqualTo(this.message);
+
+    verifyNoInteractions(this.message);
+  }
+
+  @ParameterizedTest
+  @EnumSource(JmsBrokerType.class)
+  void shouldUseCorrectProperty(final JmsBrokerType jmsBrokerType) throws JMSException {
+    final Long delay = 123L;
+    final JmsMessageCreator jmsMessageCreator = new JmsMessageCreator(jmsBrokerType);
+
+    when(this.session.createObjectMessage()).thenReturn(this.message);
+
+    final ObjectMessage createdMessage = jmsMessageCreator.createObjectMessage(this.session, delay);
+
+    this.validateMessage(createdMessage, delay, jmsBrokerType);
+    assertThat(createdMessage).isEqualTo(this.message);
+  }
+
+  @ParameterizedTest
+  @EnumSource(JmsBrokerType.class)
+  void shouldUseCorrectPropertyWithData(final JmsBrokerType jmsBrokerType) throws JMSException {
+    final Serializable payload = "1234567789";
+    final Long delay = 123L;
+    final JmsMessageCreator jmsMessageCreator = new JmsMessageCreator(jmsBrokerType);
+
+    when(this.session.createObjectMessage(payload)).thenReturn(this.message);
+
+    final ObjectMessage createdMessage =
+        jmsMessageCreator.createObjectMessage(this.session, payload, delay);
+
+    this.validateMessage(createdMessage, delay, jmsBrokerType);
+    assertThat(createdMessage).isEqualTo(this.message);
+  }
+
+  private void validateMessage(
+      final ObjectMessage createdMessage, final Long delay, final JmsBrokerType jmsBrokerType)
+      throws JMSException {
+
+    verify(this.message).setLongProperty(this.nameCaptor.capture(), this.valueCaptor.capture());
+
+    if (jmsBrokerType == JmsBrokerType.ACTIVE_MQ) {
+      assertThat(this.nameCaptor.getValue()).isEqualTo(AMQ_SCHEDULED_DELAY);
+      assertThat(this.valueCaptor.getValue()).isEqualTo(delay);
+      verify(this.message, never())
+          .setLongProperty(eq(HDR_SCHEDULED_DELIVERY_TIME.toString()), any(Long.class));
+    } else {
+      final long expected = System.currentTimeMillis() + delay;
+      assertThat(this.nameCaptor.getValue()).isEqualTo(HDR_SCHEDULED_DELIVERY_TIME.toString());
+      assertThat(this.valueCaptor.getValue()).isBetween(expected - 10, expected);
+      verify(this.message, never())
+          .setLongProperty(eq(AMQ_SCHEDULED_DELAY.toString()), any(Long.class));
+    }
+  }
+}


### PR DESCRIPTION
The property that is required for delayed messages is different on Artemis:

ActiveMQ uses the property AMQ_SCHEDULED_DELAY is used for delay values
Artemis uses the property _AMQ_SCHED_DELIVERY is used for delay values