### PR TITLE
Fix for permits that are not removed from database when release called under load

### DIFF
--- a/osgp/platform/osgp-throttling-service/src/main/java/org/opensmartgridplatform/throttling/PermitsPerNetworkSegment.java
+++ b/osgp/platform/osgp-throttling-service/src/main/java/org/opensmartgridplatform/throttling/PermitsPerNetworkSegment.java
@@ -109,7 +109,6 @@ public class PermitsPerNetworkSegment {
     final int numberOfPermitsIfReleased = permitCounter.decrementAndGet();
     if (numberOfPermitsIfReleased < 0) {
       permitCounter.incrementAndGet();
-      return false;
     }
 
     final int numberOfReleasedPermits =


### PR DESCRIPTION
Fix for permits that are not removed from database when release called under load