### PR TITLE
SMHE-1690: Use dlms object config for ClearAlarmRegister

### DIFF
--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/bundle/BundledClearAlarmRegister.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/bundle/BundledClearAlarmRegister.feature
@@ -7,7 +7,7 @@ Feature: SmartMetering Bundle - ClearAlarmRegister
   As a grid operator 
   I want to be able to clear the alarm register from a meter via a bundle request
 
-  Scenario Outline: Bundled clear alarm only for register 1 for these protocols
+  Scenario Outline: Bundled clear alarm only for register 1 for protocol <protocol> <version>
     Given a dlms device
       | DeviceIdentification     | TEST1028000000002 |
       | DeviceType               | SMART_METER_E     |

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/bundle/BundledClearAlarmRegister.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/bundle/BundledClearAlarmRegister.feature
@@ -7,13 +7,13 @@ Feature: SmartMetering Bundle - ClearAlarmRegister
   As a grid operator 
   I want to be able to clear the alarm register from a meter via a bundle request
 
-  Scenario: Clear alarm register with SMR 5.1
+  Scenario Outline: Bundled clear alarm only for register 1 for these protocols
     Given a dlms device
       | DeviceIdentification     | TEST1028000000002 |
       | DeviceType               | SMART_METER_E     |
       | SelectiveAccessSupported | true              |
-      | Protocol                 | SMR               |
-      | ProtocolVersion          | 5.1               |
+      | Protocol                 | <protocol>        |
+      | ProtocolVersion          | <version>         |
       | Port                     |              1028 |
     And device "TEST1028000000002" has alarm register "1" with some value
     And a bundle request
@@ -22,6 +22,14 @@ Feature: SmartMetering Bundle - ClearAlarmRegister
     When the bundle request is received
     Then the bundle response should contain a clear alarm register response
     And alarm register "1" of device "TEST1028000000002" has been cleared
+    Examples:
+      | protocol | version |
+      | DSMR     | 2.2     |
+      | DSMR     | 4.2.2   |
+      | SMR      | 4.3     |
+      | SMR      | 5.0.0   |
+      | SMR      | 5.1     |
+
 
   Scenario: Clear both alarm registers with SMR 5.2
     Given a dlms device

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/monitoring/AlarmRegister.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/monitoring/AlarmRegister.feature
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-@SmartMetering @Platform @SmartMeteringMonitoring @SMHE-1690
+@SmartMetering @Platform @SmartMeteringMonitoring
 Feature: SmartMetering Monitoring - Alarm Register
   As a grid operator
   I want to be able to read and clear the alarm register on a device
@@ -24,7 +24,7 @@ Feature: SmartMetering Monitoring - Alarm Register
     Then the alarm register should be returned
       | DeviceIdentification | TEST1024000000001 |
 
-  Scenario Outline: Clear only alarm register 1 for these protocols
+  Scenario Outline: Clear only alarm register 1 for protocol <protocol> <version>
     Given a dlms device
       | DeviceIdentification     | TEST1028000000002 |
       | DeviceType               | SMART_METER_E     |

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/monitoring/AlarmRegister.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/monitoring/AlarmRegister.feature
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-@SmartMetering @Platform @SmartMeteringMonitoring
+@SmartMetering @Platform @SmartMeteringMonitoring @SMHE-1690
 Feature: SmartMetering Monitoring - Alarm Register
   As a grid operator
   I want to be able to read and clear the alarm register on a device
@@ -24,13 +24,13 @@ Feature: SmartMetering Monitoring - Alarm Register
     Then the alarm register should be returned
       | DeviceIdentification | TEST1024000000001 |
 
-  Scenario: Clear alarm register SMR 5.1
+  Scenario Outline: Clear only alarm register 1 for these protocols
     Given a dlms device
       | DeviceIdentification     | TEST1028000000002 |
       | DeviceType               | SMART_METER_E     |
       | SelectiveAccessSupported | true              |
-      | Protocol                 | SMR               |
-      | ProtocolVersion          | 5.1               |
+      | Protocol                 | <protocol>        |
+      | ProtocolVersion          | <version>         |
       | Port                     |              1028 |
     And device "TEST1028000000002" has alarm register "1" with some value
     And device "TEST1028000000002" has alarm register "2" with some value
@@ -41,6 +41,13 @@ Feature: SmartMetering Monitoring - Alarm Register
       | Result               | OK                |
     And alarm register "1" of device "TEST1028000000002" has been cleared
     And alarm register "2" of device "TEST1028000000002" has not been cleared
+    Examples:
+    | protocol | version |
+    | DSMR     | 2.2     |
+    | DSMR     | 4.2.2   |
+    | SMR      | 4.3     |
+    | SMR      | 5.0.0   |
+    | SMR      | 5.1     |
 
   Scenario: Clear both alarm registers with SMR 5.2
     Given a dlms device

