### PR TITLE
Use config service 4.2.2 for dsmr 2.2, DMSR 2.2 was recgocnized befor…

### DIFF
--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/monitoring/GetPeriodicMeterReads.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/monitoring/GetPeriodicMeterReads.feature
@@ -14,7 +14,6 @@ Feature: SmartMetering Monitoring - Get Periodic Meter Reads
       | DeviceType               | SMART_METER_E     |
       | Protocol                 | <Protocol>        |
       | ProtocolVersion          | <ProtocolVersion> |
-      | Port                     | <Port>            |
     When the get "<PeriodType>" meter reads request is received
       | DeviceIdentification | <DeviceId>   |
       | PeriodType           | <PeriodType> |
@@ -24,13 +23,16 @@ Feature: SmartMetering Monitoring - Get Periodic Meter Reads
       | DeviceIdentification | <DeviceId> |
 
     Examples:
-      | PeriodType | BeginDate                | EndDate                  | DeviceId             | Protocol | ProtocolVersion | Port |
-      | INTERVAL   | 2015-09-01T00:00:00.000Z | 2015-10-01T00:00:00.000Z | TEST1024000000001    | DSMR     | 4.2.2           | 1024 |
-      | MONTHLY    | 2016-01-01T00:00:00.000Z | 2016-09-01T00:00:00.000Z | TEST1024000000001    | DSMR     | 4.2.2           | 1024 |
-      | DAILY      | 2022-05-02T00:00:00.000Z | 2022-05-02T00:00:00.000Z | TEST1024000000001    | DSMR     | 4.2.2           | 1024 |
-      | INTERVAL   | 2015-09-01T00:00:00.000Z | 2015-10-01T00:00:00.000Z | TEST1027000000001    | SMR      | 5.0.0           | 1027 |
-      | MONTHLY    | 2016-01-01T00:00:00.000Z | 2016-09-01T00:00:00.000Z | TEST1027000000001    | SMR      | 5.0.0           | 1027 |
-      | DAILY      | 2022-05-02T00:00:00.000Z | 2022-05-02T00:00:00.000Z | TEST1027000000001    | SMR      | 5.0.0           | 1027 |
+      | PeriodType | BeginDate                | EndDate                  | DeviceId             | Protocol | ProtocolVersion |
+      | INTERVAL   | 2015-09-01T00:00:00.000Z | 2015-10-01T00:00:00.000Z | TEST1026000000001    | DSMR     | 2.2             |
+      | MONTHLY    | 2016-01-01T00:00:00.000Z | 2016-09-01T00:00:00.000Z | TEST1026000000001    | DSMR     | 2.2             |
+      | DAILY      | 2022-05-02T00:00:00.000Z | 2022-05-02T00:00:00.000Z | TEST1026000000001    | DSMR     | 2.2             |
+      | INTERVAL   | 2015-09-01T00:00:00.000Z | 2015-10-01T00:00:00.000Z | TEST1024000000001    | DSMR     | 4.2.2           |
+      | MONTHLY    | 2016-01-01T00:00:00.000Z | 2016-09-01T00:00:00.000Z | TEST1024000000001    | DSMR     | 4.2.2           |
+      | DAILY      | 2022-05-02T00:00:00.000Z | 2022-05-02T00:00:00.000Z | TEST1024000000001    | DSMR     | 4.2.2           |
+      | INTERVAL   | 2015-09-01T00:00:00.000Z | 2015-10-01T00:00:00.000Z | TEST1027000000001    | SMR      | 5.0.0           |
+      | MONTHLY    | 2016-01-01T00:00:00.000Z | 2016-09-01T00:00:00.000Z | TEST1027000000001    | SMR      | 5.0.0           |
+      | DAILY      | 2022-05-02T00:00:00.000Z | 2022-05-02T00:00:00.000Z | TEST1027000000001    | SMR      | 5.0.0           |
 
   Scenario Outline: Get the periodic meter reads <PeriodType> from a <Protocol> <ProtocolVersion> G-meter
     Given a dlms device
@@ -38,7 +40,6 @@ Feature: SmartMetering Monitoring - Get Periodic Meter Reads
       | DeviceType               | SMART_METER_E     |
       | Protocol                 | <Protocol>        |
       | ProtocolVersion          | <ProtocolVersion> |
-      | Port                     | <Port>            |
     And a dlms device
       | DeviceIdentification        | <MBusId>      |
       | DeviceType                  | SMART_METER_G |
