### PR TITLE
SMHE-1444 DSMR2.2 on demand PQ

### DIFF
--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringmonitoring/ActualPowerQualitySteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringmonitoring/ActualPowerQualitySteps.java
@@ -16,6 +16,8 @@ import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.stream.IntStream;
 import org.opensmartgridplatform.adapter.ws.schema.smartmetering.monitoring.ActualPowerQualityAsyncRequest;
 import org.opensmartgridplatform.adapter.ws.schema.smartmetering.monitoring.ActualPowerQualityAsyncResponse;
 import org.opensmartgridplatform.adapter.ws.schema.smartmetering.monitoring.ActualPowerQualityRequest;
@@ -91,50 +93,44 @@ public class ActualPowerQualitySteps {
         getInteger(settings, "NumberOfPowerQualityObjects", 0);
     final List<PowerQualityObject> actualPowerQualityObjects =
         response.getActualPowerQualityData().getPowerQualityObjects().getPowerQualityObject();
-    assertThat(actualPowerQualityObjects.size())
+    assertThat(actualPowerQualityObjects)
         .as("Number of power quality objects")
-        .isEqualTo(expectedNumberOfPowerQualityObjects);
+        .hasSize(expectedNumberOfPowerQualityObjects);
+    final List<PowerQualityValue> powerQualityValues =
+        response.getActualPowerQualityData().getPowerQualityValues().getPowerQualityValue();
+    assertThat(powerQualityValues)
+        .as("Number of power quality values")
+        .hasSize(expectedNumberOfPowerQualityObjects);
 
     final String expectedName =
         SettingsHelper.getStringValue(settings, "PowerQualityObject_Name", 1);
     // Only check the received objects if there are expected objects defined in the settings
     if (expectedName != null) {
-      for (int i = 0; i < expectedNumberOfPowerQualityObjects; i++) {
-        final PowerQualityObject actualPowerQualityObject = actualPowerQualityObjects.get(i);
-        this.validatePowerQualityObject(actualPowerQualityObject, settings, i + 1);
-      }
-    }
-
-    final int expectedNumberOfPowerQualityValues =
-        getInteger(settings, "NumberOfPowerQualityValues", 0);
-    final List<PowerQualityValue> powerQualityValues =
-        response.getActualPowerQualityData().getPowerQualityValues().getPowerQualityValue();
-    assertThat(powerQualityValues.size())
-        .as("Number of power quality values")
-        .isEqualTo(expectedNumberOfPowerQualityValues);
-
-    if (expectedNumberOfPowerQualityValues > 0) {
-      /*
-       * Expected value equals expectedNumberOfPowerQualityObjects,
-       * because the number of PowerQualityValues should match the number
-       * of power quality objects from the buffer.
-       */
-      assertThat(powerQualityValues.size())
-          .as("Number of power quality values")
-          .isEqualTo(expectedNumberOfPowerQualityObjects);
+      IntStream.range(1, expectedNumberOfPowerQualityObjects)
+          .forEach(
+              i -> this.objectShouldBePresentInResponse(i, settings, actualPowerQualityObjects));
     }
   }
 