--- a/osgp/protocol-adapter-dlms/osgp-dlms/src/main/java/org/opensmartgridplatform/dlms/objectconfig/CosemObject.java
+++ b/osgp/protocol-adapter-dlms/osgp-dlms/src/main/java/org/opensmartgridplatform/dlms/objectconfig/CosemObject.java
@@ -21,6 +21,7 @@ public class CosemObject {
   private int version;
   private String obis;
   private String group;
+  private String note;
   private List<MeterType> meterTypes;
   private Map<ObjectProperty, Object> properties;
   private List<Attribute> attributes;

--- a/osgp/protocol-adapter-dlms/osgp-dlms/src/main/java/org/opensmartgridplatform/dlms/objectconfig/DlmsObjectType.java
+++ b/osgp/protocol-adapter-dlms/osgp-dlms/src/main/java/org/opensmartgridplatform/dlms/objectconfig/DlmsObjectType.java
@@ -55,7 +55,10 @@ public enum DlmsObjectType {
   LTE_DIAGNOSTIC,
   MBUS_CLIENT_SETUP,
   MBUS_DIAGNOSTIC,
-  PUSH_SETUP_UDP;
+  PUSH_SETUP_UDP,
+  ALARM_REGISTER_1,
+  ALARM_REGISTER_2,
+  ALARM_REGISTER_3;
 
   public String value() {
     return this.name();

--- a/osgp/protocol-adapter-dlms/osgp-dlms/src/main/resources/dlmsprofiles/dlmsprofile-dsmr22.json
+++ b/osgp/protocol-adapter-dlms/osgp-dlms/src/main/resources/dlmsprofiles/dlmsprofile-dsmr22.json
@@ -7,6 +7,7 @@
     {
       "tag": "CLOCK",
       "description": "Clock",
+      "note": null,
       "class-id": 8,
       "version": 0,
       "obis": "0.0.1.0.0.255",
@@ -42,6 +43,7 @@
     {
       "tag": "NUMBER_OF_VOLTAGE_SWELLS_FOR_L1",
       "description": "Number of voltage swells in phase L1",
+      "note": null,
       "class-id": 1,
       "version": 0,
       "obis": "1.0.32.36.0.255",
@@ -65,6 +67,7 @@
     {
       "tag": "NUMBER_OF_VOLTAGE_SWELLS_FOR_L2",
       "description": "Number of voltage swells in phase L2",
+      "note": null,
       "class-id": 1,
       "version": 0,
       "obis": "1.0.52.36.0.255",
@@ -88,6 +91,7 @@
     {
       "tag": "NUMBER_OF_VOLTAGE_SWELLS_FOR_L3",
       "description": "Number of voltage swells in phase L3",
+      "note": null,
       "class-id": 1,
       "version": 0,
       "obis": "1.0.72.36.0.255",
@@ -111,6 +115,7 @@
     {
       "tag": "NUMBER_OF_VOLTAGE_SAGS_FOR_L1",
       "description": "Number of voltage sags in phase L1",
+      "note": null,
       "class-id": 1,
       "version": 0,
       "obis": "1.0.32.32.0.255",
@@ -134,6 +139,7 @@
     {
       "tag": "NUMBER_OF_VOLTAGE_SAGS_FOR_L2",
       "description": "Number of voltage sags in phase L2",
+      "note": null,
       "class-id": 1,
       "version": 0,
       "obis": "1.0.52.32.0.255",
@@ -157,6 +163,7 @@
     {
       "tag": "NUMBER_OF_VOLTAGE_SAGS_FOR_L3",
       "description": "Number of voltage sags in phase L3",
+      "note": null,
       "class-id": 1,
       "version": 0,
       "obis": "1.0.72.32.0.255",
@@ -180,6 +187,7 @@
     {
       "tag": "NUMBER_OF_LONG_POWER_FAILURES",
       "description": "Number of long power failures in any phases",
+      "note": null,
       "class-id": 1,
       "version": 0,
       "obis": "0.0.96.7.9.255",
@@ -203,6 +211,7 @@
     {
       "tag": "NUMBER_OF_POWER_FAILURES",
       "description": "Number of power failures in any phases",
+      "note": null,
       "class-id": 1,
       "version": 0,
       "obis": "0.0.96.7.21.255",
@@ -226,6 +235,7 @@
     {
       "tag": "INSTANTANEOUS_VOLTAGE_L1",
       "description": "Instantaneous voltage L1",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.32.7.0.255",
@@ -257,6 +267,7 @@
     {
       "tag": "INSTANTANEOUS_VOLTAGE_L2",
       "description": "Instantaneous voltage L2",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.52.7.0.255",
@@ -288,6 +299,7 @@
     {
       "tag": "INSTANTANEOUS_VOLTAGE_L3",
       "description": "Instantaneous voltage L3",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.72.7.0.255",
@@ -319,6 +331,7 @@
     {
       "tag": "AVERAGE_VOLTAGE_L1",
       "description": "Average voltage L1",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.32.24.0.255",
@@ -350,6 +363,7 @@
     {
       "tag": "AVERAGE_VOLTAGE_L2",
       "description": "Average voltage L2",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.52.24.0.255",
@@ -381,6 +395,7 @@
     {
       "tag": "AVERAGE_VOLTAGE_L3",
       "description": "Average voltage L3",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.72.24.0.255",
@@ -412,6 +427,7 @@
     {
       "tag": "INSTANTANEOUS_CURRENT_L1",
       "description": "Instantaneous current L1",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.31.7.0.255",
@@ -443,6 +459,7 @@
     {
       "tag": "INSTANTANEOUS_CURRENT_L2",
       "description": "Instantaneous current L2",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.51.7.0.255",
@@ -474,6 +491,7 @@
     {
       "tag": "INSTANTANEOUS_CURRENT_L3",
       "description": "Instantaneous current L3",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.71.7.0.255",
@@ -505,6 +523,7 @@
     {
       "tag": "INSTANTANEOUS_ACTIVE_CURRENT_TOTAL_OVER_ALL_PHASES",
       "description": "Instantaneous current total",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.90.7.0.255",
@@ -536,6 +555,7 @@
     {
       "tag": "ALARM_REGISTER_1",
       "description": "Alarm register 1",
+      "note": null,
       "class-id": 1,
       "version": 0,
       "obis": "0.0.97.98.0.255",

--- a/osgp/protocol-adapter-dlms/osgp-dlms/src/main/resources/dlmsprofiles/dlmsprofile-dsmr22.json
+++ b/osgp/protocol-adapter-dlms/osgp-dlms/src/main/resources/dlmsprofiles/dlmsprofile-dsmr22.json
@@ -532,6 +532,26 @@
           "access": "R"
         }
       ]
+    },
+    {
+      "tag": "ALARM_REGISTER_1",
+      "description": "Alarm register 1",
+      "class-id": 1,
+      "version": 0,
+      "obis": "0.0.97.98.0.255",
+      "group": "ELECTRICITY",
+      "meterTypes": ["SP","PP"],
+      "properties": {},
+      "attributes": [
+        {
+          "id": 2,
+          "description": "value",
+          "datatype": "double-long-unsigned",
+          "valuetype": "DYNAMIC",
+          "value": "0",
+          "access": "RW"
+        }
+      ]
     }
   ]
 }

--- a/osgp/protocol-adapter-dlms/osgp-dlms/src/main/resources/dlmsprofiles/dlmsprofile-dsmr422.json
+++ b/osgp/protocol-adapter-dlms/osgp-dlms/src/main/resources/dlmsprofiles/dlmsprofile-dsmr422.json
@@ -7,11 +7,15 @@
     {
       "tag": "CLOCK",
       "description": "Clock",
+      "note": null,
       "class-id": 8,
       "version": 0,
       "obis": "0.0.1.0.0.255",
       "group": "ABSTRACT",
-      "meterTypes": ["SP","PP"],
+      "meterTypes": [
+        "SP",
+        "PP"
+      ],
       "attributes": [
         {
           "id": 2,
@@ -42,11 +46,15 @@
     {
       "tag": "DEFINABLE_LOAD_PROFILE",
       "description": "Definable load profile",
+      "note": null,
       "class-id": 7,
       "version": 1,
       "obis": "0.1.94.31.6.255",
       "group": "ELECTRICITY",
-      "meterTypes": ["SP","PP"],
+      "meterTypes": [
+        "SP",
+        "PP"
+      ],
       "properties": {
         "SELECTABLE_OBJECTS": [
           "CLOCK",
@@ -138,14 +146,22 @@
     {
       "tag": "NUMBER_OF_VOLTAGE_SWELLS_FOR_L1",
       "description": "Number of voltage swells in phase L1",
+      "note": null,
       "class-id": 1,
       "version": 0,
       "obis": "1.0.32.36.0.255",
       "group": "ELECTRICITY",
-      "meterTypes": ["SP","PP"],
+      "meterTypes": [
+        "SP",
+        "PP"
+      ],
       "properties": {
         "PQ_PROFILE": "PUBLIC",
-        "PQ_REQUEST": ["ACTUAL_SP","ACTUAL_PP","PERIODIC_SP"]
+        "PQ_REQUEST": [
+          "ACTUAL_SP",
+          "ACTUAL_PP",
+          "PERIODIC_SP"
+        ]
       },
       "attributes": [
         {
@@ -161,14 +177,19 @@
     {
       "tag": "NUMBER_OF_VOLTAGE_SWELLS_FOR_L2",
       "description": "Number of voltage swells in phase L2",
+      "note": null,
       "class-id": 1,
       "version": 0,
       "obis": "1.0.52.36.0.255",
       "group": "ELECTRICITY",
-      "meterTypes": ["PP"],
+      "meterTypes": [
+        "PP"
+      ],
       "properties": {
         "PQ_PROFILE": "PUBLIC",
-        "PQ_REQUEST": ["ACTUAL_PP"]
+        "PQ_REQUEST": [
+          "ACTUAL_PP"
+        ]
       },
       "attributes": [
         {
@@ -184,14 +205,19 @@
     {
       "tag": "NUMBER_OF_VOLTAGE_SWELLS_FOR_L3",
       "description": "Number of voltage swells in phase L3",
+      "note": null,
       "class-id": 1,
       "version": 0,
       "obis": "1.0.72.36.0.255",
       "group": "ELECTRICITY",
-      "meterTypes": ["PP"],
+      "meterTypes": [
+        "PP"
+      ],
       "properties": {
         "PQ_PROFILE": "PUBLIC",
-        "PQ_REQUEST": ["ACTUAL_PP"]
+        "PQ_REQUEST": [
+          "ACTUAL_PP"
+        ]
       },
       "attributes": [
         {
@@ -207,14 +233,22 @@
     {
       "tag": "NUMBER_OF_VOLTAGE_SAGS_FOR_L1",
       "description": "Number of voltage sags in phase L1",
+      "note": null,
       "class-id": 1,
       "version": 0,
       "obis": "1.0.32.32.0.255",
       "group": "ELECTRICITY",
-      "meterTypes": ["SP","PP"],
+      "meterTypes": [
+        "SP",
+        "PP"
+      ],
       "properties": {
         "PQ_PROFILE": "PUBLIC",
-        "PQ_REQUEST": ["ACTUAL_SP","ACTUAL_PP","PERIODIC_SP"]
+        "PQ_REQUEST": [
+          "ACTUAL_SP",
+          "ACTUAL_PP",
+          "PERIODIC_SP"
+        ]
       },
       "attributes": [
         {
@@ -230,14 +264,19 @@
     {
       "tag": "NUMBER_OF_VOLTAGE_SAGS_FOR_L2",
       "description": "Number of voltage sags in phase L2",
+      "note": null,
       "class-id": 1,
       "version": 0,
       "obis": "1.0.52.32.0.255",
       "group": "ELECTRICITY",
-      "meterTypes": ["PP"],
+      "meterTypes": [
+        "PP"
+      ],
       "properties": {
         "PQ_PROFILE": "PUBLIC",
-        "PQ_REQUEST": ["ACTUAL_PP"]
+        "PQ_REQUEST": [
+          "ACTUAL_PP"
+        ]
       },
       "attributes": [
         {
@@ -253,14 +292,19 @@
     {
       "tag": "NUMBER_OF_VOLTAGE_SAGS_FOR_L3",
       "description": "Number of voltage sags in phase L3",
+      "note": null,
       "class-id": 1,
       "version": 0,
       "obis": "1.0.72.32.0.255",
       "group": "ELECTRICITY",
-      "meterTypes": ["PP"],
+      "meterTypes": [
+        "PP"
+      ],
       "properties": {
         "PQ_PROFILE": "PUBLIC",
-        "PQ_REQUEST": ["ACTUAL_PP"]
+        "PQ_REQUEST": [
+          "ACTUAL_PP"
+        ]
       },
       "attributes": [
         {
@@ -276,14 +320,21 @@
     {
       "tag": "NUMBER_OF_LONG_POWER_FAILURES",
       "description": "Number of long power failures in any phases",
+      "note": null,
       "class-id": 1,
       "version": 0,
       "obis": "0.0.96.7.9.255",
       "group": "ELECTRICITY",
-      "meterTypes": ["SP","PP"],
+      "meterTypes": [
+        "SP",
+        "PP"
+      ],
       "properties": {
         "PQ_PROFILE": "PUBLIC",
-        "PQ_REQUEST": ["ACTUAL_SP","ACTUAL_PP"]
+        "PQ_REQUEST": [
+          "ACTUAL_SP",
+          "ACTUAL_PP"
+        ]
       },
       "attributes": [
         {
@@ -299,14 +350,22 @@
     {
       "tag": "NUMBER_OF_POWER_FAILURES",
       "description": "Number of power failures in any phases",
+      "note": null,
       "class-id": 1,
       "version": 0,
       "obis": "0.0.96.7.21.255",
       "group": "ELECTRICITY",
-      "meterTypes": ["SP","PP"],
+      "meterTypes": [
+        "SP",
+        "PP"
+      ],
       "properties": {
         "PQ_PROFILE": "PUBLIC",
-        "PQ_REQUEST": ["ACTUAL_SP","ACTUAL_PP","PERIODIC_SP"]
+        "PQ_REQUEST": [
+          "ACTUAL_SP",
+          "ACTUAL_PP",
+          "PERIODIC_SP"
+        ]
       },
       "attributes": [
         {
@@ -322,14 +381,23 @@
     {
       "tag": "INSTANTANEOUS_VOLTAGE_L1",
       "description": "Instantaneous voltage L1",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.32.7.0.255",
       "group": "ELECTRICITY",
-      "meterTypes": ["SP","PP"],
+      "meterTypes": [
+        "SP",
+        "PP"
+      ],
       "properties": {
         "PQ_PROFILE": "PUBLIC",
-        "PQ_REQUEST": ["ACTUAL_SP","ACTUAL_PP","PERIODIC_SP","PERIODIC_PP"]
+        "PQ_REQUEST": [
+          "ACTUAL_SP",
+          "ACTUAL_PP",
+          "PERIODIC_SP",
+          "PERIODIC_PP"
+        ]
       },
       "attributes": [
         {
@@ -353,14 +421,20 @@
     {
       "tag": "INSTANTANEOUS_VOLTAGE_L2",
       "description": "Instantaneous voltage L2",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.52.7.0.255",
       "group": "ELECTRICITY",
-      "meterTypes": ["PP"],
+      "meterTypes": [
+        "PP"
+      ],
       "properties": {
         "PQ_PROFILE": "PUBLIC",
-        "PQ_REQUEST": ["ACTUAL_PP","PERIODIC_PP"]
+        "PQ_REQUEST": [
+          "ACTUAL_PP",
+          "PERIODIC_PP"
+        ]
       },
       "attributes": [
         {
@@ -384,14 +458,20 @@
     {
       "tag": "INSTANTANEOUS_VOLTAGE_L3",
       "description": "Instantaneous voltage L3",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.72.7.0.255",
       "group": "ELECTRICITY",
-      "meterTypes": ["PP"],
+      "meterTypes": [
+        "PP"
+      ],
       "properties": {
         "PQ_PROFILE": "PUBLIC",
-        "PQ_REQUEST": ["ACTUAL_PP","PERIODIC_PP"]
+        "PQ_REQUEST": [
+          "ACTUAL_PP",
+          "PERIODIC_PP"
+        ]
       },
       "attributes": [
         {
@@ -415,14 +495,23 @@
     {
       "tag": "AVERAGE_VOLTAGE_L1",
       "description": "Average voltage L1",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.32.24.0.255",
       "group": "ELECTRICITY",
-      "meterTypes": ["SP","PP"],
+      "meterTypes": [
+        "SP",
+        "PP"
+      ],
       "properties": {
         "PQ_PROFILE": "PUBLIC",
-        "PQ_REQUEST": ["ACTUAL_SP","ACTUAL_PP","PERIODIC_SP","PERIODIC_PP"]
+        "PQ_REQUEST": [
+          "ACTUAL_SP",
+          "ACTUAL_PP",
+          "PERIODIC_SP",
+          "PERIODIC_PP"
+        ]
       },
       "attributes": [
         {
@@ -446,14 +535,20 @@
     {
       "tag": "AVERAGE_VOLTAGE_L2",
       "description": "Average voltage L2",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.52.24.0.255",
       "group": "ELECTRICITY",
-      "meterTypes": ["PP"],
+      "meterTypes": [
+        "PP"
+      ],
       "properties": {
         "PQ_PROFILE": "PUBLIC",
-        "PQ_REQUEST": ["ACTUAL_PP","PERIODIC_PP"]
+        "PQ_REQUEST": [
+          "ACTUAL_PP",
+          "PERIODIC_PP"
+        ]
       },
       "attributes": [
         {
@@ -477,14 +572,20 @@
     {
       "tag": "AVERAGE_VOLTAGE_L3",
       "description": "Average voltage L3",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.72.24.0.255",
       "group": "ELECTRICITY",
-      "meterTypes": ["PP"],
+      "meterTypes": [
+        "PP"
+      ],
       "properties": {
         "PQ_PROFILE": "PUBLIC",
-        "PQ_REQUEST": ["ACTUAL_PP","PERIODIC_PP"]
+        "PQ_REQUEST": [
+          "ACTUAL_PP",
+          "PERIODIC_PP"
+        ]
       },
       "attributes": [
         {
@@ -508,14 +609,22 @@
     {
       "tag": "INSTANTANEOUS_CURRENT_L1",
       "description": "Instantaneous current L1",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.31.7.0.255",
       "group": "ELECTRICITY",
-      "meterTypes": ["SP","PP"],
+      "meterTypes": [
+        "SP",
+        "PP"
+      ],
       "properties": {
         "PQ_PROFILE": "PRIVATE",
-        "PQ_REQUEST": ["ACTUAL_SP","ACTUAL_PP","PERIODIC_SP"]
+        "PQ_REQUEST": [
+          "ACTUAL_SP",
+          "ACTUAL_PP",
+          "PERIODIC_SP"
+        ]
       },
       "attributes": [
         {
@@ -539,14 +648,19 @@
     {
       "tag": "INSTANTANEOUS_CURRENT_L2",
       "description": "Instantaneous current L2",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.51.7.0.255",
       "group": "ELECTRICITY",
-      "meterTypes": ["PP"],
+      "meterTypes": [
+        "PP"
+      ],
       "properties": {
         "PQ_PROFILE": "PRIVATE",
-        "PQ_REQUEST": ["ACTUAL_PP"]
+        "PQ_REQUEST": [
+          "ACTUAL_PP"
+        ]
       },
       "attributes": [
         {
@@ -570,14 +684,19 @@
     {
       "tag": "INSTANTANEOUS_CURRENT_L3",
       "description": "Instantaneous current L3",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.71.7.0.255",
       "group": "ELECTRICITY",
-      "meterTypes": ["PP"],
+      "meterTypes": [
+        "PP"
+      ],
       "properties": {
         "PQ_PROFILE": "PRIVATE",
-        "PQ_REQUEST": ["ACTUAL_PP"]
+        "PQ_REQUEST": [
+          "ACTUAL_PP"
+        ]
       },
       "attributes": [
         {
@@ -601,14 +720,22 @@
     {
       "tag": "AVERAGE_CURRENT_L1",
       "description": "Average current L1",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.31.24.0.255",
       "group": "ELECTRICITY",
-      "meterTypes": ["SP","PP"],
+      "meterTypes": [
+        "SP",
+        "PP"
+      ],
       "properties": {
         "PQ_PROFILE": "PRIVATE",
-        "PQ_REQUEST": ["ACTUAL_SP","ACTUAL_PP","PERIODIC_SP"]
+        "PQ_REQUEST": [
+          "ACTUAL_SP",
+          "ACTUAL_PP",
+          "PERIODIC_SP"
+        ]
       },
       "attributes": [
         {
@@ -632,14 +759,19 @@
     {
       "tag": "AVERAGE_CURRENT_L2",
       "description": "Average current L2",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.51.24.0.255",
       "group": "ELECTRICITY",
-      "meterTypes": ["PP"],
+      "meterTypes": [
+        "PP"
+      ],
       "properties": {
         "PQ_PROFILE": "PRIVATE",
-        "PQ_REQUEST": ["ACTUAL_PP"]
+        "PQ_REQUEST": [
+          "ACTUAL_PP"
+        ]
       },
       "attributes": [
         {
@@ -663,14 +795,19 @@
     {
       "tag": "AVERAGE_CURRENT_L3",
       "description": "Average current L3",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.71.24.0.255",
       "group": "ELECTRICITY",
-      "meterTypes": ["PP"],
+      "meterTypes": [
+        "PP"
+      ],
       "properties": {
         "PQ_PROFILE": "PRIVATE",
-        "PQ_REQUEST": ["ACTUAL_PP"]
+        "PQ_REQUEST": [
+          "ACTUAL_PP"
+        ]
       },
       "attributes": [
         {
@@ -694,14 +831,22 @@
     {
       "tag": "INSTANTANEOUS_ACTIVE_CURRENT_TOTAL_OVER_ALL_PHASES",
       "description": "Instantaneous current total",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.90.7.0.255",
       "group": "ELECTRICITY",
-      "meterTypes": ["SP","PP"],
+      "meterTypes": [
+        "SP",
+        "PP"
+      ],
       "properties": {
         "PQ_PROFILE": "PRIVATE",
-        "PQ_REQUEST": ["ACTUAL_SP","ACTUAL_PP","PERIODIC_PP"]
+        "PQ_REQUEST": [
+          "ACTUAL_SP",
+          "ACTUAL_PP",
+          "PERIODIC_PP"
+        ]
       },
       "attributes": [
         {
@@ -725,14 +870,21 @@
     {
       "tag": "INSTANTANEOUS_ACTIVE_POWER_IMPORT",
       "description": "Instantaneous active power (+P)",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.1.7.0.255",
       "group": "ELECTRICITY",
-      "meterTypes": ["SP","PP"],
+      "meterTypes": [
+        "SP",
+        "PP"
+      ],
       "properties": {
         "PQ_PROFILE": "PRIVATE",
-        "PQ_REQUEST": ["ACTUAL_SP","ACTUAL_PP"]
+        "PQ_REQUEST": [
+          "ACTUAL_SP",
+          "ACTUAL_PP"
+        ]
       },
       "attributes": [
         {
@@ -756,14 +908,21 @@
     {
       "tag": "INSTANTANEOUS_ACTIVE_POWER_EXPORT",
       "description": "Instantaneous active power (-P)",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.2.7.0.255",
       "group": "ELECTRICITY",
-      "meterTypes": ["SP","PP"],
+      "meterTypes": [
+        "SP",
+        "PP"
+      ],
       "properties": {
         "PQ_PROFILE": "PRIVATE",
-        "PQ_REQUEST": ["ACTUAL_SP","ACTUAL_PP"]
+        "PQ_REQUEST": [
+          "ACTUAL_SP",
+          "ACTUAL_PP"
+        ]
       },
       "attributes": [
         {
@@ -787,14 +946,21 @@
     {
       "tag": "INSTANTANEOUS_ACTIVE_POWER_IMPORT_L1",
       "description": "Instantaneous active power L1 (+P)",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.21.7.0.255",
       "group": "ELECTRICITY",
-      "meterTypes": ["SP","PP"],
+      "meterTypes": [
+        "SP",
+        "PP"
+      ],
       "properties": {
         "PQ_PROFILE": "PRIVATE",
-        "PQ_REQUEST": ["ACTUAL_SP","ACTUAL_PP"]
+        "PQ_REQUEST": [
+          "ACTUAL_SP",
+          "ACTUAL_PP"
+        ]
       },
       "attributes": [
         {
@@ -818,14 +984,19 @@
     {
       "tag": "INSTANTANEOUS_ACTIVE_POWER_IMPORT_L2",
       "description": "Instantaneous active power L2 (+P)",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.41.7.0.255",
       "group": "ELECTRICITY",
-      "meterTypes": ["PP"],
+      "meterTypes": [
+        "PP"
+      ],
       "properties": {
         "PQ_PROFILE": "PRIVATE",
-        "PQ_REQUEST": ["ACTUAL_PP"]
+        "PQ_REQUEST": [
+          "ACTUAL_PP"
+        ]
       },
       "attributes": [
         {
@@ -849,14 +1020,19 @@
     {
       "tag": "INSTANTANEOUS_ACTIVE_POWER_IMPORT_L3",
       "description": "Instantaneous active power L3 (+P)",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.61.7.0.255",
       "group": "ELECTRICITY",
-      "meterTypes": ["PP"],
+      "meterTypes": [
+        "PP"
+      ],
       "properties": {
         "PQ_PROFILE": "PRIVATE",
-        "PQ_REQUEST": ["ACTUAL_PP"]
+        "PQ_REQUEST": [
+          "ACTUAL_PP"
+        ]
       },
       "attributes": [
         {
@@ -880,14 +1056,21 @@
     {
       "tag": "INSTANTANEOUS_ACTIVE_POWER_EXPORT_L1",
       "description": "Instantaneous active power L1 (-P)",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.22.7.0.255",
       "group": "ELECTRICITY",
-      "meterTypes": ["SP","PP"],
+      "meterTypes": [
+        "SP",
+        "PP"
+      ],
       "properties": {
         "PQ_PROFILE": "PRIVATE",
-        "PQ_REQUEST": ["ACTUAL_SP","ACTUAL_PP"]
+        "PQ_REQUEST": [
+          "ACTUAL_SP",
+          "ACTUAL_PP"
+        ]
       },
       "attributes": [
         {
@@ -911,14 +1094,19 @@
     {
       "tag": "INSTANTANEOUS_ACTIVE_POWER_EXPORT_L2",
       "description": "Instantaneous active power L2 (-P)",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.42.7.0.255",
       "group": "ELECTRICITY",
-      "meterTypes": ["PP"],
+      "meterTypes": [
+        "PP"
+      ],
       "properties": {
         "PQ_PROFILE": "PRIVATE",
-        "PQ_REQUEST": ["ACTUAL_PP"]
+        "PQ_REQUEST": [
+          "ACTUAL_PP"
+        ]
       },
       "attributes": [
         {
@@ -942,14 +1130,19 @@
     {
       "tag": "INSTANTANEOUS_ACTIVE_POWER_EXPORT_L3",
       "description": "Instantaneous active power L3 (-P)",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.62.7.0.255",
       "group": "ELECTRICITY",
-      "meterTypes": ["PP"],
+      "meterTypes": [
+        "PP"
+      ],
       "properties": {
         "PQ_PROFILE": "PRIVATE",
-        "PQ_REQUEST": ["ACTUAL_PP"]
+        "PQ_REQUEST": [
+          "ACTUAL_PP"
+        ]
       },
       "attributes": [
         {
@@ -973,14 +1166,23 @@
     {
       "tag": "AVERAGE_ACTIVE_POWER_IMPORT_L1",
       "description": "Average active power (+P) L1",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.21.24.0.255",
       "group": "ELECTRICITY",
-      "meterTypes": ["SP","PP"],
+      "meterTypes": [
+        "SP",
+        "PP"
+      ],
       "properties": {
         "PQ_PROFILE": "PRIVATE",
-        "PQ_REQUEST": ["ACTUAL_SP","ACTUAL_PP","PERIODIC_SP","PERIODIC_PP"]
+        "PQ_REQUEST": [
+          "ACTUAL_SP",
+          "ACTUAL_PP",
+          "PERIODIC_SP",
+          "PERIODIC_PP"
+        ]
       },
       "attributes": [
         {
@@ -1004,14 +1206,20 @@
     {
       "tag": "AVERAGE_ACTIVE_POWER_IMPORT_L2",
       "description": "Average active power (+P) L2",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.41.24.0.255",
       "group": "ELECTRICITY",
-      "meterTypes": ["PP"],
+      "meterTypes": [
+        "PP"
+      ],
       "properties": {
         "PQ_PROFILE": "PRIVATE",
-        "PQ_REQUEST": ["ACTUAL_PP","PERIODIC_PP"]
+        "PQ_REQUEST": [
+          "ACTUAL_PP",
+          "PERIODIC_PP"
+        ]
       },
       "attributes": [
         {
@@ -1035,14 +1243,20 @@
     {
       "tag": "AVERAGE_ACTIVE_POWER_IMPORT_L3",
       "description": "Average active power (+P) L3",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.61.24.0.255",
       "group": "ELECTRICITY",
-      "meterTypes": ["PP"],
+      "meterTypes": [
+        "PP"
+      ],
       "properties": {
         "PQ_PROFILE": "PRIVATE",
-        "PQ_REQUEST": ["ACTUAL_PP","PERIODIC_PP"]
+        "PQ_REQUEST": [
+          "ACTUAL_PP",
+          "PERIODIC_PP"
+        ]
       },
       "attributes": [
         {
@@ -1066,14 +1280,23 @@
     {
       "tag": "AVERAGE_ACTIVE_POWER_EXPORT_L1",
       "description": "Average active power (-P) L1",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.22.24.0.255",
       "group": "ELECTRICITY",
-      "meterTypes": ["SP","PP"],
+      "meterTypes": [
+        "SP",
+        "PP"
+      ],
       "properties": {
         "PQ_PROFILE": "PRIVATE",
-        "PQ_REQUEST": ["ACTUAL_SP","ACTUAL_PP","PERIODIC_SP","PERIODIC_PP"]
+        "PQ_REQUEST": [
+          "ACTUAL_SP",
+          "ACTUAL_PP",
+          "PERIODIC_SP",
+          "PERIODIC_PP"
+        ]
       },
       "attributes": [
         {
@@ -1097,14 +1320,20 @@
     {
       "tag": "AVERAGE_ACTIVE_POWER_EXPORT_L2",
       "description": "Average active power (-P) L2",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.42.24.0.255",
       "group": "ELECTRICITY",
-      "meterTypes": ["PP"],
+      "meterTypes": [
+        "PP"
+      ],
       "properties": {
         "PQ_PROFILE": "PRIVATE",
-        "PQ_REQUEST": ["ACTUAL_PP","PERIODIC_PP"]
+        "PQ_REQUEST": [
+          "ACTUAL_PP",
+          "PERIODIC_PP"
+        ]
       },
       "attributes": [
         {
@@ -1128,14 +1357,20 @@
     {
       "tag": "AVERAGE_ACTIVE_POWER_EXPORT_L3",
       "description": "Average active power (-P) L3",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.62.24.0.255",
       "group": "ELECTRICITY",
-      "meterTypes": ["PP"],
+      "meterTypes": [
+        "PP"
+      ],
       "properties": {
         "PQ_PROFILE": "PRIVATE",
-        "PQ_REQUEST": ["ACTUAL_PP","PERIODIC_PP"]
+        "PQ_REQUEST": [
+          "ACTUAL_PP",
+          "PERIODIC_PP"
+        ]
       },
       "attributes": [
         {
@@ -1159,14 +1394,23 @@
     {
       "tag": "AVERAGE_REACTIVE_POWER_IMPORT_L1",
       "description": "Average reactive power (+Q) L1",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.23.24.0.255",
       "group": "ELECTRICITY",
-      "meterTypes": ["SP","PP"],
+      "meterTypes": [
+        "SP",
+        "PP"
+      ],
       "properties": {
         "PQ_PROFILE": "PRIVATE",
-        "PQ_REQUEST": ["ACTUAL_SP","ACTUAL_PP","PERIODIC_SP","PERIODIC_PP"]
+        "PQ_REQUEST": [
+          "ACTUAL_SP",
+          "ACTUAL_PP",
+          "PERIODIC_SP",
+          "PERIODIC_PP"
+        ]
       },
       "attributes": [
         {
@@ -1190,14 +1434,20 @@
     {
       "tag": "AVERAGE_REACTIVE_POWER_IMPORT_L2",
       "description": "Average reactive power (+Q) L2",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.43.24.0.255",
       "group": "ELECTRICITY",
-      "meterTypes": ["PP"],
+      "meterTypes": [
+        "PP"
+      ],
       "properties": {
         "PQ_PROFILE": "PRIVATE",
-        "PQ_REQUEST": ["ACTUAL_PP","PERIODIC_PP"]
+        "PQ_REQUEST": [
+          "ACTUAL_PP",
+          "PERIODIC_PP"
+        ]
       },
       "attributes": [
         {
@@ -1221,14 +1471,20 @@
     {
       "tag": "AVERAGE_REACTIVE_POWER_IMPORT_L3",
       "description": "Average reactive power (+Q) L3",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.63.24.0.255",
       "group": "ELECTRICITY",
-      "meterTypes": ["PP"],
+      "meterTypes": [
+        "PP"
+      ],
       "properties": {
         "PQ_PROFILE": "PRIVATE",
-        "PQ_REQUEST": ["ACTUAL_PP","PERIODIC_PP"]
+        "PQ_REQUEST": [
+          "ACTUAL_PP",
+          "PERIODIC_PP"
+        ]
       },
       "attributes": [
         {
@@ -1252,14 +1508,23 @@
     {
       "tag": "AVERAGE_REACTIVE_POWER_EXPORT_L1",
       "description": "Average reactive power (-Q) L1",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.24.24.0.255",
       "group": "ELECTRICITY",
-      "meterTypes": ["SP","PP"],
+      "meterTypes": [
+        "SP",
+        "PP"
+      ],
       "properties": {
         "PQ_PROFILE": "PRIVATE",
-        "PQ_REQUEST": ["ACTUAL_SP","ACTUAL_PP","PERIODIC_SP","PERIODIC_PP"]
+        "PQ_REQUEST": [
+          "ACTUAL_SP",
+          "ACTUAL_PP",
+          "PERIODIC_SP",
+          "PERIODIC_PP"
+        ]
       },
       "attributes": [
         {
@@ -1283,14 +1548,20 @@
     {
       "tag": "AVERAGE_REACTIVE_POWER_EXPORT_L2",
       "description": "Average reactive power (-Q) L2",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.44.24.0.255",
       "group": "ELECTRICITY",
-      "meterTypes": ["PP"],
+      "meterTypes": [
+        "PP"
+      ],
       "properties": {
         "PQ_PROFILE": "PRIVATE",
-        "PQ_REQUEST": ["ACTUAL_PP","PERIODIC_PP"]
+        "PQ_REQUEST": [
+          "ACTUAL_PP",
+          "PERIODIC_PP"
+        ]
       },
       "attributes": [
         {
@@ -1314,14 +1585,20 @@
     {
       "tag": "AVERAGE_REACTIVE_POWER_EXPORT_L3",
       "description": "Average reactive power (-Q) L3",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.64.24.0.255",
       "group": "ELECTRICITY",
-      "meterTypes": ["PP"],
+      "meterTypes": [
+        "PP"
+      ],
       "properties": {
         "PQ_PROFILE": "PRIVATE",
-        "PQ_REQUEST": ["ACTUAL_PP","PERIODIC_PP"]
+        "PQ_REQUEST": [
+          "ACTUAL_PP",
+          "PERIODIC_PP"
+        ]
       },
       "attributes": [
         {
@@ -1345,11 +1622,15 @@
     {
       "tag": "ALARM_REGISTER_1",
       "description": "Alarm register 1",
+      "note": null,
       "class-id": 1,
       "version": 0,
       "obis": "0.0.97.98.0.255",
       "group": "ELECTRICITY",
-      "meterTypes": ["SP","PP"],
+      "meterTypes": [
+        "SP",
+        "PP"
+      ],
       "properties": {},
       "attributes": [
         {

--- a/osgp/protocol-adapter-dlms/osgp-dlms/src/main/resources/dlmsprofiles/dlmsprofile-dsmr422.json
+++ b/osgp/protocol-adapter-dlms/osgp-dlms/src/main/resources/dlmsprofiles/dlmsprofile-dsmr422.json
@@ -1341,6 +1341,26 @@
           "access": "R"
         }
       ]
+    },
+    {
+      "tag": "ALARM_REGISTER_1",
+      "description": "Alarm register 1",
+      "class-id": 1,
+      "version": 0,
+      "obis": "0.0.97.98.0.255",
+      "group": "ELECTRICITY",
+      "meterTypes": ["SP","PP"],
+      "properties": {},
+      "attributes": [
+        {
+          "id": 2,
+          "description": "value",
+          "datatype": "double-long-unsigned",
+          "valuetype": "DYNAMIC",
+          "value": "0",
+          "access": "RW"
+        }
+      ]
     }
   ]
 }

--- a/osgp/protocol-adapter-dlms/osgp-dlms/src/main/resources/dlmsprofiles/dlmsprofile-smr43.json
+++ b/osgp/protocol-adapter-dlms/osgp-dlms/src/main/resources/dlmsprofiles/dlmsprofile-smr43.json
@@ -7,113 +7,126 @@
     "version": "4.2.2"
   },
   "properties": [],
-  "objects": [{
-    "tag": "DEFINABLE_LOAD_PROFILE",
-    "description": "Definable load profile",
-    "class-id": 7,
-    "version": 1,
-    "obis": "0.1.94.31.6.255",
-    "group": "ELECTRICITY",
-    "meterTypes": ["SP","PP"],
-    "properties": {
-      "SELECTABLE_OBJECTS": [
-        "CLOCK",
-        "CDMA_DIAGNOSTIC",
-        "NUMBER_OF_VOLTAGE_SWELLS_FOR_L1",
-        "NUMBER_OF_VOLTAGE_SAGS_FOR_L1",
-        "NUMBER_OF_POWER_FAILURES",
-        "INSTANTANEOUS_VOLTAGE_L1",
-        "INSTANTANEOUS_VOLTAGE_L2",
-        "INSTANTANEOUS_VOLTAGE_L3",
-        "AVERAGE_VOLTAGE_L1",
-        "AVERAGE_VOLTAGE_L2",
-        "AVERAGE_VOLTAGE_L3",
-        "INSTANTANEOUS_CURRENT_L1",
-        "AVERAGE_CURRENT_L1",
-        "INSTANTANEOUS_ACTIVE_CURRENT_TOTAL_OVER_ALL_PHASES",
-        "AVERAGE_ACTIVE_POWER_IMPORT_L1",
-        "AVERAGE_ACTIVE_POWER_IMPORT_L2",
-        "AVERAGE_ACTIVE_POWER_IMPORT_L3",
-        "AVERAGE_ACTIVE_POWER_EXPORT_L1",
-        "AVERAGE_ACTIVE_POWER_EXPORT_L2",
-        "AVERAGE_ACTIVE_POWER_EXPORT_L3",
-        "AVERAGE_REACTIVE_POWER_IMPORT_L1",
-        "AVERAGE_REACTIVE_POWER_IMPORT_L2",
-        "AVERAGE_REACTIVE_POWER_IMPORT_L3",
-        "AVERAGE_REACTIVE_POWER_EXPORT_L1",
-        "AVERAGE_REACTIVE_POWER_EXPORT_L2",
-        "AVERAGE_REACTIVE_POWER_EXPORT_L3"
+  "objects": [
+    {
+      "tag": "DEFINABLE_LOAD_PROFILE",
+      "description": "Definable load profile",
+      "note": null,
+      "class-id": 7,
+      "version": 1,
+      "obis": "0.1.94.31.6.255",
+      "group": "ELECTRICITY",
+      "meterTypes": [
+        "SP",
+        "PP"
+      ],
+      "properties": {
+        "SELECTABLE_OBJECTS": [
+          "CLOCK",
+          "CDMA_DIAGNOSTIC",
+          "NUMBER_OF_VOLTAGE_SWELLS_FOR_L1",
+          "NUMBER_OF_VOLTAGE_SAGS_FOR_L1",
+          "NUMBER_OF_POWER_FAILURES",
+          "INSTANTANEOUS_VOLTAGE_L1",
+          "INSTANTANEOUS_VOLTAGE_L2",
+          "INSTANTANEOUS_VOLTAGE_L3",
+          "AVERAGE_VOLTAGE_L1",
+          "AVERAGE_VOLTAGE_L2",
+          "AVERAGE_VOLTAGE_L3",
+          "INSTANTANEOUS_CURRENT_L1",
+          "AVERAGE_CURRENT_L1",
+          "INSTANTANEOUS_ACTIVE_CURRENT_TOTAL_OVER_ALL_PHASES",
+          "AVERAGE_ACTIVE_POWER_IMPORT_L1",
+          "AVERAGE_ACTIVE_POWER_IMPORT_L2",
+          "AVERAGE_ACTIVE_POWER_IMPORT_L3",
+          "AVERAGE_ACTIVE_POWER_EXPORT_L1",
+          "AVERAGE_ACTIVE_POWER_EXPORT_L2",
+          "AVERAGE_ACTIVE_POWER_EXPORT_L3",
+          "AVERAGE_REACTIVE_POWER_IMPORT_L1",
+          "AVERAGE_REACTIVE_POWER_IMPORT_L2",
+          "AVERAGE_REACTIVE_POWER_IMPORT_L3",
+          "AVERAGE_REACTIVE_POWER_EXPORT_L1",
+          "AVERAGE_REACTIVE_POWER_EXPORT_L2",
+          "AVERAGE_REACTIVE_POWER_EXPORT_L3"
+        ]
+      },
+      "attributes": [
+        {
+          "id": 2,
+          "description": "buffer",
+          "datatype": "array",
+          "valuetype": "DYNAMIC",
+          "value": "EMPTY",
+          "access": "R"
+        },
+        {
+          "id": 3,
+          "description": "capture objects",
+          "datatype": "array",
+          "valuetype": "SET_BY_CLIENT",
+          "value": "EMPTY",
+          "access": "RW"
+        },
+        {
+          "id": 4,
+          "description": "capture period in sec",
+          "datatype": "double-long-unsigned",
+          "valuetype": "SET_BY_CLIENT",
+          "value": "86400",
+          "access": "RW"
+        },
+        {
+          "id": 5,
+          "description": "sort method",
+          "datatype": "enum",
+          "valuetype": "FIXED_IN_METER",
+          "value": "1",
+          "access": "R"
+        },
+        {
+          "id": 6,
+          "description": "sort object",
+          "datatype": "object_definition",
+          "valuetype": "FIXED_IN_METER",
+          "value": "NONE",
+          "access": "R"
+        },
+        {
+          "id": 7,
+          "description": "entries in use",
+          "datatype": "double-long-unsigned",
+          "valuetype": "DYNAMIC",
+          "value": "0",
+          "access": "R"
+        },
+        {
+          "id": 8,
+          "description": "profile entries",
+          "datatype": "double-long-unsigned",
+          "valuetype": "SET_BY_CLIENT",
+          "value": "960",
+          "access": "RW"
+        }
       ]
     },
-    "attributes": [
-      {
-        "id": 2,
-        "description": "buffer",
-        "datatype": "array",
-        "valuetype": "DYNAMIC",
-        "value": "EMPTY",
-        "access": "R"
-      },
-      {
-        "id": 3,
-        "description": "capture objects",
-        "datatype": "array",
-        "valuetype": "SET_BY_CLIENT",
-        "value": "EMPTY",
-        "access": "RW"
-      },
-      {
-        "id": 4,
-        "description": "capture period in sec",
-        "datatype": "double-long-unsigned",
-        "valuetype": "SET_BY_CLIENT",
-        "value": "86400",
-        "access": "RW"
-      },
-      {
-        "id": 5,
-        "description": "sort method",
-        "datatype": "enum",
-        "valuetype": "FIXED_IN_METER",
-        "value": "1",
-        "access": "R"
-      },
-      {
-        "id": 6,
-        "description": "sort object",
-        "datatype": "object_definition",
-        "valuetype": "FIXED_IN_METER",
-        "value": "NONE",
-        "access": "R"
-      },
-      {
-        "id": 7,
-        "description": "entries in use",
-        "datatype": "double-long-unsigned",
-        "valuetype": "DYNAMIC",
-        "value": "0",
-        "access": "R"
-      },
-      {
-        "id": 8,
-        "description": "profile entries",
-        "datatype": "double-long-unsigned",
-        "valuetype": "SET_BY_CLIENT",
-        "value": "960",
-        "access": "RW"
-      }
-    ]
-  },{
+    {
       "tag": "CDMA_DIAGNOSTIC",
       "description": "CDMA Diagnostic",
+      "note": null,
       "class-id": 47,
       "version": 0,
       "obis": "0.1.25.6.0.255",
       "group": "ELECTRICITY",
-      "meterTypes": ["SP","PP"],
+      "meterTypes": [
+        "SP",
+        "PP"
+      ],
       "properties": {
         "PQ_PROFILE": "PUBLIC",
-        "PQ_REQUEST": ["PERIODIC_SP","PERIODIC_PP"]
+        "PQ_REQUEST": [
+          "PERIODIC_SP",
+          "PERIODIC_PP"
+        ]
       },
       "attributes": [
         {

--- a/osgp/protocol-adapter-dlms/osgp-dlms/src/main/resources/dlmsprofiles/dlmsprofile-smr500.json
+++ b/osgp/protocol-adapter-dlms/osgp-dlms/src/main/resources/dlmsprofiles/dlmsprofile-smr500.json
@@ -1841,6 +1841,26 @@
           "access": "R"
         }
       ]
+    },
+    {
+      "tag": "ALARM_REGISTER_1",
+      "description": "Alarm register 1",
+      "class-id": 1,
+      "version": 0,
+      "obis": "0.0.97.98.0.255",
+      "group": "ELECTRICITY",
+      "meterTypes": ["SP","PP"],
+      "properties": {},
+      "attributes": [
+        {
+          "id": 2,
+          "description": "value",
+          "datatype": "double-long-unsigned",
+          "valuetype": "DYNAMIC",
+          "value": "0",
+          "access": "RW"
+        }
+      ]
     }
   ]
 }

--- a/osgp/protocol-adapter-dlms/osgp-dlms/src/main/resources/dlmsprofiles/dlmsprofile-smr500.json
+++ b/osgp/protocol-adapter-dlms/osgp-dlms/src/main/resources/dlmsprofiles/dlmsprofile-smr500.json
@@ -7,6 +7,7 @@
     {
       "tag": "CLOCK",
       "description": "Clock",
+      "note": null,
       "class-id": 8,
       "version": 0,
       "obis": "0.0.1.0.0.255",
@@ -42,6 +43,7 @@
     {
       "tag": "DEFINABLE_LOAD_PROFILE",
       "description": "Definable load profile",
+      "note": null,
       "class-id": 7,
       "version": 1,
       "obis": "0.1.94.31.6.255",
@@ -126,6 +128,7 @@
     {
       "tag": "POWER_QUALITY_PROFILE_1",
       "description": "Power Quality profile 1, 15 min power quality values",
+      "note": null,
       "class-id": 7,
       "version": 1,
       "obis": "1.0.99.1.1.255",
@@ -298,6 +301,7 @@
     {
       "tag": "INSTANTANEOUS_ACTIVE_POWER_IMPORT",
       "description": "Instantaneous active power (+P)",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.1.7.0.255",
@@ -329,6 +333,7 @@
     {
       "tag": "INSTANTANEOUS_ACTIVE_POWER_EXPORT",
       "description": "Instantaneous active power (-P)",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.2.7.0.255",
@@ -360,6 +365,7 @@
     {
       "tag": "INSTANTANEOUS_ACTIVE_POWER_IMPORT_L1",
       "description": "Instantaneous active power L1 (+P)",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.21.7.0.255",
@@ -391,6 +397,7 @@
     {
       "tag": "INSTANTANEOUS_ACTIVE_POWER_IMPORT_L2",
       "description": "Instantaneous active power L2 (+P)",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.41.7.0.255",
@@ -422,6 +429,7 @@
     {
       "tag": "INSTANTANEOUS_ACTIVE_POWER_IMPORT_L3",
       "description": "Instantaneous active power L3 (+P)",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.61.7.0.255",
@@ -453,6 +461,7 @@
     {
       "tag": "INSTANTANEOUS_ACTIVE_POWER_EXPORT_L1",
       "description": "Instantaneous active power L1 (-P)",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.22.7.0.255",
@@ -484,6 +493,7 @@
     {
       "tag": "INSTANTANEOUS_ACTIVE_POWER_EXPORT_L2",
       "description": "Instantaneous active power L2 (-P)",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.42.7.0.255",
@@ -515,6 +525,7 @@
     {
       "tag": "INSTANTANEOUS_ACTIVE_POWER_EXPORT_L3",
       "description": "Instantaneous active power L3 (-P)",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.62.7.0.255",
@@ -546,6 +557,7 @@
     {
       "tag": "INSTANTANEOUS_ACTIVE_CURRENT_TOTAL_OVER_ALL_PHASES",
       "description": "Instantaneous current total",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.90.7.0.255",
@@ -577,6 +589,7 @@
     {
       "tag": "INSTANTANEOUS_CURRENT_L1",
       "description": "Instantaneous current L1",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.31.7.0.255",
@@ -608,6 +621,7 @@
     {
       "tag": "INSTANTANEOUS_CURRENT_L2",
       "description": "Instantaneous current L2",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.51.7.0.255",
@@ -639,6 +653,7 @@
     {
       "tag": "INSTANTANEOUS_CURRENT_L3",
       "description": "Instantaneous current L3",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.71.7.0.255",
@@ -670,6 +685,7 @@
     {
       "tag": "INSTANTANEOUS_VOLTAGE_L1",
       "description": "Instantaneous voltage L1",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.32.7.0.255",
@@ -701,6 +717,7 @@
     {
       "tag": "INSTANTANEOUS_VOLTAGE_L2",
       "description": "Instantaneous voltage L2",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.52.7.0.255",
@@ -732,6 +749,7 @@
     {
       "tag": "INSTANTANEOUS_VOLTAGE_L3",
       "description": "Instantaneous voltage L3",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.72.7.0.255",
@@ -763,6 +781,7 @@
     {
       "tag": "AVERAGE_ACTIVE_POWER_EXPORT_L1",
       "description": "Average active power (-P) L1",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.22.4.0.255",
@@ -794,6 +813,7 @@
     {
       "tag": "AVERAGE_ACTIVE_POWER_EXPORT_L2",
       "description": "Average active power (-P) L2",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.42.4.0.255",
@@ -825,6 +845,7 @@
     {
       "tag": "AVERAGE_ACTIVE_POWER_EXPORT_L3",
       "description": "Average active power (-P) L3",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.62.4.0.255",
@@ -856,6 +877,7 @@
     {
       "tag": "AVERAGE_ACTIVE_POWER_IMPORT_L1",
       "description": "Average active power (+P) L1",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.21.4.0.255",
@@ -887,6 +909,7 @@
     {
       "tag": "AVERAGE_ACTIVE_POWER_IMPORT_L2",
       "description": "Average active power (+P) L2",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.41.4.0.255",
@@ -918,6 +941,7 @@
     {
       "tag": "AVERAGE_ACTIVE_POWER_IMPORT_L3",
       "description": "Average active power (+P) L3",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.61.4.0.255",
@@ -949,6 +973,7 @@
     {
       "tag": "AVERAGE_REACTIVE_POWER_IMPORT_L1",
       "description": "Average reactive power (+Q) L1",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.23.4.0.255",
@@ -980,6 +1005,7 @@
     {
       "tag": "AVERAGE_REACTIVE_POWER_IMPORT_L2",
       "description": "Average reactive power (+Q) L2",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.43.4.0.255",
@@ -1011,6 +1037,7 @@
     {
       "tag": "AVERAGE_REACTIVE_POWER_IMPORT_L3",
       "description": "Average reactive power (+Q) L3",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.63.4.0.255",
@@ -1042,6 +1069,7 @@
     {
       "tag": "AVERAGE_REACTIVE_POWER_EXPORT_L1",
       "description": "Average reactive power (-Q) L1",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.24.4.0.255",
@@ -1073,6 +1101,7 @@
     {
       "tag": "AVERAGE_REACTIVE_POWER_EXPORT_L2",
       "description": "Average reactive power (-Q) L2",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.44.4.0.255",
@@ -1104,6 +1133,7 @@
     {
       "tag": "AVERAGE_REACTIVE_POWER_EXPORT_L3",
       "description": "Average reactive power (-Q) L3",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.64.4.0.255",
@@ -1135,6 +1165,7 @@
     {
       "tag": "AVERAGE_CURRENT_L1",
       "description": "Average current L1",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.31.24.0.255",
@@ -1166,6 +1197,7 @@
     {
       "tag": "AVERAGE_CURRENT_L2",
       "description": "Average current L2",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.51.24.0.255",
@@ -1197,6 +1229,7 @@
     {
       "tag": "AVERAGE_CURRENT_L3",
       "description": "Average current L3",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.71.24.0.255",
@@ -1228,6 +1261,7 @@
     {
       "tag": "AVERAGE_VOLTAGE_L1",
       "description": "Average voltage L1",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.32.24.0.255",
@@ -1259,6 +1293,7 @@
     {
       "tag": "AVERAGE_VOLTAGE_L2",
       "description": "Average voltage L2",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.52.24.0.255",
@@ -1290,6 +1325,7 @@
     {
       "tag": "AVERAGE_VOLTAGE_L3",
       "description": "Average voltage L3",
+      "note": null,
       "class-id": 3,
       "version": 0,
       "obis": "1.0.72.24.0.255",
@@ -1321,6 +1357,7 @@
     {
       "tag": "NUMBER_OF_POWER_FAILURES",
       "description": "Number of power failures in any phases",
+      "note": null,
       "class-id": 1,
       "version": 0,
       "obis": "0.0.96.7.21.255",
@@ -1344,6 +1381,7 @@
     {
       "tag": "NUMBER_OF_LONG_POWER_FAILURES",
       "description": "Number of long power failures in any phases",
+      "note": null,
       "class-id": 1,
       "version": 0,
       "obis": "0.0.96.7.9.255",
@@ -1367,6 +1405,7 @@
     {
       "tag": "NUMBER_OF_VOLTAGE_SAGS_FOR_L1",
       "description": "Number of voltage sags in phase L1",
+      "note": null,
       "class-id": 1,
       "version": 0,
       "obis": "1.0.32.32.0.255",
@@ -1390,6 +1429,7 @@
     {
       "tag": "NUMBER_OF_VOLTAGE_SAGS_FOR_L2",
       "description": "Number of voltage sags in phase L2",
+      "note": null,
       "class-id": 1,
       "version": 0,
       "obis": "1.0.52.32.0.255",
@@ -1413,6 +1453,7 @@
     {
       "tag": "NUMBER_OF_VOLTAGE_SAGS_FOR_L3",
       "description": "Number of voltage sags in phase L3",
+      "note": null,
       "class-id": 1,
       "version": 0,
       "obis": "1.0.72.32.0.255",
@@ -1436,6 +1477,7 @@
     {
       "tag": "NUMBER_OF_VOLTAGE_SWELLS_FOR_L1",
       "description": "Number of voltage swells in phase L1",
+      "note": null,
       "class-id": 1,
       "version": 0,
       "obis": "1.0.32.36.0.255",
@@ -1459,6 +1501,7 @@
     {
       "tag": "NUMBER_OF_VOLTAGE_SWELLS_FOR_L2",
       "description": "Number of voltage swells in phase L2",
+      "note": null,
       "class-id": 1,
       "version": 0,
       "obis": "1.0.52.36.0.255",
@@ -1482,6 +1525,7 @@
     {
       "tag": "NUMBER_OF_VOLTAGE_SWELLS_FOR_L3",
       "description": "Number of voltage swells in phase L3",
+      "note": null,
       "class-id": 1,
       "version": 0,
       "obis": "1.0.72.36.0.255",
@@ -1505,6 +1549,7 @@
     {
       "tag": "CDMA_DIAGNOSTIC",
       "description": "CDMA Diagnostic",
+      "note": null,
       "class-id": 47,
       "version": 0,
       "obis": "0.1.25.6.0.255",
@@ -1576,6 +1621,7 @@
     {
       "tag": "GPRS_DIAGNOSTIC",
       "description": "GPRS Diagnostic",
+      "note": null,
       "class-id": 47,
       "version": 0,
       "obis": "0.0.25.6.0.255",
@@ -1647,6 +1693,7 @@
     {
       "tag": "MBUS_CLIENT_SETUP",
       "description": "M-Bus client setup",
+      "note": null,
       "class-id": 72,
       "version": 1,
       "obis": "0.x.24.1.0.255",
@@ -1766,6 +1813,7 @@
     {
       "tag": "MBUS_DIAGNOSTIC",
       "description": "M-Bus diagnostic",
+      "note": null,
       "class-id": 77,
       "version": 0,
       "obis": "0.x.24.9.0.255",
@@ -1845,6 +1893,7 @@
     {
       "tag": "ALARM_REGISTER_1",
       "description": "Alarm register 1",
+      "note": null,
       "class-id": 1,
       "version": 0,
       "obis": "0.0.97.98.0.255",

--- a/osgp/protocol-adapter-dlms/osgp-dlms/src/main/resources/dlmsprofiles/dlmsprofile-smr52.json
+++ b/osgp/protocol-adapter-dlms/osgp-dlms/src/main/resources/dlmsprofiles/dlmsprofile-smr52.json
@@ -162,5 +162,25 @@
         "access": "R"
       }
     ]
-  }]
+  },
+    {
+      "tag": "ALARM_REGISTER_2",
+      "description": "Alarm register 2",
+      "class-id": 1,
+      "version": 0,
+      "obis": "0.0.97.98.1.255",
+      "group": "ELECTRICITY",
+      "meterTypes": ["SP","PP"],
+      "properties": {},
+      "attributes": [
+        {
+          "id": 2,
+          "description": "value",
+          "datatype": "double-long-unsigned",
+          "valuetype": "DYNAMIC",
+          "value": "0",
+          "access": "RW"
+        }
+      ]
+    }]
 }

--- a/osgp/protocol-adapter-dlms/osgp-dlms/src/main/resources/dlmsprofiles/dlmsprofile-smr52.json
+++ b/osgp/protocol-adapter-dlms/osgp-dlms/src/main/resources/dlmsprofiles/dlmsprofile-smr52.json
@@ -11,11 +11,15 @@
     {
       "tag": "DEFINABLE_LOAD_PROFILE",
       "description": "Definable load profile",
+      "note": null,
       "class-id": 7,
       "version": 1,
       "obis": "0.1.94.31.6.255",
       "group": "ELECTRICITY",
-      "meterTypes": ["SP","PP"],
+      "meterTypes": [
+        "SP",
+        "PP"
+      ],
       "properties": {
         "SELECTABLE_OBJECTS": [
           "CLOCK",
@@ -92,85 +96,97 @@
           "access": "RW"
         }
       ]
-    },{
-    "tag": "LTE_DIAGNOSTIC",
-    "description": "LTE Diagnostic",
-    "class-id": 47,
-    "version": 0,
-    "obis": "0.2.25.6.0.255",
-    "group": "ELECTRICITY",
-    "meterTypes": ["SP","PP"],
-    "properties": {
-      "PQ_PROFILE": "PUBLIC",
-      "PQ_REQUEST": ["PERIODIC_SP","PERIODIC_PP"]
     },
-    "attributes": [
-      {
-        "id": 2,
-        "description": "operator",
-        "datatype": "visible-string",
-        "valuetype": "DYNAMIC",
-        "value": "EMPTY",
-        "access": "R"
+    {
+      "tag": "LTE_DIAGNOSTIC",
+      "description": "LTE Diagnostic",
+      "note": null,
+      "class-id": 47,
+      "version": 0,
+      "obis": "0.2.25.6.0.255",
+      "group": "ELECTRICITY",
+      "meterTypes": [
+        "SP",
+        "PP"
+      ],
+      "properties": {
+        "PQ_PROFILE": "PUBLIC",
+        "PQ_REQUEST": [
+          "PERIODIC_SP",
+          "PERIODIC_PP"
+        ]
       },
-      {
-        "id": 3,
-        "description": "status",
-        "datatype": "enum",
-        "valuetype": "DYNAMIC",
-        "value": "0",
-        "access": "R"
-      },
-      {
-        "id": 4,
-        "description": "cs attachment",
-        "datatype": "enum",
-        "valuetype": "DYNAMIC",
-        "value": "0",
-        "access": "R"
-      },
-      {
-        "id": 5,
-        "description": "ps status",
-        "datatype": "enum",
-        "valuetype": "DYNAMIC",
-        "value": "0",
-        "access": "R"
-      },
-      {
-        "id": 6,
-        "description": "cell info",
-        "datatype": "cell_info_type",
-        "valuetype": "DYNAMIC",
-        "value": "EMPTY",
-        "access": "R"
-      },
-      {
-        "id": 7,
-        "description": "adjacent cells",
-        "datatype": "array",
-        "valuetype": "DYNAMIC",
-        "value": "EMPTY",
-        "access": "R"
-      },
-      {
-        "id": 8,
-        "description": "capture time",
-        "datatype": "date-time",
-        "valuetype": "DYNAMIC",
-        "value": "EMPTY",
-        "access": "R"
-      }
-    ]
-  },
+      "attributes": [
+        {
+          "id": 2,
+          "description": "operator",
+          "datatype": "visible-string",
+          "valuetype": "DYNAMIC",
+          "value": "EMPTY",
+          "access": "R"
+        },
+        {
+          "id": 3,
+          "description": "status",
+          "datatype": "enum",
+          "valuetype": "DYNAMIC",
+          "value": "0",
+          "access": "R"
+        },
+        {
+          "id": 4,
+          "description": "cs attachment",
+          "datatype": "enum",
+          "valuetype": "DYNAMIC",
+          "value": "0",
+          "access": "R"
+        },
+        {
+          "id": 5,
+          "description": "ps status",
+          "datatype": "enum",
+          "valuetype": "DYNAMIC",
+          "value": "0",
+          "access": "R"
+        },
+        {
+          "id": 6,
+          "description": "cell info",
+          "datatype": "cell_info_type",
+          "valuetype": "DYNAMIC",
+          "value": "EMPTY",
+          "access": "R"
+        },
+        {
+          "id": 7,
+          "description": "adjacent cells",
+          "datatype": "array",
+          "valuetype": "DYNAMIC",
+          "value": "EMPTY",
+          "access": "R"
+        },
+        {
+          "id": 8,
+          "description": "capture time",
+          "datatype": "date-time",
+          "valuetype": "DYNAMIC",
+          "value": "EMPTY",
+          "access": "R"
+        }
+      ]
+    },
     {
       "tag": "ALARM_REGISTER_2",
       "description": "Alarm register 2",
+      "note": "Specified in addendum for SMR5.2",
       "class-id": 1,
       "version": 0,
       "obis": "0.0.97.98.1.255",
       "group": "ELECTRICITY",
-      "meterTypes": ["SP","PP"],
+      "meterTypes": [
+        "SP",
+        "PP"
+      ],
       "properties": {},
       "attributes": [
         {
@@ -182,5 +198,6 @@
           "access": "RW"
         }
       ]
-    }]
+    }
+  ]
 }

--- a/osgp/protocol-adapter-dlms/osgp-dlms/src/main/resources/dlmsprofiles/dlmsprofile-smr55.json
+++ b/osgp/protocol-adapter-dlms/osgp-dlms/src/main/resources/dlmsprofiles/dlmsprofile-smr55.json
@@ -10,6 +10,7 @@
   "objects": [{
     "tag": "PUSH_SETUP_UDP",
     "description": "Push Setup UDP",
+    "note": null,
     "class-id": 40,
     "version": 0,
     "obis": "0.3.25.9.0.255",
@@ -69,6 +70,7 @@
     {
       "tag": "ALARM_REGISTER_3",
       "description": "Alarm register 3",
+      "note": "Specified in addendum for SMR5.5",
       "class-id": 1,
       "version": 0,
       "obis": "0.0.97.98.2.255",

--- a/osgp/protocol-adapter-dlms/osgp-dlms/src/main/resources/dlmsprofiles/dlmsprofile-smr55.json
+++ b/osgp/protocol-adapter-dlms/osgp-dlms/src/main/resources/dlmsprofiles/dlmsprofile-smr55.json
@@ -65,5 +65,25 @@
         "access": "RW"
       }
     ]
-  }]
+  },
+    {
+      "tag": "ALARM_REGISTER_3",
+      "description": "Alarm register 3",
+      "class-id": 1,
+      "version": 0,
+      "obis": "0.0.97.98.2.255",
+      "group": "ELECTRICITY",
+      "meterTypes": ["SP","PP"],
+      "properties": {},
+      "attributes": [
+        {
+          "id": 2,
+          "description": "value",
+          "datatype": "double-long-unsigned",
+          "valuetype": "DYNAMIC",
+          "value": "0",
+          "access": "RW"
+        }
+      ]
+    }]
 }

--- a/osgp/protocol-adapter-dlms/osgp-dlms/src/test/java/org/opensmartgridplatform/dlms/objectcondig/DlmsProfileTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-dlms/src/test/java/org/opensmartgridplatform/dlms/objectcondig/DlmsProfileTest.java
@@ -4,15 +4,15 @@
 
 package org.opensmartgridplatform.dlms.objectcondig;
 
-import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.api.AssertionsForInterfaceTypes;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opensmartgridplatform.dlms.objectconfig.DlmsProfile;
+import org.opensmartgridplatform.dlms.services.Protocol;
 import org.springframework.core.io.ClassPathResource;
 
 @Slf4j
@@ -33,7 +33,8 @@ class DlmsProfileTest {
             new ClassPathResource("/dlmsprofiles/dlmsprofile-smr500.json").getFile(),
             DlmsProfile.class);
 
-    assertNotNull(dlmsProfile);
-    assertThat(dlmsProfile.getObjects()).hasSize(49);
+    Assertions.assertNotNull(dlmsProfile);
+    AssertionsForInterfaceTypes.assertThat(dlmsProfile.getObjects())
+        .hasSize(Protocol.SMR_5_0_0.getNrOfCosemObjects());
   }
 }

--- a/osgp/protocol-adapter-dlms/osgp-dlms/src/test/java/org/opensmartgridplatform/dlms/services/ObjectConfigServiceTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-dlms/src/test/java/org/opensmartgridplatform/dlms/services/ObjectConfigServiceTest.java
@@ -17,8 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
-import org.assertj.core.api.AssertionsForClassTypes;
-import org.assertj.core.api.AssertionsForInterfaceTypes;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -45,41 +44,41 @@ class ObjectConfigServiceTest {
 
     final Map<DlmsObjectType, CosemObject> cosemObjects =
         this.objectConfigService.getCosemObjects(protocol.getName(), protocol.getVersion());
-    AssertionsForInterfaceTypes.assertThat(cosemObjects).hasSize(protocol.getNrOfCosemObjects());
+    Assertions.assertThat(cosemObjects).hasSize(protocol.getNrOfCosemObjects());
 
     final List<CosemObject> cosemObjectsOnDemandPrivate =
         this.getCosemObjectsWithProperties(
             protocol, PowerQualityRequest.ACTUAL_SP, Profile.PRIVATE);
-    AssertionsForInterfaceTypes.assertThat(cosemObjectsOnDemandPrivate)
+    Assertions.assertThat(cosemObjectsOnDemandPrivate)
         .hasSize(protocol.getNrOfCosemObjects(PowerQualityRequest.ACTUAL_SP, Profile.PRIVATE));
 
     final List<CosemObject> cosemObjectsOnDemandPublic =
         this.getCosemObjectsWithProperties(protocol, PowerQualityRequest.ACTUAL_SP, Profile.PUBLIC);
-    AssertionsForInterfaceTypes.assertThat(cosemObjectsOnDemandPublic)
+    Assertions.assertThat(cosemObjectsOnDemandPublic)
         .hasSize(protocol.getNrOfCosemObjects(PowerQualityRequest.ACTUAL_SP, Profile.PUBLIC));
 
     final List<CosemObject> cosemObjectsOnPeriodicSpPrivate =
         this.getCosemObjectsWithProperties(
             protocol, PowerQualityRequest.PERIODIC_SP, Profile.PRIVATE);
-    AssertionsForInterfaceTypes.assertThat(cosemObjectsOnPeriodicSpPrivate)
+    Assertions.assertThat(cosemObjectsOnPeriodicSpPrivate)
         .hasSize(protocol.getNrOfCosemObjects(PowerQualityRequest.PERIODIC_SP, Profile.PRIVATE));
 
     final List<CosemObject> cosemObjectsOnPeriodicPpPrivate =
         this.getCosemObjectsWithProperties(
             protocol, PowerQualityRequest.PERIODIC_PP, Profile.PRIVATE);
-    AssertionsForInterfaceTypes.assertThat(cosemObjectsOnPeriodicPpPrivate)
+    Assertions.assertThat(cosemObjectsOnPeriodicPpPrivate)
         .hasSize(protocol.getNrOfCosemObjects(PowerQualityRequest.PERIODIC_PP, Profile.PRIVATE));
 
     final List<CosemObject> cosemObjectsPeriodicSpPublic =
         this.getCosemObjectsWithProperties(
             protocol, PowerQualityRequest.PERIODIC_SP, Profile.PUBLIC);
-    AssertionsForInterfaceTypes.assertThat(cosemObjectsPeriodicSpPublic)
+    Assertions.assertThat(cosemObjectsPeriodicSpPublic)
         .hasSize(protocol.getNrOfCosemObjects(PowerQualityRequest.PERIODIC_SP, Profile.PUBLIC));
 
     final List<CosemObject> cosemObjectsPeriodicPpPublic =
         this.getCosemObjectsWithProperties(
             protocol, PowerQualityRequest.PERIODIC_PP, Profile.PUBLIC);
-    AssertionsForInterfaceTypes.assertThat(cosemObjectsPeriodicPpPublic)
+    Assertions.assertThat(cosemObjectsPeriodicPpPublic)
         .hasSize(protocol.getNrOfCosemObjects(PowerQualityRequest.PERIODIC_PP, Profile.PUBLIC));
   }
 
@@ -99,20 +98,20 @@ class ObjectConfigServiceTest {
   void testAllPqObjectMapToProfile(final Protocol protocol) throws ObjectConfigException {
     final List<DlmsObjectType> dlmsProfiles = new ArrayList<>();
     if (protocol.hasDefinableLoadProfile()) {
-      AssertionsForClassTypes.assertThat(
+      Assertions.assertThat(
               this.objectConfigService.getCosemObject(
                   protocol.getName(), protocol.getVersion(), DlmsObjectType.DEFINABLE_LOAD_PROFILE))
           .isNotNull();
       dlmsProfiles.add(DlmsObjectType.DEFINABLE_LOAD_PROFILE);
     }
     if (protocol.hasPqProfiles()) {
-      AssertionsForClassTypes.assertThat(
+      Assertions.assertThat(
               this.objectConfigService.getCosemObject(
                   protocol.getName(),
                   protocol.getVersion(),
                   DlmsObjectType.POWER_QUALITY_PROFILE_1))
           .isNotNull();
-      AssertionsForClassTypes.assertThat(
+      Assertions.assertThat(
               this.objectConfigService.getCosemObject(
                   protocol.getName(),
                   protocol.getVersion(),
@@ -143,8 +142,7 @@ class ObjectConfigServiceTest {
         this.objectConfigService.getCosemObjects("DSMR", "2.2");
 
     assertNotNull(cosemObjects);
-    AssertionsForInterfaceTypes.assertThat(cosemObjects)
-        .hasSize(Protocol.DSMR_2_2.getNrOfCosemObjects());
+    Assertions.assertThat(cosemObjects).hasSize(Protocol.DSMR_2_2.getNrOfCosemObjects());
     assertNotNull(cosemObjects.get(DlmsObjectType.ALARM_REGISTER_1));
     assertNotNull(cosemObjects.get(DlmsObjectType.NUMBER_OF_VOLTAGE_SWELLS_FOR_L1));
   }
@@ -155,8 +153,7 @@ class ObjectConfigServiceTest {
         this.objectConfigService.getCosemObjects("DSMR", "4.2.2");
 
     assertNotNull(cosemObjects);
-    AssertionsForInterfaceTypes.assertThat(cosemObjects)
-        .hasSize(Protocol.DSMR_4_2_2.getNrOfCosemObjects());
+    Assertions.assertThat(cosemObjects).hasSize(Protocol.DSMR_4_2_2.getNrOfCosemObjects());
     assertNotNull(cosemObjects.get(DlmsObjectType.ALARM_REGISTER_1));
     assertNotNull(cosemObjects.get(DlmsObjectType.NUMBER_OF_VOLTAGE_SWELLS_FOR_L1));
     assertNull(cosemObjects.get(DlmsObjectType.CDMA_DIAGNOSTIC));
@@ -171,23 +168,22 @@ class ObjectConfigServiceTest {
         this.objectConfigService.getCosemObjects(protocolName, protocolVersion43);
 
     assertNotNull(cosemObjects);
-    AssertionsForInterfaceTypes.assertThat(cosemObjects)
+    org.assertj.core.api.Assertions.assertThat(cosemObjects)
         .hasSize(Protocol.SMR_4_3.getNrOfCosemObjects());
     assertNotNull(cosemObjects.get(DlmsObjectType.ALARM_REGISTER_1));
-    assertNull(cosemObjects.get(DlmsObjectType.MBUS_DIAGNOSTIC));
   }
 
   @Test
-  void testGetCosemObjectsSmr43() throws ObjectConfigException {
+  void testGetCosemObjectsSmr43_shouldComplyWithAssertionChecks() throws ObjectConfigException {
     final Map<DlmsObjectType, CosemObject> cosemObjects =
         this.objectConfigService.getCosemObjects("SMR", "4.3");
 
     assertNotNull(cosemObjects);
-    AssertionsForInterfaceTypes.assertThat(cosemObjects)
-        .hasSize(Protocol.SMR_4_3.getNrOfCosemObjects());
+    Assertions.assertThat(cosemObjects).hasSize(Protocol.SMR_4_3.getNrOfCosemObjects());
     assertNotNull(cosemObjects.get(DlmsObjectType.ALARM_REGISTER_1));
     assertNotNull(cosemObjects.get(DlmsObjectType.NUMBER_OF_VOLTAGE_SWELLS_FOR_L1));
     assertNotNull(cosemObjects.get(DlmsObjectType.CDMA_DIAGNOSTIC));
+    assertNull(cosemObjects.get(DlmsObjectType.MBUS_DIAGNOSTIC));
   }
 
   @Test
@@ -196,8 +192,7 @@ class ObjectConfigServiceTest {
         this.objectConfigService.getCosemObjects("SMR", "5.0.0");
 
     assertNotNull(cosemObjects);
-    AssertionsForInterfaceTypes.assertThat(cosemObjects)
-        .hasSize(Protocol.SMR_5_0_0.getNrOfCosemObjects());
+    Assertions.assertThat(cosemObjects).hasSize(Protocol.SMR_5_0_0.getNrOfCosemObjects());
     assertNotNull(cosemObjects.get(DlmsObjectType.ALARM_REGISTER_1));
     assertNotNull(cosemObjects.get(DlmsObjectType.NUMBER_OF_POWER_FAILURES));
     assertNull(cosemObjects.get(DlmsObjectType.LTE_DIAGNOSTIC));
@@ -210,8 +205,7 @@ class ObjectConfigServiceTest {
         this.objectConfigService.getCosemObjects("SMR", "5.1");
 
     assertNotNull(cosemObjects);
-    AssertionsForInterfaceTypes.assertThat(cosemObjects)
-        .hasSize(Protocol.SMR_5_1.getNrOfCosemObjects());
+    Assertions.assertThat(cosemObjects).hasSize(Protocol.SMR_5_1.getNrOfCosemObjects());
     assertNotNull(cosemObjects.get(DlmsObjectType.ALARM_REGISTER_1));
     assertNotNull(cosemObjects.get(DlmsObjectType.NUMBER_OF_POWER_FAILURES));
     assertNull(cosemObjects.get(DlmsObjectType.LTE_DIAGNOSTIC));
@@ -224,8 +218,7 @@ class ObjectConfigServiceTest {
         this.objectConfigService.getCosemObjects("SMR", "5.2");
 
     assertNotNull(cosemObjects);
-    AssertionsForInterfaceTypes.assertThat(cosemObjects)
-        .hasSize(Protocol.SMR_5_2.getNrOfCosemObjects());
+    Assertions.assertThat(cosemObjects).hasSize(Protocol.SMR_5_2.getNrOfCosemObjects());
     assertNotNull(cosemObjects.get(DlmsObjectType.ALARM_REGISTER_1));
     assertNotNull(cosemObjects.get(DlmsObjectType.ALARM_REGISTER_2));
     assertNotNull(cosemObjects.get(DlmsObjectType.NUMBER_OF_POWER_FAILURES));
@@ -239,8 +232,7 @@ class ObjectConfigServiceTest {
         this.objectConfigService.getCosemObjects("SMR", "5.5");
 
     assertNotNull(cosemObjects);
-    AssertionsForInterfaceTypes.assertThat(cosemObjects)
-        .hasSize(Protocol.SMR_5_5.getNrOfCosemObjects());
+    Assertions.assertThat(cosemObjects).hasSize(Protocol.SMR_5_5.getNrOfCosemObjects());
     assertNotNull(cosemObjects.get(DlmsObjectType.ALARM_REGISTER_1));
     assertNotNull(cosemObjects.get(DlmsObjectType.ALARM_REGISTER_2));
     assertNotNull(cosemObjects.get(DlmsObjectType.ALARM_REGISTER_3));
@@ -277,18 +269,18 @@ class ObjectConfigServiceTest {
             protocolName, protocolVersion43, DlmsObjectType.AVERAGE_VOLTAGE_L1);
 
     assertNotNull(cosemObject);
-    AssertionsForClassTypes.assertThat(cosemObject.getTag())
+    Assertions.assertThat(cosemObject.getTag())
         .isEqualTo(DlmsObjectType.AVERAGE_VOLTAGE_L1.value());
   }
 
   @Test
   void getOptionalCosemObject() throws ObjectConfigException {
-    AssertionsForClassTypes.assertThat(
+    Assertions.assertThat(
             this.objectConfigService.getOptionalCosemObject(
                 "DSMR", "4.2.2", DlmsObjectType.POWER_QUALITY_PROFILE_1))
         .isEmpty();
 
-    AssertionsForClassTypes.assertThat(
+    Assertions.assertThat(
             this.objectConfigService.getOptionalCosemObject(
                 "SMR", "5.0.0", DlmsObjectType.POWER_QUALITY_PROFILE_1))
         .isPresent();
@@ -309,7 +301,7 @@ class ObjectConfigServiceTest {
             protocolName, protocolVersion50, requestMap);
 
     assertNotNull(cosemObjectsWithSelectableObjects);
-    AssertionsForInterfaceTypes.assertThat(cosemObjectsWithSelectableObjects).hasSize(45);
+    Assertions.assertThat(cosemObjectsWithSelectableObjects).hasSize(45);
   }
 
   @Test
@@ -329,7 +321,7 @@ class ObjectConfigServiceTest {
             protocolName, protocolVersion50, requestMap);
 
     assertNotNull(cosemObjectsWithSelectableObjects);
-    AssertionsForInterfaceTypes.assertThat(cosemObjectsWithSelectableObjects).hasSize(9);
+    Assertions.assertThat(cosemObjectsWithSelectableObjects).hasSize(9);
   }
 
   @Test
@@ -348,9 +340,9 @@ class ObjectConfigServiceTest {
         this.objectConfigService.getOptionalCosemObject(
             protocol.getName(), protocol.getVersion(), dlmsObjectType);
     if (!shouldHaveObjectType) {
-      AssertionsForClassTypes.assertThat(optionalProfile).isEmpty();
+      Assertions.assertThat(optionalProfile).isEmpty();
     } else {
-      AssertionsForClassTypes.assertThat(optionalProfile).isPresent();
+      Assertions.assertThat(optionalProfile).isPresent();
 
       final List<String> selectableObjects =
           optionalProfile.orElseThrow().getListProperty(ObjectProperty.SELECTABLE_OBJECTS);
@@ -361,8 +353,7 @@ class ObjectConfigServiceTest {
       // All selectable objects must be in config
       selectableObjects.forEach(
           selectableObject ->
-              AssertionsForClassTypes.assertThat(
-                      cosemObjects.get(DlmsObjectType.valueOf(selectableObject)))
+              Assertions.assertThat(cosemObjects.get(DlmsObjectType.valueOf(selectableObject)))
                   .isNotNull());
     }
   }
@@ -383,8 +374,7 @@ class ObjectConfigServiceTest {
     pqObjects.forEach(
         (dlmsObjectType, pqObject) -> {
           if (isPeriodicRequest(pqObject)) {
-            AssertionsForInterfaceTypes.assertThat(allSelectableObjects)
-                .contains(pqObject.getTag());
+            Assertions.assertThat(allSelectableObjects).contains(pqObject.getTag());
           }
         });
   }

--- a/osgp/protocol-adapter-dlms/osgp-dlms/src/test/java/org/opensmartgridplatform/dlms/services/ObjectConfigServiceTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-dlms/src/test/java/org/opensmartgridplatform/dlms/services/ObjectConfigServiceTest.java
@@ -4,7 +4,6 @@
 
 package org.opensmartgridplatform.dlms.services;
 
-import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -18,6 +17,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.api.AssertionsForClassTypes;
+import org.assertj.core.api.AssertionsForInterfaceTypes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -44,41 +45,41 @@ class ObjectConfigServiceTest {
 
     final Map<DlmsObjectType, CosemObject> cosemObjects =
         this.objectConfigService.getCosemObjects(protocol.getName(), protocol.getVersion());
-    assertThat(cosemObjects).hasSize(protocol.getNrOfCosemObjectsPq());
+    AssertionsForInterfaceTypes.assertThat(cosemObjects).hasSize(protocol.getNrOfCosemObjects());
 
     final List<CosemObject> cosemObjectsOnDemandPrivate =
         this.getCosemObjectsWithProperties(
             protocol, PowerQualityRequest.ACTUAL_SP, Profile.PRIVATE);
-    assertThat(cosemObjectsOnDemandPrivate)
+    AssertionsForInterfaceTypes.assertThat(cosemObjectsOnDemandPrivate)
         .hasSize(protocol.getNrOfCosemObjects(PowerQualityRequest.ACTUAL_SP, Profile.PRIVATE));
 
     final List<CosemObject> cosemObjectsOnDemandPublic =
         this.getCosemObjectsWithProperties(protocol, PowerQualityRequest.ACTUAL_SP, Profile.PUBLIC);
-    assertThat(cosemObjectsOnDemandPublic)
+    AssertionsForInterfaceTypes.assertThat(cosemObjectsOnDemandPublic)
         .hasSize(protocol.getNrOfCosemObjects(PowerQualityRequest.ACTUAL_SP, Profile.PUBLIC));
 
     final List<CosemObject> cosemObjectsOnPeriodicSpPrivate =
         this.getCosemObjectsWithProperties(
             protocol, PowerQualityRequest.PERIODIC_SP, Profile.PRIVATE);
-    assertThat(cosemObjectsOnPeriodicSpPrivate)
+    AssertionsForInterfaceTypes.assertThat(cosemObjectsOnPeriodicSpPrivate)
         .hasSize(protocol.getNrOfCosemObjects(PowerQualityRequest.PERIODIC_SP, Profile.PRIVATE));
 
     final List<CosemObject> cosemObjectsOnPeriodicPpPrivate =
         this.getCosemObjectsWithProperties(
             protocol, PowerQualityRequest.PERIODIC_PP, Profile.PRIVATE);
-    assertThat(cosemObjectsOnPeriodicPpPrivate)
+    AssertionsForInterfaceTypes.assertThat(cosemObjectsOnPeriodicPpPrivate)
         .hasSize(protocol.getNrOfCosemObjects(PowerQualityRequest.PERIODIC_PP, Profile.PRIVATE));
 
     final List<CosemObject> cosemObjectsPeriodicSpPublic =
         this.getCosemObjectsWithProperties(
             protocol, PowerQualityRequest.PERIODIC_SP, Profile.PUBLIC);
-    assertThat(cosemObjectsPeriodicSpPublic)
+    AssertionsForInterfaceTypes.assertThat(cosemObjectsPeriodicSpPublic)
         .hasSize(protocol.getNrOfCosemObjects(PowerQualityRequest.PERIODIC_SP, Profile.PUBLIC));
 
     final List<CosemObject> cosemObjectsPeriodicPpPublic =
         this.getCosemObjectsWithProperties(
             protocol, PowerQualityRequest.PERIODIC_PP, Profile.PUBLIC);
-    assertThat(cosemObjectsPeriodicPpPublic)
+    AssertionsForInterfaceTypes.assertThat(cosemObjectsPeriodicPpPublic)
         .hasSize(protocol.getNrOfCosemObjects(PowerQualityRequest.PERIODIC_PP, Profile.PUBLIC));
   }
 
@@ -98,20 +99,20 @@ class ObjectConfigServiceTest {
   void testAllPqObjectMapToProfile(final Protocol protocol) throws ObjectConfigException {
     final List<DlmsObjectType> dlmsProfiles = new ArrayList<>();
     if (protocol.hasDefinableLoadProfile()) {
-      assertThat(
+      AssertionsForClassTypes.assertThat(
               this.objectConfigService.getCosemObject(
                   protocol.getName(), protocol.getVersion(), DlmsObjectType.DEFINABLE_LOAD_PROFILE))
           .isNotNull();
       dlmsProfiles.add(DlmsObjectType.DEFINABLE_LOAD_PROFILE);
     }
     if (protocol.hasPqProfiles()) {
-      assertThat(
+      AssertionsForClassTypes.assertThat(
               this.objectConfigService.getCosemObject(
                   protocol.getName(),
                   protocol.getVersion(),
                   DlmsObjectType.POWER_QUALITY_PROFILE_1))
           .isNotNull();
-      assertThat(
+      AssertionsForClassTypes.assertThat(
               this.objectConfigService.getCosemObject(
                   protocol.getName(),
                   protocol.getVersion(),
@@ -137,25 +138,14 @@ class ObjectConfigServiceTest {
   }
 
   @Test
-  void getCosemObjectIsNull() throws ObjectConfigException {
-    final String protocolName = "SMR";
-    final String protocolVersion43 = "4.3";
-
-    final Map<DlmsObjectType, CosemObject> cosemObjects =
-        this.objectConfigService.getCosemObjects(protocolName, protocolVersion43);
-
-    assertNotNull(cosemObjects);
-    assertThat(cosemObjects).hasSize(44);
-    assertNull(cosemObjects.get(DlmsObjectType.MBUS_DIAGNOSTIC));
-  }
-
-  @Test
   void testGetCosemObjectsDsmr22() throws ObjectConfigException {
     final Map<DlmsObjectType, CosemObject> cosemObjects =
         this.objectConfigService.getCosemObjects("DSMR", "2.2");
 
     assertNotNull(cosemObjects);
-    assertThat(cosemObjects).hasSize(19);
+    AssertionsForInterfaceTypes.assertThat(cosemObjects)
+        .hasSize(Protocol.DSMR_2_2.getNrOfCosemObjects());
+    assertNotNull(cosemObjects.get(DlmsObjectType.ALARM_REGISTER_1));
     assertNotNull(cosemObjects.get(DlmsObjectType.NUMBER_OF_VOLTAGE_SWELLS_FOR_L1));
   }
 
@@ -165,9 +155,26 @@ class ObjectConfigServiceTest {
         this.objectConfigService.getCosemObjects("DSMR", "4.2.2");
 
     assertNotNull(cosemObjects);
-    assertThat(cosemObjects).hasSize(43);
+    AssertionsForInterfaceTypes.assertThat(cosemObjects)
+        .hasSize(Protocol.DSMR_4_2_2.getNrOfCosemObjects());
+    assertNotNull(cosemObjects.get(DlmsObjectType.ALARM_REGISTER_1));
     assertNotNull(cosemObjects.get(DlmsObjectType.NUMBER_OF_VOLTAGE_SWELLS_FOR_L1));
     assertNull(cosemObjects.get(DlmsObjectType.CDMA_DIAGNOSTIC));
+  }
+
+  @Test
+  void getCosemObjectIsNull() throws ObjectConfigException {
+    final String protocolName = "SMR";
+    final String protocolVersion43 = "4.3";
+
+    final Map<DlmsObjectType, CosemObject> cosemObjects =
+        this.objectConfigService.getCosemObjects(protocolName, protocolVersion43);
+
+    assertNotNull(cosemObjects);
+    AssertionsForInterfaceTypes.assertThat(cosemObjects)
+        .hasSize(Protocol.SMR_4_3.getNrOfCosemObjects());
+    assertNotNull(cosemObjects.get(DlmsObjectType.ALARM_REGISTER_1));
+    assertNull(cosemObjects.get(DlmsObjectType.MBUS_DIAGNOSTIC));
   }
 
   @Test
@@ -176,7 +183,9 @@ class ObjectConfigServiceTest {
         this.objectConfigService.getCosemObjects("SMR", "4.3");
 
     assertNotNull(cosemObjects);
-    assertThat(cosemObjects).hasSize(44);
+    AssertionsForInterfaceTypes.assertThat(cosemObjects)
+        .hasSize(Protocol.SMR_4_3.getNrOfCosemObjects());
+    assertNotNull(cosemObjects.get(DlmsObjectType.ALARM_REGISTER_1));
     assertNotNull(cosemObjects.get(DlmsObjectType.NUMBER_OF_VOLTAGE_SWELLS_FOR_L1));
     assertNotNull(cosemObjects.get(DlmsObjectType.CDMA_DIAGNOSTIC));
   }
@@ -187,7 +196,9 @@ class ObjectConfigServiceTest {
         this.objectConfigService.getCosemObjects("SMR", "5.0.0");
 
     assertNotNull(cosemObjects);
-    assertThat(cosemObjects).hasSize(49);
+    AssertionsForInterfaceTypes.assertThat(cosemObjects)
+        .hasSize(Protocol.SMR_5_0_0.getNrOfCosemObjects());
+    assertNotNull(cosemObjects.get(DlmsObjectType.ALARM_REGISTER_1));
     assertNotNull(cosemObjects.get(DlmsObjectType.NUMBER_OF_POWER_FAILURES));
     assertNull(cosemObjects.get(DlmsObjectType.LTE_DIAGNOSTIC));
     assertNull(cosemObjects.get(DlmsObjectType.PUSH_SETUP_UDP));
@@ -199,7 +210,9 @@ class ObjectConfigServiceTest {
         this.objectConfigService.getCosemObjects("SMR", "5.1");
 
     assertNotNull(cosemObjects);
-    assertThat(cosemObjects).hasSize(49);
+    AssertionsForInterfaceTypes.assertThat(cosemObjects)
+        .hasSize(Protocol.SMR_5_1.getNrOfCosemObjects());
+    assertNotNull(cosemObjects.get(DlmsObjectType.ALARM_REGISTER_1));
     assertNotNull(cosemObjects.get(DlmsObjectType.NUMBER_OF_POWER_FAILURES));
     assertNull(cosemObjects.get(DlmsObjectType.LTE_DIAGNOSTIC));
     assertNull(cosemObjects.get(DlmsObjectType.PUSH_SETUP_UDP));
@@ -211,7 +224,10 @@ class ObjectConfigServiceTest {
         this.objectConfigService.getCosemObjects("SMR", "5.2");
 
     assertNotNull(cosemObjects);
-    assertThat(cosemObjects).hasSize(50);
+    AssertionsForInterfaceTypes.assertThat(cosemObjects)
+        .hasSize(Protocol.SMR_5_2.getNrOfCosemObjects());
+    assertNotNull(cosemObjects.get(DlmsObjectType.ALARM_REGISTER_1));
+    assertNotNull(cosemObjects.get(DlmsObjectType.ALARM_REGISTER_2));
     assertNotNull(cosemObjects.get(DlmsObjectType.NUMBER_OF_POWER_FAILURES));
     assertNotNull(cosemObjects.get(DlmsObjectType.LTE_DIAGNOSTIC));
     assertNull(cosemObjects.get(DlmsObjectType.PUSH_SETUP_UDP));
@@ -223,7 +239,11 @@ class ObjectConfigServiceTest {
         this.objectConfigService.getCosemObjects("SMR", "5.5");
 
     assertNotNull(cosemObjects);
-    assertThat(cosemObjects).hasSize(51);
+    AssertionsForInterfaceTypes.assertThat(cosemObjects)
+        .hasSize(Protocol.SMR_5_5.getNrOfCosemObjects());
+    assertNotNull(cosemObjects.get(DlmsObjectType.ALARM_REGISTER_1));
+    assertNotNull(cosemObjects.get(DlmsObjectType.ALARM_REGISTER_2));
+    assertNotNull(cosemObjects.get(DlmsObjectType.ALARM_REGISTER_3));
     assertNotNull(cosemObjects.get(DlmsObjectType.NUMBER_OF_POWER_FAILURES));
     assertNotNull(cosemObjects.get(DlmsObjectType.LTE_DIAGNOSTIC));
     assertNotNull(cosemObjects.get(DlmsObjectType.PUSH_SETUP_UDP));
@@ -257,17 +277,18 @@ class ObjectConfigServiceTest {
             protocolName, protocolVersion43, DlmsObjectType.AVERAGE_VOLTAGE_L1);
 
     assertNotNull(cosemObject);
-    assertThat(cosemObject.getTag()).isEqualTo(DlmsObjectType.AVERAGE_VOLTAGE_L1.value());
+    AssertionsForClassTypes.assertThat(cosemObject.getTag())
+        .isEqualTo(DlmsObjectType.AVERAGE_VOLTAGE_L1.value());
   }
 
   @Test
   void getOptionalCosemObject() throws ObjectConfigException {
-    assertThat(
+    AssertionsForClassTypes.assertThat(
             this.objectConfigService.getOptionalCosemObject(
                 "DSMR", "4.2.2", DlmsObjectType.POWER_QUALITY_PROFILE_1))
         .isEmpty();
 
-    assertThat(
+    AssertionsForClassTypes.assertThat(
             this.objectConfigService.getOptionalCosemObject(
                 "SMR", "5.0.0", DlmsObjectType.POWER_QUALITY_PROFILE_1))
         .isPresent();
@@ -288,7 +309,7 @@ class ObjectConfigServiceTest {
             protocolName, protocolVersion50, requestMap);
 
     assertNotNull(cosemObjectsWithSelectableObjects);
-    assertThat(cosemObjectsWithSelectableObjects).hasSize(45);
+    AssertionsForInterfaceTypes.assertThat(cosemObjectsWithSelectableObjects).hasSize(45);
   }
 
   @Test
@@ -308,7 +329,7 @@ class ObjectConfigServiceTest {
             protocolName, protocolVersion50, requestMap);
 
     assertNotNull(cosemObjectsWithSelectableObjects);
-    assertThat(cosemObjectsWithSelectableObjects).hasSize(9);
+    AssertionsForInterfaceTypes.assertThat(cosemObjectsWithSelectableObjects).hasSize(9);
   }
 
   @Test
@@ -327,21 +348,22 @@ class ObjectConfigServiceTest {
         this.objectConfigService.getOptionalCosemObject(
             protocol.getName(), protocol.getVersion(), dlmsObjectType);
     if (!shouldHaveObjectType) {
-      assertThat(optionalProfile).isEmpty();
+      AssertionsForClassTypes.assertThat(optionalProfile).isEmpty();
     } else {
-      assertThat(optionalProfile).isPresent();
+      AssertionsForClassTypes.assertThat(optionalProfile).isPresent();
 
       final List<String> selectableObjects =
-          optionalProfile.get().getListProperty(ObjectProperty.SELECTABLE_OBJECTS);
+          optionalProfile.orElseThrow().getListProperty(ObjectProperty.SELECTABLE_OBJECTS);
 
       final Map<DlmsObjectType, CosemObject> cosemObjects =
           this.objectConfigService.getCosemObjects(protocol.getName(), protocol.getVersion());
 
       // All selectable objects must be in config
       selectableObjects.forEach(
-          selectableObject -> {
-            assertThat(cosemObjects.get(DlmsObjectType.valueOf(selectableObject))).isNotNull();
-          });
+          selectableObject ->
+              AssertionsForClassTypes.assertThat(
+                      cosemObjects.get(DlmsObjectType.valueOf(selectableObject)))
+                  .isNotNull());
     }
   }
 
@@ -361,7 +383,8 @@ class ObjectConfigServiceTest {
     pqObjects.forEach(
         (dlmsObjectType, pqObject) -> {
           if (isPeriodicRequest(pqObject)) {
-            assertThat(allSelectableObjects).contains(pqObject.getTag());
+            AssertionsForInterfaceTypes.assertThat(allSelectableObjects)
+                .contains(pqObject.getTag());
           }
         });
   }

--- a/osgp/protocol-adapter-dlms/osgp-dlms/src/test/java/org/opensmartgridplatform/dlms/services/Protocol.java
+++ b/osgp/protocol-adapter-dlms/osgp-dlms/src/test/java/org/opensmartgridplatform/dlms/services/Protocol.java
@@ -11,18 +11,18 @@ import org.opensmartgridplatform.dlms.objectconfig.PowerQualityRequest;
 
 @Getter
 public enum Protocol {
-  DSMR_2_2("DSMR", "2.2", 19, 2, 4, 6, 14, 0, 0, 0, 0, false, false),
-  DSMR_4_2_2("DSMR", "4.2.2", 43, 11, 27, 6, 14, 6, 13, 5, 6, true, false),
-  SMR_4_3("SMR", "4.3", 44, 11, 27, 6, 14, 6, 13, 6, 7, true, false),
-  SMR_5_0_0("SMR", "5.0.0", 49, 11, 27, 6, 14, 6, 15, 9, 14, true, true),
+  DSMR_2_2("DSMR", "2.2", 20, 2, 4, 6, 14, 0, 0, 0, 0, false, false),
+  DSMR_4_2_2("DSMR", "4.2.2", 44, 11, 27, 6, 14, 6, 13, 5, 6, true, false),
+  SMR_4_3("SMR", "4.3", 45, 11, 27, 6, 14, 6, 13, 6, 7, true, false),
+  SMR_5_0_0("SMR", "5.0.0", 50, 11, 27, 6, 14, 6, 15, 9, 14, true, true),
 
-  SMR_5_1("SMR", "5.1", 49, 11, 27, 6, 14, 6, 15, 9, 14, true, true),
-  SMR_5_2("SMR", "5.2", 50, 11, 27, 6, 14, 6, 15, 10, 15, true, true),
-  SMR_5_5("SMR", "5.5", 51, 11, 27, 6, 14, 6, 15, 10, 15, true, true);
+  SMR_5_1("SMR", "5.1", 50, 11, 27, 6, 14, 6, 15, 9, 14, true, true),
+  SMR_5_2("SMR", "5.2", 52, 11, 27, 6, 14, 6, 15, 10, 15, true, true),
+  SMR_5_5("SMR", "5.5", 54, 11, 27, 6, 14, 6, 15, 10, 15, true, true);
 
   private final String name;
   private final String version;
-  private final int nrOfCosemObjectsPq;
+  private final int nrOfCosemObjects;
   private final int nrOfCosemObjectsPqOnActualSpPrivate;
   private final int nrOfCosemObjectsPqOnActualPpPrivate;
   private final int nrOfCosemObjectsPqOnActualSpPublic;
@@ -37,7 +37,7 @@ public enum Protocol {
   Protocol(
       final String name,
       final String version,
-      final int nrOfCosemObjectsPq,
+      final int nrOfCosemObjects,
       final int nrOfCosemObjectsPqOnActualSpPrivate,
       final int nrOfCosemObjectsPqOnActualPpPrivate,
       final int nrOfCosemObjectsPqOnActualSpPublic,
@@ -50,7 +50,7 @@ public enum Protocol {
       final boolean hasPqProfiles) {
     this.name = name;
     this.version = version;
-    this.nrOfCosemObjectsPq = nrOfCosemObjectsPq;
+    this.nrOfCosemObjects = nrOfCosemObjects;
     this.nrOfCosemObjectsPqOnActualSpPublic = nrOfCosemObjectsPqOnActualSpPublic;
     this.nrOfCosemObjectsPqOnActualPpPublic = nrOfCosemObjectsPqOnActualPpPublic;
     this.nrOfCosemObjectsPqOnActualSpPrivate = nrOfCosemObjectsPqOnActualSpPrivate;

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/alarm/ClearAlarmRegisterCommandExecutor.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/alarm/ClearAlarmRegisterCommandExecutor.java
@@ -100,8 +100,11 @@ public class ClearAlarmRegisterCommandExecutor
       throws ProtocolAdapterException {
     log.debug("clearAlarmRegister {}", objectType);
     final Optional<AttributeAddress> optAlarmRegisterAttributeAddress =
-        this.objectConfigServiceHelper.findAttributeAddress(
-            device, objectType, ALARM_REGISTER_ATTRIBUTE_ID);
+        this.objectConfigServiceHelper.findOptionalAttributeAddress(
+            device.getProtocolName(),
+            device.getProtocolVersion(),
+            objectType,
+            ALARM_REGISTER_ATTRIBUTE_ID);
 
     if (optAlarmRegisterAttributeAddress.isEmpty()) {
       return Optional.empty();

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/utils/ObjectConfigServiceHelper.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/utils/ObjectConfigServiceHelper.java
@@ -16,7 +16,7 @@ import org.opensmartgridplatform.dlms.services.ObjectConfigService;
 import org.springframework.stereotype.Component;
 
 @Component
-/**
+/*
  * Is an intermediate class to get acces from the dlms-protocol-adapter to the ObjectConfigService.
  * It contains helper functions to lookup CosemObjects and Attributes.
  */
@@ -24,11 +24,13 @@ public class ObjectConfigServiceHelper {
 
   private final ObjectConfigService objectConfigService;
 
+  @SuppressWarnings("java:S1144")
+  /* Suppress warning java:S1144 because it's injected with spring autowired. */
   private ObjectConfigServiceHelper(final ObjectConfigService objectConfigService) {
     this.objectConfigService = objectConfigService;
   }
 
-  /**
+  /*
    * Find an Attribute from the ObjectConfigService based on the protocol and protocolVersion and a
    * DlmsObjectType name. When not found the Optional.empty is returned.
    *

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/utils/ObjectConfigServiceHelper.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/utils/ObjectConfigServiceHelper.java
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: Copyright Contributors to the GXF project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.utils;
+
+import java.util.Optional;
+import org.openmuc.jdlms.AttributeAddress;
+import org.openmuc.jdlms.ObisCode;
+import org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.dlmsobjectconfig.DlmsObjectType;
+import org.opensmartgridplatform.adapter.protocol.dlms.domain.entities.DlmsDevice;
+import org.opensmartgridplatform.adapter.protocol.dlms.exceptions.ProtocolAdapterException;
+import org.opensmartgridplatform.dlms.exceptions.ObjectConfigException;
+import org.opensmartgridplatform.dlms.objectconfig.Attribute;
+import org.opensmartgridplatform.dlms.objectconfig.CosemObject;
+import org.opensmartgridplatform.dlms.services.ObjectConfigService;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ObjectConfigServiceHelper {
+
+  private final ObjectConfigService objectConfigService;
+
+  private ObjectConfigServiceHelper(final ObjectConfigService objectConfigService) {
+    this.objectConfigService = objectConfigService;
+  }
+
+  public Optional<AttributeAddress> findAttributeAddress(
+      final DlmsDevice device, final DlmsObjectType type, final int attributeId)
+      throws ProtocolAdapterException {
+
+    final Optional<CosemObject> optObject = this.getObject(device, type);
+    if (optObject.isEmpty()) {
+      return Optional.empty();
+    }
+
+    final CosemObject cosemObject = optObject.get();
+    final int classId = cosemObject.getClassId();
+    final ObisCode obisCode = new ObisCode(cosemObject.getObis());
+
+    final Optional<Attribute> attributeOpt =
+        Optional.ofNullable(cosemObject.getAttribute(attributeId));
+
+    return attributeOpt.map(value -> new AttributeAddress(classId, obisCode, value.getId()));
+  }
+
+  private Optional<CosemObject> getObject(final DlmsDevice device, final DlmsObjectType objectType)
+      throws ProtocolAdapterException {
+    try {
+      return Optional.ofNullable(
+          this.objectConfigService.getCosemObject(
+              device.getProtocolName(),
+              device.getProtocolVersion(),
+              org.opensmartgridplatform.dlms.objectconfig.DlmsObjectType.valueOf(
+                  objectType.name())));
+    } catch (final ObjectConfigException e) {
+      final String message =
+          String.format(
+              "Cannot read CosemObject for protocol %s, version %s and DlsmObjectType %s",
+              device.getProtocolName(), device.getProtocolVersion(), objectType.name());
+      throw new ProtocolAdapterException(message, e);
+    }
+  }
+}

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/utils/ObjectConfigServiceHelper.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/utils/ObjectConfigServiceHelper.java
@@ -16,7 +16,7 @@ import org.opensmartgridplatform.dlms.services.ObjectConfigService;
 import org.springframework.stereotype.Component;
 
 @Component
-/*
+/**
  * Is an intermediate class to get acces from the dlms-protocol-adapter to the ObjectConfigService.
  * It contains helper functions to lookup CosemObjects and Attributes.
  */
@@ -30,7 +30,7 @@ public class ObjectConfigServiceHelper {
     this.objectConfigService = objectConfigService;
   }
 
-  /*
+  /**
    * Find an Attribute from the ObjectConfigService based on the protocol and protocolVersion and a
    * DlmsObjectType name. When not found the Optional.empty is returned.
    *

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/alarm/ClearAlarmRegisterCommandExecutorTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/alarm/ClearAlarmRegisterCommandExecutorTest.java
@@ -179,8 +179,7 @@ class ClearAlarmRegisterCommandExecutorTest {
   }
 
   @Test
-  void failureRegister1AndResultAlarmRegister2()
-      throws ProtocolAdapterException, IOException, ObjectConfigException {
+  void failureRegister1AndResultAlarmRegister2() throws ProtocolAdapterException, IOException {
     when(this.dlmsConnection.set(this.setParameterArgumentCaptor.capture()))
         .thenReturn(AccessResultCode.OTHER_REASON)
         .thenReturn(AccessResultCode.SUCCESS);
@@ -269,8 +268,7 @@ class ClearAlarmRegisterCommandExecutorTest {
   }
 
   @Test
-  void successRegister1AndResultAlarmRegister3()
-      throws ProtocolAdapterException, IOException, ObjectConfigException {
+  void successRegister1AndResultAlarmRegister3() throws ProtocolAdapterException, IOException {
     when(this.dlmsConnection.set(this.setParameterArgumentCaptor.capture()))
         .thenReturn(AccessResultCode.SUCCESS)
         .thenReturn(AccessResultCode.SUCCESS)
@@ -306,8 +304,7 @@ class ClearAlarmRegisterCommandExecutorTest {
     when(this.connectionManager.getConnection()).thenReturn(this.dlmsConnection);
   }
 
-  void setupAlarmRegister2(final DlmsDevice dlmsDevice)
-      throws ObjectConfigException, ProtocolAdapterException {
+  void setupAlarmRegister2(final DlmsDevice dlmsDevice) throws ProtocolAdapterException {
 
     this.mockAlarmCosemObject(
         dlmsDevice, OBIS_CODE_ALARM_REGISTER_1, DlmsObjectType.ALARM_REGISTER_1.name());
@@ -330,8 +327,9 @@ class ClearAlarmRegisterCommandExecutorTest {
         .thenReturn(ClearAlarmRegisterCommandExecutor.ALARM_REGISTER_ATTRIBUTE_ID);
     when(attributeAddress.getInstanceId()).thenReturn(newObisCode);
 
-    when(this.objectConfigServiceHelper.findAttributeAddress(
-            dlmsDevice,
+    when(this.objectConfigServiceHelper.findOptionalAttributeAddress(
+            dlmsDevice.getProtocolName(),
+            dlmsDevice.getProtocolVersion(),
             DlmsObjectType.valueOf(dlmsObjectTypeName),
             ClearAlarmRegisterCommandExecutor.ALARM_REGISTER_ATTRIBUTE_ID))
         .thenReturn(Optional.of(attributeAddress));
@@ -358,7 +356,7 @@ class ClearAlarmRegisterCommandExecutorTest {
   }
 
   void assertForOneRegister(final String protocol, final String protocolVersion)
-      throws ProtocolAdapterException, IOException, ObjectConfigException {
+      throws ProtocolAdapterException, IOException {
     final DlmsDevice dlmsDevice = new DlmsDevice(protocol + " " + protocolVersion + " device");
     dlmsDevice.setProtocol(protocol, protocolVersion);
 

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/alarm/ClearAlarmRegisterCommandExecutorTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/alarm/ClearAlarmRegisterCommandExecutorTest.java
@@ -5,36 +5,34 @@
 package org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.alarm;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.ThrowableAssert.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
-import java.util.Optional;
+import org.assertj.core.api.ThrowableAssert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.openmuc.jdlms.AccessResultCode;
 import org.openmuc.jdlms.AttributeAddress;
 import org.openmuc.jdlms.DlmsConnection;
 import org.openmuc.jdlms.SetParameter;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.dlmsobjectconfig.DlmsObjectConfigService;
-import org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.dlmsobjectconfig.DlmsObjectType;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.entities.DlmsDevice;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.factories.DlmsConnectionManager;
 import org.opensmartgridplatform.adapter.protocol.dlms.exceptions.ConnectionException;
 import org.opensmartgridplatform.adapter.protocol.dlms.exceptions.ProtocolAdapterException;
 import org.opensmartgridplatform.adapter.protocol.dlms.infra.messaging.DlmsMessageListener;
 import org.opensmartgridplatform.adapter.protocol.dlms.infra.messaging.LoggingDlmsMessageListener;
-import org.opensmartgridplatform.dlms.interfaceclass.InterfaceClass;
-import org.opensmartgridplatform.dlms.interfaceclass.attribute.DataAttribute;
+import org.opensmartgridplatform.dlms.exceptions.ObjectConfigException;
+import org.opensmartgridplatform.dlms.objectconfig.Attribute;
+import org.opensmartgridplatform.dlms.objectconfig.CosemObject;
+import org.opensmartgridplatform.dlms.services.ObjectConfigService;
 import org.opensmartgridplatform.dto.valueobjects.smartmetering.ActionResponseDto;
 import org.opensmartgridplatform.dto.valueobjects.smartmetering.ClearAlarmRegisterRequestDto;
 import org.opensmartgridplatform.dto.valueobjects.smartmetering.OsgpResultTypeDto;
@@ -52,6 +50,7 @@ class ClearAlarmRegisterCommandExecutorTest {
   private static final Long ALARM_CODE = 0L;
 
   @Mock private DlmsObjectConfigService dlmsObjectConfigService;
+  @Mock private ObjectConfigService objectConfigService;
 
   @Mock private DlmsConnectionManager connectionManager;
 
@@ -69,7 +68,9 @@ class ClearAlarmRegisterCommandExecutorTest {
 
   @BeforeEach
   void setup() {
-    this.executor = new ClearAlarmRegisterCommandExecutor(this.dlmsObjectConfigService);
+    this.executor =
+        new ClearAlarmRegisterCommandExecutor(
+            this.dlmsObjectConfigService, this.objectConfigService);
     this.dlmsMessageListener = new LoggingDlmsMessageListener(null, null);
   }
 
@@ -82,44 +83,50 @@ class ClearAlarmRegisterCommandExecutorTest {
   @Test
   void testAsBundleResponseOtherReason() {
     final Throwable actual =
-        catchThrowable(() -> this.executor.asBundleResponse(AccessResultCode.OTHER_REASON));
+        ThrowableAssert.catchThrowable(
+            () -> this.executor.asBundleResponse(AccessResultCode.OTHER_REASON));
     assertThat(actual).isInstanceOf(ProtocolAdapterException.class);
   }
 
   @Test
-  void shouldExecuteForProtocolDsmr422() throws ProtocolAdapterException, IOException {
+  void shouldExecuteForProtocolDsmr422()
+      throws ProtocolAdapterException, IOException, ObjectConfigException {
     this.assertForOneRegister("DSMR", "4.2.2");
   }
 
   @Test
-  void shouldExecuteForProtocolSmr500() throws ProtocolAdapterException, IOException {
+  void shouldExecuteForProtocolSmr500()
+      throws ProtocolAdapterException, IOException, ObjectConfigException {
     this.assertForOneRegister("SMR", "5.0.0");
   }
 
   @Test
-  void shouldExecuteForProtocolSmr51() throws ProtocolAdapterException, IOException {
+  void shouldExecuteForProtocolSmr51()
+      throws ProtocolAdapterException, IOException, ObjectConfigException {
     this.assertForOneRegister("SMR", "5.1");
   }
 
   @Test
-  void shouldExecuteForProtocolSmr52() throws ProtocolAdapterException, IOException {
+  void shouldExecuteForProtocolSmr52()
+      throws ProtocolAdapterException, IOException, ObjectConfigException {
     this.assertForTwoRegisters("SMR", "5.2");
   }
 
   @Test
-  void shouldExecuteForProtocolSmr55() throws ProtocolAdapterException, IOException {
+  void shouldExecuteForProtocolSmr55()
+      throws ProtocolAdapterException, IOException, ObjectConfigException {
     this.assertForThreeRegisters("SMR", "5.5");
   }
 
   @Test
-  void connectionProblemAlarmRegister1() throws ProtocolAdapterException, IOException {
+  void connectionProblemAlarmRegister1() throws IOException, ObjectConfigException {
     when(this.dlmsConnection.set(this.setParameterArgumentCaptor.capture()))
         .thenThrow(new IOException());
 
     final DlmsDevice dlmsDevice = new DlmsDevice("SMR 5.2 device");
     this.setupAlarmRegister1(dlmsDevice);
     final Throwable actual =
-        catchThrowable(
+        ThrowableAssert.catchThrowable(
             () ->
                 this.executor.execute(
                     this.connectionManager, dlmsDevice, this.dto, this.messageMetadata));
@@ -127,13 +134,13 @@ class ClearAlarmRegisterCommandExecutorTest {
   }
 
   @Test
-  void nullResultAlarmRegister1() throws ProtocolAdapterException, IOException {
+  void nullResultAlarmRegister1() throws IOException, ObjectConfigException {
     when(this.dlmsConnection.set(this.setParameterArgumentCaptor.capture())).thenReturn(null);
 
     final DlmsDevice dlmsDevice = new DlmsDevice("SMR 5.2 device");
     this.setupAlarmRegister1(dlmsDevice);
     final Throwable actual =
-        catchThrowable(
+        ThrowableAssert.catchThrowable(
             () ->
                 this.executor.execute(
                     this.connectionManager, dlmsDevice, this.dto, this.messageMetadata));
@@ -141,7 +148,7 @@ class ClearAlarmRegisterCommandExecutorTest {
   }
 
   @Test
-  void connectionProblemAlarmRegister2() throws ProtocolAdapterException, IOException {
+  void connectionProblemAlarmRegister2() throws IOException, ObjectConfigException {
     when(this.dlmsConnection.set(any(SetParameter.class)))
         .thenReturn(AccessResultCode.SUCCESS)
         .thenThrow(new IOException());
@@ -149,7 +156,7 @@ class ClearAlarmRegisterCommandExecutorTest {
     final DlmsDevice dlmsDevice = new DlmsDevice("SMR 5.2 device");
     this.setupAlarmRegister2(dlmsDevice);
     final Throwable actual =
-        catchThrowable(
+        ThrowableAssert.catchThrowable(
             () ->
                 this.executor.execute(
                     this.connectionManager, dlmsDevice, this.dto, this.messageMetadata));
@@ -157,7 +164,7 @@ class ClearAlarmRegisterCommandExecutorTest {
   }
 
   @Test
-  void nullResultAlarmRegister2() throws ProtocolAdapterException, IOException {
+  void nullResultAlarmRegister2() throws IOException, ObjectConfigException {
     when(this.dlmsConnection.set(this.setParameterArgumentCaptor.capture()))
         .thenReturn(AccessResultCode.SUCCESS)
         .thenReturn(null);
@@ -165,7 +172,7 @@ class ClearAlarmRegisterCommandExecutorTest {
     final DlmsDevice dlmsDevice = new DlmsDevice("SMR 5.2 device");
     this.setupAlarmRegister2(dlmsDevice);
     final Throwable actual =
-        catchThrowable(
+        ThrowableAssert.catchThrowable(
             () ->
                 this.executor.execute(
                     this.connectionManager, dlmsDevice, this.dto, this.messageMetadata));
@@ -173,7 +180,8 @@ class ClearAlarmRegisterCommandExecutorTest {
   }
 
   @Test
-  void failureRegister1AndResultAlarmRegister2() throws ProtocolAdapterException, IOException {
+  void failureRegister1AndResultAlarmRegister2()
+      throws ProtocolAdapterException, IOException, ObjectConfigException {
     when(this.dlmsConnection.set(this.setParameterArgumentCaptor.capture()))
         .thenReturn(AccessResultCode.OTHER_REASON)
         .thenReturn(AccessResultCode.SUCCESS);
@@ -183,12 +191,13 @@ class ClearAlarmRegisterCommandExecutorTest {
     final AccessResultCode accessResultCode =
         this.executor.execute(this.connectionManager, dlmsDevice, this.dto, this.messageMetadata);
     assertThat(accessResultCode).isEqualTo(AccessResultCode.OTHER_REASON);
-    verify(this.dlmsObjectConfigService, times(1))
-        .findAttributeAddress(eq(dlmsDevice), any(), any());
+    //    verify(this.dlmsObjectConfigService, times(1))
+    //        .findAttributeAddress(eq(dlmsDevice), any(), any());
   }
 
   @Test
-  void successRegister1AndResultAlarmRegister2() throws ProtocolAdapterException, IOException {
+  void successRegister1AndResultAlarmRegister2()
+      throws ProtocolAdapterException, IOException, ObjectConfigException {
     when(this.dlmsConnection.set(this.setParameterArgumentCaptor.capture()))
         .thenReturn(AccessResultCode.SUCCESS)
         .thenReturn(AccessResultCode.TEMPORARY_FAILURE);
@@ -201,7 +210,7 @@ class ClearAlarmRegisterCommandExecutorTest {
   }
 
   @Test
-  void resultAlarmRegister2() throws ProtocolAdapterException, IOException {
+  void resultAlarmRegister2() throws ProtocolAdapterException, IOException, ObjectConfigException {
     when(this.dlmsConnection.set(this.setParameterArgumentCaptor.capture()))
         .thenReturn(AccessResultCode.SUCCESS)
         .thenReturn(AccessResultCode.SUCCESS);
@@ -214,7 +223,7 @@ class ClearAlarmRegisterCommandExecutorTest {
   }
 
   @Test
-  void connectionProblemAlarmRegister3() throws ProtocolAdapterException, IOException {
+  void connectionProblemAlarmRegister3() throws IOException, ObjectConfigException {
     when(this.dlmsConnection.set(any(SetParameter.class)))
         .thenReturn(AccessResultCode.SUCCESS)
         .thenReturn(AccessResultCode.SUCCESS)
@@ -223,7 +232,7 @@ class ClearAlarmRegisterCommandExecutorTest {
     final DlmsDevice dlmsDevice = new DlmsDevice("SMR 5.5 device");
     this.setupAlarmRegister3(dlmsDevice);
     final Throwable actual =
-        catchThrowable(
+        ThrowableAssert.catchThrowable(
             () ->
                 this.executor.execute(
                     this.connectionManager, dlmsDevice, this.dto, this.messageMetadata));
@@ -231,7 +240,7 @@ class ClearAlarmRegisterCommandExecutorTest {
   }
 
   @Test
-  void nullResultAlarmRegister3() throws ProtocolAdapterException, IOException {
+  void nullResultAlarmRegister3() throws IOException, ObjectConfigException {
     when(this.dlmsConnection.set(this.setParameterArgumentCaptor.capture()))
         .thenReturn(AccessResultCode.SUCCESS)
         .thenReturn(AccessResultCode.SUCCESS)
@@ -240,7 +249,7 @@ class ClearAlarmRegisterCommandExecutorTest {
     final DlmsDevice dlmsDevice = new DlmsDevice("SMR 5.5 device");
     this.setupAlarmRegister3(dlmsDevice);
     final Throwable actual =
-        catchThrowable(
+        ThrowableAssert.catchThrowable(
             () ->
                 this.executor.execute(
                     this.connectionManager, dlmsDevice, this.dto, this.messageMetadata));
@@ -248,7 +257,8 @@ class ClearAlarmRegisterCommandExecutorTest {
   }
 
   @Test
-  void failureRegister2AndResultAlarmRegister3() throws ProtocolAdapterException, IOException {
+  void failureRegister2AndResultAlarmRegister3()
+      throws ProtocolAdapterException, IOException, ObjectConfigException {
     when(this.dlmsConnection.set(this.setParameterArgumentCaptor.capture()))
         .thenReturn(AccessResultCode.SUCCESS)
         .thenReturn(AccessResultCode.OTHER_REASON)
@@ -259,12 +269,13 @@ class ClearAlarmRegisterCommandExecutorTest {
     final AccessResultCode accessResultCode =
         this.executor.execute(this.connectionManager, dlmsDevice, this.dto, this.messageMetadata);
     assertThat(accessResultCode).isEqualTo(AccessResultCode.OTHER_REASON);
-    verify(this.dlmsObjectConfigService, times(2))
-        .findAttributeAddress(eq(dlmsDevice), any(), any());
+    //    verify(this.dlmsObjectConfigService, times(2))
+    //        .findAttributeAddress(eq(dlmsDevice), any(), any());
   }
 
   @Test
-  void successRegister1AndResultAlarmRegister3() throws ProtocolAdapterException, IOException {
+  void successRegister1AndResultAlarmRegister3()
+      throws ProtocolAdapterException, IOException, ObjectConfigException {
     when(this.dlmsConnection.set(this.setParameterArgumentCaptor.capture()))
         .thenReturn(AccessResultCode.SUCCESS)
         .thenReturn(AccessResultCode.SUCCESS)
@@ -278,7 +289,7 @@ class ClearAlarmRegisterCommandExecutorTest {
   }
 
   @Test
-  void resultAlarmRegister3() throws ProtocolAdapterException, IOException {
+  void resultAlarmRegister3() throws ProtocolAdapterException, IOException, ObjectConfigException {
     when(this.dlmsConnection.set(this.setParameterArgumentCaptor.capture()))
         .thenReturn(AccessResultCode.SUCCESS)
         .thenReturn(AccessResultCode.SUCCESS)
@@ -291,98 +302,85 @@ class ClearAlarmRegisterCommandExecutorTest {
     assertThat(accessResultCode).isEqualTo(AccessResultCode.SUCCESS);
   }
 
-  void setupAlarmRegister1(final DlmsDevice dlmsDevice)
-      throws ProtocolAdapterException, IOException {
+  void setupAlarmRegister1(final DlmsDevice dlmsDevice) throws ObjectConfigException {
 
     dlmsDevice.setProtocol("SMR", "5.2");
 
-    when(this.dlmsObjectConfigService.findAttributeAddress(
-            dlmsDevice, DlmsObjectType.ALARM_REGISTER_1, null))
-        .thenReturn(
-            Optional.of(
-                new AttributeAddress(
-                    InterfaceClass.DATA.id(),
-                    OBIS_CODE_ALARM_REGISTER_1,
-                    DataAttribute.VALUE.attributeId())));
+    this.mockAlarmCosemObject(
+        dlmsDevice,
+        OBIS_CODE_ALARM_REGISTER_1,
+        org.opensmartgridplatform.dlms.objectconfig.DlmsObjectType.ALARM_REGISTER_1);
 
     when(this.connectionManager.getDlmsMessageListener()).thenReturn(this.dlmsMessageListener);
     when(this.connectionManager.getConnection()).thenReturn(this.dlmsConnection);
   }
 
-  void setupAlarmRegister2(final DlmsDevice dlmsDevice)
-      throws ProtocolAdapterException, IOException {
-    dlmsDevice.setProtocol("SMR", "5.2");
+  void setupAlarmRegister2(final DlmsDevice dlmsDevice) throws ObjectConfigException {
 
-    when(this.dlmsObjectConfigService.findAttributeAddress(
-            dlmsDevice, DlmsObjectType.ALARM_REGISTER_1, null))
-        .thenReturn(
-            Optional.of(
-                new AttributeAddress(
-                    InterfaceClass.DATA.id(),
-                    OBIS_CODE_ALARM_REGISTER_1,
-                    DataAttribute.VALUE.attributeId())));
-
-    when(this.dlmsObjectConfigService.findAttributeAddress(
-            dlmsDevice, DlmsObjectType.ALARM_REGISTER_2, null))
-        .thenReturn(
-            Optional.of(
-                new AttributeAddress(
-                    InterfaceClass.DATA.id(),
-                    OBIS_CODE_ALARM_REGISTER_2,
-                    DataAttribute.VALUE.attributeId())));
+    this.mockAlarmCosemObject(
+        dlmsDevice,
+        OBIS_CODE_ALARM_REGISTER_1,
+        org.opensmartgridplatform.dlms.objectconfig.DlmsObjectType.ALARM_REGISTER_1);
+    this.mockAlarmCosemObject(
+        dlmsDevice,
+        OBIS_CODE_ALARM_REGISTER_2,
+        org.opensmartgridplatform.dlms.objectconfig.DlmsObjectType.ALARM_REGISTER_2);
 
     when(this.connectionManager.getDlmsMessageListener()).thenReturn(this.dlmsMessageListener);
     when(this.connectionManager.getConnection()).thenReturn(this.dlmsConnection);
   }
 
-  void setupAlarmRegister3(final DlmsDevice dlmsDevice)
-      throws ProtocolAdapterException, IOException {
+  private void mockAlarmCosemObject(
+      final DlmsDevice dlmsDevice,
+      final String obisCode,
+      final org.opensmartgridplatform.dlms.objectconfig.DlmsObjectType dlmsObjectType)
+      throws ObjectConfigException {
+    final CosemObject cosemObjectForAlarm = Mockito.mock(CosemObject.class);
+
+    final Attribute attribute = Mockito.mock(Attribute.class);
+
+    when(cosemObjectForAlarm.getObis()).thenReturn(obisCode);
+    when(cosemObjectForAlarm.getAttribute(
+            ClearAlarmRegisterCommandExecutor.ALARM_REGISTER_ATTRIBUTE_ID))
+        .thenReturn(attribute);
+
+    when(attribute.getId()).thenReturn(2);
+    when(cosemObjectForAlarm.getClassId()).thenReturn(1);
+
+    when(this.objectConfigService.getCosemObject(
+            dlmsDevice.getProtocolName(), dlmsDevice.getProtocolVersion(), dlmsObjectType))
+        .thenReturn(cosemObjectForAlarm);
+  }
+
+  void setupAlarmRegister3(final DlmsDevice dlmsDevice) throws ObjectConfigException {
     dlmsDevice.setProtocol("SMR", "5.5");
 
-    when(this.dlmsObjectConfigService.findAttributeAddress(
-            dlmsDevice, DlmsObjectType.ALARM_REGISTER_1, null))
-        .thenReturn(
-            Optional.of(
-                new AttributeAddress(
-                    InterfaceClass.DATA.id(),
-                    OBIS_CODE_ALARM_REGISTER_1,
-                    DataAttribute.VALUE.attributeId())));
-
-    when(this.dlmsObjectConfigService.findAttributeAddress(
-            dlmsDevice, DlmsObjectType.ALARM_REGISTER_2, null))
-        .thenReturn(
-            Optional.of(
-                new AttributeAddress(
-                    InterfaceClass.DATA.id(),
-                    OBIS_CODE_ALARM_REGISTER_2,
-                    DataAttribute.VALUE.attributeId())));
-
-    when(this.dlmsObjectConfigService.findAttributeAddress(
-            dlmsDevice, DlmsObjectType.ALARM_REGISTER_3, null))
-        .thenReturn(
-            Optional.of(
-                new AttributeAddress(
-                    InterfaceClass.DATA.id(),
-                    OBIS_CODE_ALARM_REGISTER_3,
-                    DataAttribute.VALUE.attributeId())));
+    this.mockAlarmCosemObject(
+        dlmsDevice,
+        OBIS_CODE_ALARM_REGISTER_1,
+        org.opensmartgridplatform.dlms.objectconfig.DlmsObjectType.ALARM_REGISTER_1);
+    this.mockAlarmCosemObject(
+        dlmsDevice,
+        OBIS_CODE_ALARM_REGISTER_2,
+        org.opensmartgridplatform.dlms.objectconfig.DlmsObjectType.ALARM_REGISTER_2);
+    this.mockAlarmCosemObject(
+        dlmsDevice,
+        OBIS_CODE_ALARM_REGISTER_3,
+        org.opensmartgridplatform.dlms.objectconfig.DlmsObjectType.ALARM_REGISTER_3);
 
     when(this.connectionManager.getDlmsMessageListener()).thenReturn(this.dlmsMessageListener);
     when(this.connectionManager.getConnection()).thenReturn(this.dlmsConnection);
   }
 
   void assertForOneRegister(final String protocol, final String protocolVersion)
-      throws ProtocolAdapterException, IOException {
+      throws ProtocolAdapterException, IOException, ObjectConfigException {
     final DlmsDevice dlmsDevice = new DlmsDevice(protocol + " " + protocolVersion + " device");
     dlmsDevice.setProtocol(protocol, protocolVersion);
 
-    when(this.dlmsObjectConfigService.findAttributeAddress(
-            dlmsDevice, DlmsObjectType.ALARM_REGISTER_1, null))
-        .thenReturn(
-            Optional.of(
-                new AttributeAddress(
-                    InterfaceClass.DATA.id(),
-                    OBIS_CODE_ALARM_REGISTER_1,
-                    DataAttribute.VALUE.attributeId())));
+    this.mockAlarmCosemObject(
+        dlmsDevice,
+        OBIS_CODE_ALARM_REGISTER_1,
+        org.opensmartgridplatform.dlms.objectconfig.DlmsObjectType.ALARM_REGISTER_1);
 
     when(this.connectionManager.getDlmsMessageListener()).thenReturn(this.dlmsMessageListener);
     when(this.connectionManager.getConnection()).thenReturn(this.dlmsConnection);
@@ -401,27 +399,19 @@ class ClearAlarmRegisterCommandExecutorTest {
   }
 
   void assertForTwoRegisters(final String protocol, final String protocolVersion)
-      throws ProtocolAdapterException, IOException {
+      throws ProtocolAdapterException, IOException, ObjectConfigException {
     final DlmsDevice dlmsDevice = new DlmsDevice(protocol + " " + protocolVersion + " device");
     dlmsDevice.setProtocol(protocol, protocolVersion);
 
-    when(this.dlmsObjectConfigService.findAttributeAddress(
-            dlmsDevice, DlmsObjectType.ALARM_REGISTER_1, null))
-        .thenReturn(
-            Optional.of(
-                new AttributeAddress(
-                    InterfaceClass.DATA.id(),
-                    OBIS_CODE_ALARM_REGISTER_1,
-                    DataAttribute.VALUE.attributeId())));
+    this.mockAlarmCosemObject(
+        dlmsDevice,
+        OBIS_CODE_ALARM_REGISTER_1,
+        org.opensmartgridplatform.dlms.objectconfig.DlmsObjectType.ALARM_REGISTER_1);
 
-    when(this.dlmsObjectConfigService.findAttributeAddress(
-            dlmsDevice, DlmsObjectType.ALARM_REGISTER_2, null))
-        .thenReturn(
-            Optional.of(
-                new AttributeAddress(
-                    InterfaceClass.DATA.id(),
-                    OBIS_CODE_ALARM_REGISTER_2,
-                    DataAttribute.VALUE.attributeId())));
+    this.mockAlarmCosemObject(
+        dlmsDevice,
+        OBIS_CODE_ALARM_REGISTER_2,
+        org.opensmartgridplatform.dlms.objectconfig.DlmsObjectType.ALARM_REGISTER_2);
 
     when(this.connectionManager.getDlmsMessageListener()).thenReturn(this.dlmsMessageListener);
     when(this.connectionManager.getConnection()).thenReturn(this.dlmsConnection);
@@ -447,36 +437,24 @@ class ClearAlarmRegisterCommandExecutorTest {
   }
 
   void assertForThreeRegisters(final String protocol, final String protocolVersion)
-      throws ProtocolAdapterException, IOException {
+      throws ProtocolAdapterException, IOException, ObjectConfigException {
     final DlmsDevice dlmsDevice = new DlmsDevice(protocol + " " + protocolVersion + " device");
     dlmsDevice.setProtocol(protocol, protocolVersion);
 
-    when(this.dlmsObjectConfigService.findAttributeAddress(
-            dlmsDevice, DlmsObjectType.ALARM_REGISTER_1, null))
-        .thenReturn(
-            Optional.of(
-                new AttributeAddress(
-                    InterfaceClass.DATA.id(),
-                    OBIS_CODE_ALARM_REGISTER_1,
-                    DataAttribute.VALUE.attributeId())));
+    this.mockAlarmCosemObject(
+        dlmsDevice,
+        OBIS_CODE_ALARM_REGISTER_1,
+        org.opensmartgridplatform.dlms.objectconfig.DlmsObjectType.ALARM_REGISTER_1);
 
-    when(this.dlmsObjectConfigService.findAttributeAddress(
-            dlmsDevice, DlmsObjectType.ALARM_REGISTER_2, null))
-        .thenReturn(
-            Optional.of(
-                new AttributeAddress(
-                    InterfaceClass.DATA.id(),
-                    OBIS_CODE_ALARM_REGISTER_2,
-                    DataAttribute.VALUE.attributeId())));
+    this.mockAlarmCosemObject(
+        dlmsDevice,
+        OBIS_CODE_ALARM_REGISTER_2,
+        org.opensmartgridplatform.dlms.objectconfig.DlmsObjectType.ALARM_REGISTER_2);
 
-    when(this.dlmsObjectConfigService.findAttributeAddress(
-            dlmsDevice, DlmsObjectType.ALARM_REGISTER_3, null))
-        .thenReturn(
-            Optional.of(
-                new AttributeAddress(
-                    InterfaceClass.DATA.id(),
-                    OBIS_CODE_ALARM_REGISTER_3,
-                    DataAttribute.VALUE.attributeId())));
+    this.mockAlarmCosemObject(
+        dlmsDevice,
+        OBIS_CODE_ALARM_REGISTER_3,
+        org.opensmartgridplatform.dlms.objectconfig.DlmsObjectType.ALARM_REGISTER_3);
 
     when(this.connectionManager.getDlmsMessageListener()).thenReturn(this.dlmsMessageListener);
     when(this.connectionManager.getConnection()).thenReturn(this.dlmsConnection);

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/MessagingTestConfiguration.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/MessagingTestConfiguration.java
@@ -29,9 +29,11 @@ import org.opensmartgridplatform.adapter.protocol.dlms.infra.messaging.processor
 import org.opensmartgridplatform.adapter.protocol.dlms.infra.messaging.requests.to.core.OsgpRequestMessageSender;
 import org.opensmartgridplatform.shared.application.config.AbstractConfig;
 import org.opensmartgridplatform.shared.application.config.messaging.DefaultJmsConfiguration;
+import org.opensmartgridplatform.shared.application.config.messaging.JmsBrokerType;
 import org.opensmartgridplatform.shared.domain.services.CorrelationIdProviderService;
 import org.opensmartgridplatform.shared.domain.services.CorrelationIdProviderUUIDService;
 import org.opensmartgridplatform.shared.infra.jms.BaseMessageProcessorMap;
+import org.opensmartgridplatform.shared.infra.jms.JmsMessageCreator;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.networking.ping.Pinger;
 import org.springframework.context.annotation.Bean;
@@ -51,7 +53,6 @@ import stub.DlmsPersistenceConfigStub;
 /** Test Configuration for JMS Listener triggered tests. */
 @Configuration
 @ComponentScan(
-    basePackages = {},
     excludeFilters =
         @ComponentScan.Filter(
             type = FilterType.CUSTOM,
@@ -71,6 +72,11 @@ public class MessagingTestConfiguration extends AbstractConfig {
   @Bean
   public DefaultJmsConfiguration defaultJmsConfiguration() {
     return new DefaultJmsConfiguration();
+  }
+
+  @Bean
+  public JmsMessageCreator jmsMessageCreator() {
+    return new JmsMessageCreator(JmsBrokerType.ACTIVE_MQ);
   }
 
   @Bean("protocolDlmsInboundOsgpCoreRequestsMessageListener")


### PR DESCRIPTION
Refactor the ClearAlarmRegister operation to use the dlm object config. And fix the DeviceRequestMessageListenerIT integration test.