### PR TITLE
Upgrade JDLMS 1.8.0

### DIFF
--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/pom.xml
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/pom.xml
@@ -27,7 +27,7 @@ SPDX-License-Identifier: Apache-2.0
     <display.version>${project.version}-${BUILD_TAG}</display.version>
     <osgp-ws-secret-management-version>${project.version}</osgp-ws-secret-management-version>
     <skipITs>true</skipITs>
-    <openmuc.jdlms.version>1.7.2.2-SNAPSHOT</openmuc.jdlms.version>
+    <openmuc.jdlms.version>1.8.0</openmuc.jdlms.version>
   </properties>
 
   <build>
@@ -192,6 +192,12 @@ SPDX-License-Identifier: Apache-2.0
     <dependency>
       <groupId>org.springframework.ws</groupId>
       <artifactId>spring-ws-security</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcprov-jdk15on</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework.ws</groupId>

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/factories/SecureDlmsConnector.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/factories/SecureDlmsConnector.java
@@ -65,6 +65,10 @@ public abstract class SecureDlmsConnector extends Lls0Connector {
         .setReferencingMethod(
             device.isUseSn() ? ReferencingMethod.SHORT : ReferencingMethod.LOGICAL);
 
+    if (device.isLls1Active()) {
+      tcpConnectionBuilder.setAlwaysSendSecurityMechanismName(true).setSkipAARQEncryption(true);
+    }
+
     if (device.isUseHdlc()) {
       tcpConnectionBuilder.useHdlc();
     }

--- a/osgp/protocol-adapter-dlms/osgp-protocol-simulator-dlms/simulator/dlms-device-simulator/pom.xml
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-simulator-dlms/simulator/dlms-device-simulator/pom.xml
@@ -40,6 +40,12 @@ SPDX-License-Identifier: Apache-2.0
     <dependency>
       <groupId>org.springframework.ws</groupId>
       <artifactId>spring-ws-security</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcprov-jdk15on</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.jaxrs</groupId>

--- a/super/pom.xml
+++ b/super/pom.xml
@@ -107,8 +107,8 @@ SPDX-License-Identifier: Apache-2.0
     <maven.clean.plugin.version>3.1.0</maven.clean.plugin.version>
     <maven.compiler.plugin.version>3.10.1</maven.compiler.plugin.version>
     <netty.version>4.1.80.Final</netty.version>
-    <openmuc.jdlms.version>1.7.2.2-SNAPSHOT</openmuc.jdlms.version>
-    <openmuc.jdlms-annotation.version>1.7.2</openmuc.jdlms-annotation.version>
+    <openmuc.jdlms.version>1.8.0</openmuc.jdlms.version>
+    <openmuc.jdlms-annotation.version>1.8.0</openmuc.jdlms-annotation.version>
     <beanit.openiec61850.version>1.8.0</beanit.openiec61850.version>
     <openmuc.j60870.version>1.4.0</openmuc.j60870.version>
     <javax.inject.version>1</javax.inject.version>
@@ -876,13 +876,6 @@ SPDX-License-Identifier: Apache-2.0
         <groupId>org.openmuc</groupId>
         <artifactId>jdlms</artifactId>
         <version>${openmuc.jdlms.version}</version>
-        <exclusions>
-          <exclusion>
-            <!-- Exclude to ensure compatibility with (older) 1.51 users -->
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
 
       <!-- Google Protocol Buffers -->


### PR DESCRIPTION
Update to new version of jDLMS. For DSMR2.2 using LLS1 two new options need to be set.