### PR TITLE
Use artemis-jms-client instead of artemis-jms-client-all

### DIFF
--- a/osgp/shared/shared/pom.xml
+++ b/osgp/shared/shared/pom.xml
@@ -171,7 +171,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.activemq</groupId>
-      <artifactId>artemis-jms-client-all</artifactId>
+      <artifactId>artemis-jms-client</artifactId>
       <version>2.27.1</version>
     </dependency>
 


### PR DESCRIPTION
The artemis-jms-client-all dependency is a fat jar that combines all the classes of its dependencies. This can cause class path conflicts with dependencies that are also declared in a pom.