### PR TITLE
SMHE-1444: Remove PQ object for single phase DSMR2.2

### DIFF
--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringmonitoring/ActualPowerQualitySteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringmonitoring/ActualPowerQualitySteps.java
@@ -106,7 +106,7 @@ public class ActualPowerQualitySteps {
         SettingsHelper.getStringValue(settings, "PowerQualityObject_Name", 1);
     // Only check the received objects if there are expected objects defined in the settings
     if (expectedName != null) {
-      IntStream.range(1, expectedNumberOfPowerQualityObjects)
+      IntStream.range(1, expectedNumberOfPowerQualityObjects + 1) // +1 because end is exclusive
           .forEach(
               i -> this.objectShouldBePresentInResponse(i, settings, actualPowerQualityObjects));
     }

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/monitoring/GetActualPowerQuality.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/monitoring/GetActualPowerQuality.feature
@@ -177,9 +177,9 @@ Feature: SmartMetering Monitoring - Get Actual Power Quality
       | PowerQualityObject_Name_1   | CLOCK                                              |
       | PowerQualityObject_Name_2   | INSTANTANEOUS_ACTIVE_POWER_IMPORT                  |
       | PowerQualityObject_Unit_2   | W                                                  |
-      | PowerQualityObject_Name_3   | INSTANTANEOUS_ACTIVE_CURRENT_TOTAL_OVER_ALL_PHASES |
+      | PowerQualityObject_Name_3   | INSTANTANEOUS_CURRENT_L1                           |
       | PowerQualityObject_Unit_3   | AMP                                                |
-      | PowerQualityObject_Name_4   | INSTANTANEOUS_CURRENT_L1                           |
+      | PowerQualityObject_Name_4   | INSTANTANEOUS_ACTIVE_CURRENT_TOTAL_OVER_ALL_PHASES |
       | PowerQualityObject_Unit_4   | AMP                                                |
       | PowerQualityObject_Name_5   | INSTANTANEOUS_ACTIVE_POWER_EXPORT                  |
       | PowerQualityObject_Unit_5   | W                                                  |
@@ -200,7 +200,7 @@ Feature: SmartMetering Monitoring - Get Actual Power Quality
 
     Examples:
       | DeviceId             | Protocol | ProtocolVersion | Lls1active | Hls5active | ExpectedNumber |
-      | KTEST10260000001     | DSMR     | 2.2             | true       | false      | 4              |
+      | KTEST10260000001     | DSMR     | 2.2             | true       | false      | 3              |
       | TEST1024000000001    | DSMR     | 4.2.2           | false      | true       | 12             |
       | TEST1027000000001    | SMR      | 5.0.0           | false      | true       | 12             |
 

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/resources/dlmsprofiles/dlmsprofile-dsmr22.json
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/resources/dlmsprofiles/dlmsprofile-dsmr22.json
@@ -509,7 +509,7 @@
       "version": 0,
       "obis": "1.0.90.7.0.255",
       "group": "ELECTRICITY",
-      "meterTypes": ["SP","PP"],
+      "meterTypes": ["PP"],
       "properties": {
         "PQ_PROFILE": "PRIVATE",
         "PQ_REQUEST": "ONDEMAND"


### PR DESCRIPTION
Object `Instantaneous current, sum over all phases` is removed from the object config for DSMR2.2.
And a small fix in the cucumber test code for PQ: the IntRange was not used correctly.