-  private void validatePowerQualityObject(
+  private void objectShouldBePresentInResponse(
+      final int settingsIndex,
+      final Map<String, String> settings,
+      final List<PowerQualityObject> actualPowerQualityObjects) {
+    final String expectedName =
+        SettingsHelper.getStringValue(settings, "PowerQualityObject_Name", settingsIndex);
+
+    final Optional<PowerQualityObject> matchingObjectInResponse =
+        actualPowerQualityObjects.stream()
+            .filter(pqObject -> pqObject.getName().equals(expectedName))
+            .findFirst();
+    assertThat(matchingObjectInResponse).as("Response should contain " + expectedName).isPresent();
+    this.validateUnit(matchingObjectInResponse.get(), settings, settingsIndex);
+  }
+
+  private void validateUnit(
       final PowerQualityObject actualPowerQualityObject,
       final Map<String, String> settings,
       final int index) {
-
-    final String expectedName =
-        SettingsHelper.getStringValue(settings, "PowerQualityObject_Name", index);
-    assertThat(actualPowerQualityObject.getName())
-        .as("LogicalName of PowerQualityObject " + index)
-        .isEqualTo(expectedName);
 
     final String expectedUnit =
         SettingsHelper.getStringValue(settings, "PowerQualityObject_Unit", index);

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/monitoring/GetActualPowerQuality.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/monitoring/GetActualPowerQuality.feature
@@ -11,12 +11,13 @@ Feature: SmartMetering Monitoring - Get Actual Power Quality
       | Protocol                  | <Protocol>        |
       | ProtocolVersion           | <ProtocolVersion> |
       | Polyphase                 | true              |
+      | Lls1active                | <Lls1active>      |
+      | Hls5active                | <Hls5active>      |
     When the get actual power quality request is received
       | DeviceIdentification | <DeviceId> |
       | ProfileType          | PUBLIC     |
     Then the actual power quality result should be returned
       | NumberOfPowerQualityObjects |                              15 |
-      | NumberOfPowerQualityValues  |                              15 |
       | DeviceIdentification        | <DeviceId>                      |
       | PowerQualityObject_Name_1   | CLOCK                           |
       | PowerQualityObject_Name_2   | INSTANTANEOUS_VOLTAGE_L1        |
@@ -41,9 +42,10 @@ Feature: SmartMetering Monitoring - Get Actual Power Quality
       | PowerQualityObject_Name_15  | NUMBER_OF_VOLTAGE_SWELLS_FOR_L3 |
 
     Examples:
-      | DeviceId             | Protocol | ProtocolVersion |
-      | TEST1024000000001    | DSMR     | 4.2.2           |
-      | TEST1027000000001    | SMR      | 5.0.0           |
+      | DeviceId             | Protocol | ProtocolVersion | Lls1active | Hls5active |
+      | KTEST10260000001     | DSMR     | 2.2             | true       | false      |
+      | TEST1024000000001    | DSMR     | 4.2.2           | false      | true       |
+      | TEST1027000000001    | SMR      | 5.0.0           | false      | true       |
 
   Scenario Outline: Get the actual power quality public from a device for a single phase <Protocol> <ProtocolVersion> meter
     Given a dlms device
@@ -52,12 +54,13 @@ Feature: SmartMetering Monitoring - Get Actual Power Quality
       | Protocol                  | <Protocol>        |
       | ProtocolVersion           | <ProtocolVersion> |
       | Polyphase                 | false             |
+      | Lls1active                | <Lls1active>      |
+      | Hls5active                | <Hls5active>      |
     When the get actual power quality request is received
       | DeviceIdentification | <DeviceId> |
       | ProfileType          | PUBLIC     |
     Then the actual power quality result should be returned
       | NumberOfPowerQualityObjects |                               7 |
-      | NumberOfPowerQualityValues  |                               7 |
       | DeviceIdentification        | <DeviceId>                      |
       | PowerQualityObject_Name_1   | CLOCK                           |
       | PowerQualityObject_Name_2   | INSTANTANEOUS_VOLTAGE_L1        |
@@ -70,9 +73,10 @@ Feature: SmartMetering Monitoring - Get Actual Power Quality
       | PowerQualityObject_Name_7   | NUMBER_OF_VOLTAGE_SWELLS_FOR_L1 |
 
     Examples:
-      | DeviceId             | Protocol | ProtocolVersion |
-      | TEST1024000000001    | DSMR     | 4.2.2           |
-      | TEST1027000000001    | SMR      | 5.0.0           |
+      | DeviceId             | Protocol | ProtocolVersion | Lls1active | Hls5active |
+      | KTEST10260000001     | DSMR     | 2.2             | true       | false      |
+      | TEST1024000000001    | DSMR     | 4.2.2           | false      | true       |
+      | TEST1027000000001    | SMR      | 5.0.0           | false      | true       |
 
   Scenario Outline: Get the actual power quality private from a device for a polyphase <Protocol> <ProtocolVersion> meter
     Given a dlms device
@@ -81,38 +85,39 @@ Feature: SmartMetering Monitoring - Get Actual Power Quality
       | Protocol                  | <Protocol>        |
       | ProtocolVersion           | <ProtocolVersion> |
       | Polyphase                 | true              |
+      | Lls1active                | <Lls1active>      |
+      | Hls5active                | <Hls5active>      |
     When the get actual power quality request is received
       | DeviceIdentification | <DeviceId> |
       | ProfileType          | PRIVATE    |
     Then the actual power quality result should be returned
       | DeviceIdentification        | <DeviceId>                                         |
-      | NumberOfPowerQualityObjects |                                                 28 |
-      | NumberOfPowerQualityValues  |                                                 28 |
+      | NumberOfPowerQualityObjects | <ExpectedNumber>                                   |
       | PowerQualityObject_Name_1   | CLOCK                                              |
       | PowerQualityObject_Name_2   | INSTANTANEOUS_ACTIVE_POWER_IMPORT                  |
       | PowerQualityObject_Unit_2   | W                                                  |
-      | PowerQualityObject_Name_3   | INSTANTANEOUS_ACTIVE_POWER_EXPORT                  |
-      | PowerQualityObject_Unit_3   | W                                                  |
-      | PowerQualityObject_Name_4   | INSTANTANEOUS_ACTIVE_POWER_IMPORT_L1               |
-      | PowerQualityObject_Unit_4   | W                                                  |
-      | PowerQualityObject_Name_5   | INSTANTANEOUS_ACTIVE_POWER_IMPORT_L2               |
-      | PowerQualityObject_Unit_5   | W                                                  |
-      | PowerQualityObject_Name_6   | INSTANTANEOUS_ACTIVE_POWER_IMPORT_L3               |
-      | PowerQualityObject_Unit_6   | W                                                  |
-      | PowerQualityObject_Name_7   | INSTANTANEOUS_ACTIVE_POWER_EXPORT_L1               |
+      | PowerQualityObject_Name_3   | INSTANTANEOUS_ACTIVE_CURRENT_TOTAL_OVER_ALL_PHASES |
+      | PowerQualityObject_Unit_3   | AMP                                                |
+      | PowerQualityObject_Name_4   | INSTANTANEOUS_CURRENT_L1                           |
+      | PowerQualityObject_Unit_4   | AMP                                                |
+      | PowerQualityObject_Name_5   | INSTANTANEOUS_CURRENT_L2                           |
+      | PowerQualityObject_Unit_5   | AMP                                                |
+      | PowerQualityObject_Name_6   | INSTANTANEOUS_CURRENT_L3                           |
+      | PowerQualityObject_Unit_6   | AMP                                                |
+      | PowerQualityObject_Name_7   | INSTANTANEOUS_ACTIVE_POWER_EXPORT                  |
       | PowerQualityObject_Unit_7   | W                                                  |
-      | PowerQualityObject_Name_8   | INSTANTANEOUS_ACTIVE_POWER_EXPORT_L2               |
+      | PowerQualityObject_Name_8   | INSTANTANEOUS_ACTIVE_POWER_IMPORT_L1               |
       | PowerQualityObject_Unit_8   | W                                                  |
-      | PowerQualityObject_Name_9   | INSTANTANEOUS_ACTIVE_POWER_EXPORT_L3               |
+      | PowerQualityObject_Name_9   | INSTANTANEOUS_ACTIVE_POWER_IMPORT_L2               |
       | PowerQualityObject_Unit_9   | W                                                  |
-      | PowerQualityObject_Name_10  | INSTANTANEOUS_ACTIVE_CURRENT_TOTAL_OVER_ALL_PHASES |
-      | PowerQualityObject_Unit_10  | AMP                                                |
-      | PowerQualityObject_Name_11  | INSTANTANEOUS_CURRENT_L1                           |
-      | PowerQualityObject_Unit_11  | AMP                                                |
-      | PowerQualityObject_Name_12  | INSTANTANEOUS_CURRENT_L2                           |
-      | PowerQualityObject_Unit_12  | AMP                                                |
-      | PowerQualityObject_Name_13  | INSTANTANEOUS_CURRENT_L3                           |
-      | PowerQualityObject_Unit_13  | AMP                                                |
+      | PowerQualityObject_Name_10  | INSTANTANEOUS_ACTIVE_POWER_IMPORT_L3               |
+      | PowerQualityObject_Unit_10  | W                                                  |
+      | PowerQualityObject_Name_11  | INSTANTANEOUS_ACTIVE_POWER_EXPORT_L1               |
+      | PowerQualityObject_Unit_11  | W                                                  |
+      | PowerQualityObject_Name_12  | INSTANTANEOUS_ACTIVE_POWER_EXPORT_L2               |
+      | PowerQualityObject_Unit_12  | W                                                  |
+      | PowerQualityObject_Name_13  | INSTANTANEOUS_ACTIVE_POWER_EXPORT_L3               |
+      | PowerQualityObject_Unit_13  | W                                                  |
       | PowerQualityObject_Name_14  | AVERAGE_ACTIVE_POWER_IMPORT_L1                     |
       | PowerQualityObject_Unit_14  | W                                                  |
       | PowerQualityObject_Name_15  | AVERAGE_ACTIVE_POWER_IMPORT_L2                     |
@@ -145,9 +150,10 @@ Feature: SmartMetering Monitoring - Get Actual Power Quality
       | PowerQualityObject_Unit_28  | AMP                                                |
 
     Examples:
-      | DeviceId             | Protocol | ProtocolVersion |
-      | TEST1024000000001    | DSMR     | 4.2.2           |
-      | TEST1027000000001    | SMR      | 5.0.0           |
+      | DeviceId             | Protocol | ProtocolVersion | Lls1active | Hls5active | ExpectedNumber |
+      | KTEST10260000001     | DSMR     | 2.2             | true       | false      | 6              |
+      | TEST1024000000001    | DSMR     | 4.2.2           | false      | true       | 28             |
+      | TEST1027000000001    | SMR      | 5.0.0           | false      | true       | 28             |
 
   Scenario Outline: Get the actual power quality private from a device for a single phase <Protocol> <ProtocolVersion> meter
     Given a dlms device
@@ -156,26 +162,27 @@ Feature: SmartMetering Monitoring - Get Actual Power Quality
       | Protocol                  | <Protocol>        |
       | ProtocolVersion           | <ProtocolVersion> |
       | Polyphase                 | false             |
+      | Lls1active                | <Lls1active>      |
+      | Hls5active                | <Hls5active>      |
     When the get actual power quality request is received
       | DeviceIdentification | <DeviceId> |
       | ProfileType          | PRIVATE    |
     Then the actual power quality result should be returned
       | DeviceIdentification        | <DeviceId>                                         |
-      | NumberOfPowerQualityObjects |                                                 12 |
-      | NumberOfPowerQualityValues  |                                                 12 |
+      | NumberOfPowerQualityObjects | <ExpectedNumber>                                   |
       | PowerQualityObject_Name_1   | CLOCK                                              |
       | PowerQualityObject_Name_2   | INSTANTANEOUS_ACTIVE_POWER_IMPORT                  |
       | PowerQualityObject_Unit_2   | W                                                  |
-      | PowerQualityObject_Name_3   | INSTANTANEOUS_ACTIVE_POWER_EXPORT                  |
-      | PowerQualityObject_Unit_3   | W                                                  |
-      | PowerQualityObject_Name_4   | INSTANTANEOUS_ACTIVE_POWER_IMPORT_L1               |
-      | PowerQualityObject_Unit_4   | W                                                  |
-      | PowerQualityObject_Name_5   | INSTANTANEOUS_ACTIVE_POWER_EXPORT_L1               |
+      | PowerQualityObject_Name_3   | INSTANTANEOUS_ACTIVE_CURRENT_TOTAL_OVER_ALL_PHASES |
+      | PowerQualityObject_Unit_3   | AMP                                                |
+      | PowerQualityObject_Name_4   | INSTANTANEOUS_CURRENT_L1                           |
+      | PowerQualityObject_Unit_4   | AMP                                                |
+      | PowerQualityObject_Name_5   | INSTANTANEOUS_ACTIVE_POWER_EXPORT                  |
       | PowerQualityObject_Unit_5   | W                                                  |
-      | PowerQualityObject_Name_6   | INSTANTANEOUS_ACTIVE_CURRENT_TOTAL_OVER_ALL_PHASES |
-      | PowerQualityObject_Unit_6   | AMP                                                |
-      | PowerQualityObject_Name_7   | INSTANTANEOUS_CURRENT_L1                           |
-      | PowerQualityObject_Unit_7   | AMP                                                |
+      | PowerQualityObject_Name_6   | INSTANTANEOUS_ACTIVE_POWER_IMPORT_L1               |
+      | PowerQualityObject_Unit_6   | W                                                  |
+      | PowerQualityObject_Name_7   | INSTANTANEOUS_ACTIVE_POWER_EXPORT_L1               |
+      | PowerQualityObject_Unit_7   | W                                                  |
       | PowerQualityObject_Name_8   | AVERAGE_ACTIVE_POWER_IMPORT_L1                     |
       | PowerQualityObject_Unit_8   | W                                                  |
       | PowerQualityObject_Name_9   | AVERAGE_ACTIVE_POWER_EXPORT_L1                     |
@@ -188,9 +195,10 @@ Feature: SmartMetering Monitoring - Get Actual Power Quality
       | PowerQualityObject_Unit_12  | AMP                                                |
 
     Examples:
-      | DeviceId             | Protocol | ProtocolVersion |
-      | TEST1024000000001    | DSMR     | 4.2.2           |
-      | TEST1027000000001    | SMR      | 5.0.0           |
+      | DeviceId             | Protocol | ProtocolVersion | Lls1active | Hls5active | ExpectedNumber |
+      | KTEST10260000001     | DSMR     | 2.2             | true       | false      | 4              |
+      | TEST1024000000001    | DSMR     | 4.2.2           | false      | true       | 12             |
+      | TEST1027000000001    | SMR      | 5.0.0           | false      | true       | 12             |
 
   Scenario: Do not refuse an operation with an inactive device
     Given a dlms device

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/monitoring/GetActualPowerQuality.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/monitoring/GetActualPowerQuality.feature
@@ -93,6 +93,8 @@ Feature: SmartMetering Monitoring - Get Actual Power Quality
     Then the actual power quality result should be returned
       | DeviceIdentification        | <DeviceId>                                         |
       | NumberOfPowerQualityObjects | <ExpectedNumber>                                   |
+      # Only for the expectedNumber of objects is checked if a value is present in the response,
+      # the rest of the list below will be ignored.
       | PowerQualityObject_Name_1   | CLOCK                                              |
       | PowerQualityObject_Name_2   | INSTANTANEOUS_ACTIVE_POWER_IMPORT                  |
       | PowerQualityObject_Unit_2   | W                                                  |
@@ -170,6 +172,8 @@ Feature: SmartMetering Monitoring - Get Actual Power Quality
     Then the actual power quality result should be returned
       | DeviceIdentification        | <DeviceId>                                         |
       | NumberOfPowerQualityObjects | <ExpectedNumber>                                   |
+      # Only for the expectedNumber of objects is checked if a value is present in the response,
+      # the rest of the list below will be ignored.
       | PowerQualityObject_Name_1   | CLOCK                                              |
       | PowerQualityObject_Name_2   | INSTANTANEOUS_ACTIVE_POWER_IMPORT                  |
       | PowerQualityObject_Unit_2   | W                                                  |

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/resources/dlmsprofiles/dlmsprofile-dsmr22.json
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/resources/dlmsprofiles/dlmsprofile-dsmr22.json
@@ -1,0 +1,568 @@
+{
+  "profile": "DSMR",
+  "version": "2.2",
+  "description": "Profile for Smart Meter Requirements 2.2",
+  "properties": [],
+  "objects": [
+    {
+      "tag": "CLOCK",
+      "description": "Clock",
+      "class-id": 8,
+      "version": 0,
+      "obis": "0.0.1.0.0.255",
+      "group": "ABSTRACT",
+      "meterTypes": ["SP","PP"],
+      "attributes": [
+        {
+          "id": 2,
+          "description": "time",
+          "datatype": "octet-string",
+          "valuetype": "DYNAMIC",
+          "value": "CURRENT_LOCAL_DATE_AND_TIME",
+          "access": "RW"
+        },
+        {
+          "id": 3,
+          "description": "time_zone",
+          "datatype": "long",
+          "valuetype": "FIXED_IN_PROFILE",
+          "value": "-60",
+          "access": "RW"
+        },
+        {
+          "id": 4,
+          "description": "status",
+          "datatype": "clock_status",
+          "valuetype": "DYNAMIC",
+          "value": "OK",
+          "access": "R"
+        }
+      ]
+    },
+    {
+      "tag": "NUMBER_OF_VOLTAGE_SWELLS_FOR_L1",
+      "description": "Number of voltage swells in phase L1",
+      "class-id": 1,
+      "version": 0,
+      "obis": "1.0.32.36.0.255",
+      "group": "ELECTRICITY",
+      "meterTypes": ["SP","PP"],
+      "properties": {
+        "PQ_PROFILE": "PUBLIC",
+        "PQ_REQUEST": "ONDEMAND"
+      },
+      "attributes": [
+        {
+          "id": 2,
+          "description": "value",
+          "datatype": "long-unsigned",
+          "valuetype": "DYNAMIC",
+          "value": "0",
+          "access": "R"
+        }
+      ]
+    },
+    {
+      "tag": "NUMBER_OF_VOLTAGE_SWELLS_FOR_L2",
+      "description": "Number of voltage swells in phase L2",
+      "class-id": 1,
+      "version": 0,
+      "obis": "1.0.52.36.0.255",
+      "group": "ELECTRICITY",
+      "meterTypes": ["PP"],
+      "properties": {
+        "PQ_PROFILE": "PUBLIC",
+        "PQ_REQUEST": "ONDEMAND"
+      },
+      "attributes": [
+        {
+          "id": 2,
+          "description": "value",
+          "datatype": "long-unsigned",
+          "valuetype": "DYNAMIC",
+          "value": "0",
+          "access": "R"
+        }
+      ]
+    },
+    {
+      "tag": "NUMBER_OF_VOLTAGE_SWELLS_FOR_L3",
+      "description": "Number of voltage swells in phase L3",
+      "class-id": 1,
+      "version": 0,
+      "obis": "1.0.72.36.0.255",
+      "group": "ELECTRICITY",
+      "meterTypes": ["PP"],
+      "properties": {
+        "PQ_PROFILE": "PUBLIC",
+        "PQ_REQUEST": "ONDEMAND"
+      },
+      "attributes": [
+        {
+          "id": 2,
+          "description": "value",
+          "datatype": "long-unsigned",
+          "valuetype": "DYNAMIC",
+          "value": "0",
+          "access": "R"
+        }
+      ]
+    },
+    {
+      "tag": "NUMBER_OF_VOLTAGE_SAGS_FOR_L1",
+      "description": "Number of voltage sags in phase L1",
+      "class-id": 1,
+      "version": 0,
+      "obis": "1.0.32.32.0.255",
+      "group": "ELECTRICITY",
+      "meterTypes": ["SP","PP"],
+      "properties": {
+        "PQ_PROFILE": "PUBLIC",
+        "PQ_REQUEST": "ONDEMAND"
+      },
+      "attributes": [
+        {
+          "id": 2,
+          "description": "value",
+          "datatype": "long-unsigned",
+          "valuetype": "DYNAMIC",
+          "value": "0",
+          "access": "R"
+        }
+      ]
+    },
+    {
+      "tag": "NUMBER_OF_VOLTAGE_SAGS_FOR_L2",
+      "description": "Number of voltage sags in phase L2",
+      "class-id": 1,
+      "version": 0,
+      "obis": "1.0.52.32.0.255",
+      "group": "ELECTRICITY",
+      "meterTypes": ["PP"],
+      "properties": {
+        "PQ_PROFILE": "PUBLIC",
+        "PQ_REQUEST": "ONDEMAND"
+      },
+      "attributes": [
+        {
+          "id": 2,
+          "description": "value",
+          "datatype": "long-unsigned",
+          "valuetype": "DYNAMIC",
+          "value": "0",
+          "access": "R"
+        }
+      ]
+    },
+    {
+      "tag": "NUMBER_OF_VOLTAGE_SAGS_FOR_L3",
+      "description": "Number of voltage sags in phase L3",
+      "class-id": 1,
+      "version": 0,
+      "obis": "1.0.72.32.0.255",
+      "group": "ELECTRICITY",
+      "meterTypes": ["PP"],
+      "properties": {
+        "PQ_PROFILE": "PUBLIC",
+        "PQ_REQUEST": "ONDEMAND"
+      },
+      "attributes": [
+        {
+          "id": 2,
+          "description": "value",
+          "datatype": "long-unsigned",
+          "valuetype": "DYNAMIC",
+          "value": "0",
+          "access": "R"
+        }
+      ]
+    },
+    {
+      "tag": "NUMBER_OF_LONG_POWER_FAILURES",
+      "description": "Number of long power failures in any phases",
+      "class-id": 1,
+      "version": 0,
+      "obis": "0.0.96.7.9.255",
+      "group": "ELECTRICITY",
+      "meterTypes": ["SP","PP"],
+      "properties": {
+        "PQ_PROFILE": "PUBLIC",
+        "PQ_REQUEST": "ONDEMAND"
+      },
+      "attributes": [
+        {
+          "id": 2,
+          "description": "value",
+          "datatype": "long-unsigned",
+          "valuetype": "DYNAMIC",
+          "value": "0",
+          "access": "R"
+        }
+      ]
+    },
+    {
+      "tag": "NUMBER_OF_POWER_FAILURES",
+      "description": "Number of power failures in any phases",
+      "class-id": 1,
+      "version": 0,
+      "obis": "0.0.96.7.21.255",
+      "group": "ELECTRICITY",
+      "meterTypes": ["SP","PP"],
+      "properties": {
+        "PQ_PROFILE": "PUBLIC",
+        "PQ_REQUEST": "ONDEMAND"
+      },
+      "attributes": [
+        {
+          "id": 2,
+          "description": "value",
+          "datatype": "long-unsigned",
+          "valuetype": "DYNAMIC",
+          "value": "0",
+          "access": "R"
+        }
+      ]
+    },
+    {
+      "tag": "INSTANTANEOUS_VOLTAGE_L1",
+      "description": "Instantaneous voltage L1",
+      "class-id": 3,
+      "version": 0,
+      "obis": "1.0.32.7.0.255",
+      "group": "ELECTRICITY",
+      "meterTypes": ["SP","PP"],
+      "properties": {
+        "PQ_PROFILE": "PUBLIC",
+        "PQ_REQUEST": "ONDEMAND"
+      },
+      "attributes": [
+        {
+          "id": 2,
+          "description": "value",
+          "datatype": "long-unsigned",
+          "valuetype": "DYNAMIC",
+          "value": "0",
+          "access": "R"
+        },
+        {
+          "id": 3,
+          "description": "scaler_unit",
+          "datatype": "scal_unit_type",
+          "valuetype": "FIXED_IN_PROFILE",
+          "value": "0, V",
+          "access": "RW"
+        }
+      ]
+    },
+    {
+      "tag": "INSTANTANEOUS_VOLTAGE_L2",
+      "description": "Instantaneous voltage L2",
+      "class-id": 3,
+      "version": 0,
+      "obis": "1.0.52.7.0.255",
+      "group": "ELECTRICITY",
+      "meterTypes": ["PP"],
+      "properties": {
+        "PQ_PROFILE": "PUBLIC",
+        "PQ_REQUEST": "ONDEMAND"
+      },
+      "attributes": [
+        {
+          "id": 2,
+          "description": "value",
+          "datatype": "long-unsigned",
+          "valuetype": "DYNAMIC",
+          "value": "0",
+          "access": "R"
+        },
+        {
+          "id": 3,
+          "description": "scaler_unit",
+          "datatype": "scal_unit_type",
+          "valuetype": "FIXED_IN_PROFILE",
+          "value": "0, V",
+          "access": "RW"
+        }
+      ]
+    },
+    {
+      "tag": "INSTANTANEOUS_VOLTAGE_L3",
+      "description": "Instantaneous voltage L3",
+      "class-id": 3,
+      "version": 0,
+      "obis": "1.0.72.7.0.255",
+      "group": "ELECTRICITY",
+      "meterTypes": ["PP"],
+      "properties": {
+        "PQ_PROFILE": "PUBLIC",
+        "PQ_REQUEST": "ONDEMAND"
+      },
+      "attributes": [
+        {
+          "id": 2,
+          "description": "value",
+          "datatype": "long-unsigned",
+          "valuetype": "DYNAMIC",
+          "value": "0",
+          "access": "R"
+        },
+        {
+          "id": 3,
+          "description": "scaler_unit",
+          "datatype": "scal_unit_type",
+          "valuetype": "FIXED_IN_PROFILE",
+          "value": "0, V",
+          "access": "RW"
+        }
+      ]
+    },
+    {
+      "tag": "AVERAGE_VOLTAGE_L1",
+      "description": "Average voltage L1",
+      "class-id": 3,
+      "version": 0,
+      "obis": "1.0.32.24.0.255",
+      "group": "ELECTRICITY",
+      "meterTypes": ["SP","PP"],
+      "properties": {
+        "PQ_PROFILE": "PUBLIC",
+        "PQ_REQUEST": "ONDEMAND"
+      },
+      "attributes": [
+        {
+          "id": 2,
+          "description": "value",
+          "datatype": "long-unsigned",
+          "valuetype": "DYNAMIC",
+          "value": "0",
+          "access": "R"
+        },
+        {
+          "id": 3,
+          "description": "scaler_unit",
+          "datatype": "scal_unit_type",
+          "valuetype": "FIXED_IN_PROFILE",
+          "value": "0, V",
+          "access": "R"
+        }
+      ]
+    },
+    {
+      "tag": "AVERAGE_VOLTAGE_L2",
+      "description": "Average voltage L2",
+      "class-id": 3,
+      "version": 0,
+      "obis": "1.0.52.24.0.255",
+      "group": "ELECTRICITY",
+      "meterTypes": ["PP"],
+      "properties": {
+        "PQ_PROFILE": "PUBLIC",
+        "PQ_REQUEST": "ONDEMAND"
+      },
+      "attributes": [
+        {
+          "id": 2,
+          "description": "value",
+          "datatype": "long-unsigned",
+          "valuetype": "DYNAMIC",
+          "value": "0",
+          "access": "R"
+        },
+        {
+          "id": 3,
+          "description": "scaler_unit",
+          "datatype": "scal_unit_type",
+          "valuetype": "FIXED_IN_PROFILE",
+          "value": "0, V",
+          "access": "R"
+        }
+      ]
+    },
+    {
+      "tag": "AVERAGE_VOLTAGE_L3",
+      "description": "Average voltage L3",
+      "class-id": 3,
+      "version": 0,
+      "obis": "1.0.72.24.0.255",
+      "group": "ELECTRICITY",
+      "meterTypes": ["PP"],
+      "properties": {
+        "PQ_PROFILE": "PUBLIC",
+        "PQ_REQUEST": "ONDEMAND"
+      },
+      "attributes": [
+        {
+          "id": 2,
+          "description": "value",
+          "datatype": "long-unsigned",
+          "valuetype": "DYNAMIC",
+          "value": "0",
+          "access": "R"
+        },
+        {
+          "id": 3,
+          "description": "scaler_unit",
+          "datatype": "scal_unit_type",
+          "valuetype": "FIXED_IN_PROFILE",
+          "value": "0, V",
+          "access": "R"
+        }
+      ]
+    },
+    {
+      "tag": "INSTANTANEOUS_CURRENT_L1",
+      "description": "Instantaneous current L1",
+      "class-id": 3,
+      "version": 0,
+      "obis": "1.0.31.7.0.255",
+      "group": "ELECTRICITY",
+      "meterTypes": ["SP","PP"],
+      "properties": {
+        "PQ_PROFILE": "PRIVATE",
+        "PQ_REQUEST": "ONDEMAND"
+      },
+      "attributes": [
+        {
+          "id": 2,
+          "description": "value",
+          "datatype": "long-unsigned",
+          "valuetype": "DYNAMIC",
+          "value": "0",
+          "access": "R"
+        },
+        {
+          "id": 3,
+          "description": "scaler_unit",
+          "datatype": "scal_unit_type",
+          "valuetype": "FIXED_IN_PROFILE",
+          "value": "0, A",
+          "access": "RW"
+        }
+      ]
+    },
+    {
+      "tag": "INSTANTANEOUS_CURRENT_L2",
+      "description": "Instantaneous current L2",
+      "class-id": 3,
+      "version": 0,
+      "obis": "1.0.51.7.0.255",
+      "group": "ELECTRICITY",
+      "meterTypes": ["PP"],
+      "properties": {
+        "PQ_PROFILE": "PRIVATE",
+        "PQ_REQUEST": "ONDEMAND"
+      },
+      "attributes": [
+        {
+          "id": 2,
+          "description": "value",
+          "datatype": "long-unsigned",
+          "valuetype": "DYNAMIC",
+          "value": "0",
+          "access": "R"
+        },
+        {
+          "id": 3,
+          "description": "scaler_unit",
+          "datatype": "scal_unit_type",
+          "valuetype": "FIXED_IN_PROFILE",
+          "value": "0, A",
+          "access": "RW"
+        }
+      ]
+    },
+    {
+      "tag": "INSTANTANEOUS_CURRENT_L3",
+      "description": "Instantaneous current L3",
+      "class-id": 3,
+      "version": 0,
+      "obis": "1.0.71.7.0.255",
+      "group": "ELECTRICITY",
+      "meterTypes": ["PP"],
+      "properties": {
+        "PQ_PROFILE": "PRIVATE",
+        "PQ_REQUEST": "ONDEMAND"
+      },
+      "attributes": [
+        {
+          "id": 2,
+          "description": "value",
+          "datatype": "long-unsigned",
+          "valuetype": "DYNAMIC",
+          "value": "0",
+          "access": "R"
+        },
+        {
+          "id": 3,
+          "description": "scaler_unit",
+          "datatype": "scal_unit_type",
+          "valuetype": "FIXED_IN_PROFILE",
+          "value": "0, A",
+          "access": "RW"
+        }
+      ]
+    },
+    {
+      "tag": "INSTANTANEOUS_ACTIVE_CURRENT_TOTAL_OVER_ALL_PHASES",
+      "description": "Instantaneous current total",
+      "class-id": 3,
+      "version": 0,
+      "obis": "1.0.90.7.0.255",
+      "group": "ELECTRICITY",
+      "meterTypes": ["SP","PP"],
+      "properties": {
+        "PQ_PROFILE": "PRIVATE",
+        "PQ_REQUEST": "ONDEMAND"
+      },
+      "attributes": [
+        {
+          "id": 2,
+          "description": "value",
+          "datatype": "long-unsigned",
+          "valuetype": "DYNAMIC",
+          "value": "0",
+          "access": "R"
+        },
+        {
+          "id": 3,
+          "description": "scaler_unit",
+          "datatype": "scal_unit_type",
+          "valuetype": "FIXED_IN_PROFILE",
+          "value": "0, A",
+          "access": "R"
+        }
+      ]
+    },
+    {
+      "tag": "INSTANTANEOUS_ACTIVE_POWER_IMPORT",
+      "description": "Instantaneous active power (+P)",
+      "class-id": 3,
+      "version": 0,
+      "obis": "1.0.15.7.0.255",
+      "group": "ELECTRICITY",
+      "meterTypes": ["SP","PP"],
+      "properties": {
+        "PQ_PROFILE": "PRIVATE",
+        "PQ_REQUEST": "ONDEMAND"
+      },
+      "attributes": [
+        {
+          "id": 2,
+          "description": "value",
+          "datatype": "long-unsigned",
+          "valuetype": "DYNAMIC",
+          "value": "0",
+          "access": "R"
+        },
+        {
+          "id": 3,
+          "description": "scaler_unit",
+          "datatype": "scal_unit_type",
+          "valuetype": "FIXED_IN_PROFILE",
+          "value": "0, W",
+          "access": "R"
+        }
+      ]
+    }
+  ]
+}

--- a/osgp/protocol-adapter-dlms/osgp-protocol-simulator-dlms/simulator/dlms-device-simulator/src/main/java/org/opensmartgridplatform/simulator/protocol/dlms/cosem/PowerQualityProfile2.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-simulator-dlms/simulator/dlms-device-simulator/src/main/java/org/opensmartgridplatform/simulator/protocol/dlms/cosem/PowerQualityProfile2.java
@@ -57,6 +57,8 @@ public class PowerQualityProfile2 extends ProfileGeneric {
   public static final String INSTANTANEOUS_CURRENT_L3_LOGICAL_NAME = "1.0.71.7.0.255";
 
   public static final String INSTANTANEOUS_ACTIVE_POWER_IMPORT_LOGICAL_NAME = "1.0.1.7.0.255";
+  public static final String INSTANTANEOUS_ACTIVE_POWER_IMPORT_LOGICAL_NAME_DSMR22 =
+      "1.0.15.7.0.255";
   public static final String INSTANTANEOUS_ACTIVE_POWER_EXPORT_LOGICAL_NAME = "1.0.2.7.0.255";
 
   public static final String INSTANTANEOUS_ACTIVE_POWER_EXPORT_L1_LOGICAL_NAME = "1.0.22.7.0.255";
@@ -67,7 +69,7 @@ public class PowerQualityProfile2 extends ProfileGeneric {
   public static final String INSTANTANEOUS_ACTIVE_POWER_IMPORT_L2_LOGICAL_NAME = "1.0.41.7.0.255";
   public static final String INSTANTANEOUS_ACTIVE_POWER_IMPORT_L3_LOGICAL_NAME = "1.0.61.7.0.255";
 
-  private CaptureObjectDefinitionCollection captureObjectDefinitionCollection;
+  private final CaptureObjectDefinitionCollection captureObjectDefinitionCollection;
   private static final Map<CaptureObject, DataProcessor> PROCESSORS_BY_CAPTURE_OBJECT =
       new HashMap<>();
   private static final DataProcessor COSEM_DATE_TIME_PROCESSOR = new CosemDateTimeProcessor();

--- a/osgp/protocol-adapter-dlms/osgp-protocol-simulator-dlms/simulator/dlms-device-simulator/src/main/java/org/opensmartgridplatform/simulator/protocol/dlms/server/profile/DefaultDeviceProfile.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-simulator-dlms/simulator/dlms-device-simulator/src/main/java/org/opensmartgridplatform/simulator/protocol/dlms/server/profile/DefaultDeviceProfile.java
@@ -35,6 +35,7 @@ import static org.opensmartgridplatform.simulator.protocol.dlms.cosem.PowerQuali
 import static org.opensmartgridplatform.simulator.protocol.dlms.cosem.PowerQualityProfile2.INSTANTANEOUS_ACTIVE_POWER_IMPORT_L2_LOGICAL_NAME;
 import static org.opensmartgridplatform.simulator.protocol.dlms.cosem.PowerQualityProfile2.INSTANTANEOUS_ACTIVE_POWER_IMPORT_L3_LOGICAL_NAME;
 import static org.opensmartgridplatform.simulator.protocol.dlms.cosem.PowerQualityProfile2.INSTANTANEOUS_ACTIVE_POWER_IMPORT_LOGICAL_NAME;
+import static org.opensmartgridplatform.simulator.protocol.dlms.cosem.PowerQualityProfile2.INSTANTANEOUS_ACTIVE_POWER_IMPORT_LOGICAL_NAME_DSMR22;
 import static org.opensmartgridplatform.simulator.protocol.dlms.cosem.PowerQualityProfile2.INSTANTANEOUS_CURRENT_L1_LOGICAL_NAME;
 import static org.opensmartgridplatform.simulator.protocol.dlms.cosem.PowerQualityProfile2.INSTANTANEOUS_CURRENT_L2_LOGICAL_NAME;
 import static org.opensmartgridplatform.simulator.protocol.dlms.cosem.PowerQualityProfile2.INSTANTANEOUS_CURRENT_L3_LOGICAL_NAME;
@@ -1084,6 +1085,12 @@ public class DefaultDeviceProfile {
   public LongUnsignedRegister instantaneousActivePowerImport() {
     return new LongUnsignedRegister(
         INSTANTANEOUS_ACTIVE_POWER_IMPORT_LOGICAL_NAME, 1, 0, UnitType.WATT);
+  }
+
+  @Bean
+  public LongUnsignedRegister instantaneousActivePowerImportDsmr22() {
+    return new LongUnsignedRegister(
+        INSTANTANEOUS_ACTIVE_POWER_IMPORT_LOGICAL_NAME_DSMR22, 1, 0, UnitType.WATT);
   }
 
   @Bean


### PR DESCRIPTION
The command executor for actual PQ (on demand PQ), requested values from too much PQ objects from DSMR2.2 meters. To solve this, a new object config is added for DSMR2.2 meters. This new config only contains the PQ objects that are present in DSMR2.2 meters. For one object the OBIS code is different in DSMR2.2.
The cucumber test is updated to test DSMR2.2 as well. The check if all expected values are received is changed from a fixed list to a list based on the number of expected objects per protocol.