@@ -53,10 +54,13 @@ Feature: SmartMetering Monitoring - Get Periodic Meter Reads
       | DeviceIdentification | <MBusId> |
 
     Examples:
-      | PeriodType | BeginDate                | EndDate                  | MBusId            | DeviceId             | Protocol | ProtocolVersion | Port |
-      | INTERVAL   | 2015-09-01T00:00:00.000Z | 2015-10-01T00:00:00.000Z | TESTG102400000001 | TEST1024000000001    | DSMR     | 4.2.2           | 1024 |
-      | MONTHLY    | 2016-01-01T00:00:00.000Z | 2016-09-01T00:00:00.000Z | TESTG102400000001 | TEST1024000000001    | DSMR     | 4.2.2           | 1024 |
-      | DAILY      | 2022-05-02T00:00:00.000Z | 2022-05-02T00:00:00.000Z | TESTG102400000001 | TEST1024000000001    | DSMR     | 4.2.2           | 1024 |
-      | INTERVAL   | 2015-09-01T00:00:00.000Z | 2015-10-01T00:00:00.000Z | TESTG102700000001 | TEST1027000000001    | SMR      | 5.0.0           | 1027 |
-      | MONTHLY    | 2016-01-01T00:00:00.000Z | 2016-09-01T00:00:00.000Z | TESTG102700000001 | TEST1027000000001    | SMR      | 5.0.0           | 1027 |
-      | DAILY      | 2022-05-02T00:00:00.000Z | 2022-05-02T00:00:00.000Z | TESTG102700000001 | TEST1027000000001    | SMR      | 5.0.0           | 1027 |
+      | PeriodType | BeginDate                | EndDate                  | MBusId            | DeviceId             | Protocol | ProtocolVersion |
+      | INTERVAL   | 2015-09-01T00:00:00.000Z | 2015-10-01T00:00:00.000Z | TESTG102600000001 | TEST1026000000001    | DSMR     | 2.2             |
+      | MONTHLY    | 2016-01-01T00:00:00.000Z | 2016-09-01T00:00:00.000Z | TESTG102600000001 | TEST1026000000001    | DSMR     | 2.2             |
+      | DAILY      | 2022-05-02T00:00:00.000Z | 2022-05-02T00:00:00.000Z | TESTG102600000001 | TEST1026000000001    | DSMR     | 2.2             |
+      | INTERVAL   | 2015-09-01T00:00:00.000Z | 2015-10-01T00:00:00.000Z | TESTG102400000001 | TEST1024000000001    | DSMR     | 4.2.2           |
+      | MONTHLY    | 2016-01-01T00:00:00.000Z | 2016-09-01T00:00:00.000Z | TESTG102400000001 | TEST1024000000001    | DSMR     | 4.2.2           |
+      | DAILY      | 2022-05-02T00:00:00.000Z | 2022-05-02T00:00:00.000Z | TESTG102400000001 | TEST1024000000001    | DSMR     | 4.2.2           |
+      | INTERVAL   | 2015-09-01T00:00:00.000Z | 2015-10-01T00:00:00.000Z | TESTG102700000001 | TEST1027000000001    | SMR      | 5.0.0           |
+      | MONTHLY    | 2016-01-01T00:00:00.000Z | 2016-09-01T00:00:00.000Z | TESTG102700000001 | TEST1027000000001    | SMR      | 5.0.0           |
+      | DAILY      | 2022-05-02T00:00:00.000Z | 2022-05-02T00:00:00.000Z | TESTG102700000001 | TEST1027000000001    | SMR      | 5.0.0           |

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/dlmsobjectconfig/DlmsObjectConfigDsmr422.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/dlmsobjectconfig/DlmsObjectConfigDsmr422.java
@@ -70,7 +70,7 @@ public class DlmsObjectConfigDsmr422 extends DlmsObjectConfig {
 
   @Override
   List<Protocol> initProtocols() {
-    return Arrays.asList(Protocol.DSMR_4_2_2, Protocol.OTHER_PROTOCOL);
+    return Arrays.asList(Protocol.DSMR_2_2, Protocol.DSMR_4_2_2, Protocol.OTHER_PROTOCOL);
   }
 
   @Override


### PR DESCRIPTION
Use config service 4.2.2 for dsmr 2.2, DMSR 2.2 was recgocnized before as OTHER_PROTOCOL, so service already handled DSMR 2.2