### PR TITLE
Get scalar_unit from device when valuetype is not FIXED_IN_PROFILE

### DIFF
--- a/osgp/protocol-adapter-dlms/osgp-dlms/src/main/java/org/opensmartgridplatform/dlms/objectconfig/CosemObject.java
+++ b/osgp/protocol-adapter-dlms/osgp-dlms/src/main/java/org/opensmartgridplatform/dlms/objectconfig/CosemObject.java
@@ -33,6 +33,13 @@ public class CosemObject {
         .orElseThrow(() -> new IllegalArgumentException("Attribute " + id + " not found"));
   }
 
+  public boolean hasAttribute(final int id) {
+    if (this.attributes == null) {
+      return false;
+    }
+    return this.attributes.stream().anyMatch(attribute -> attribute.getId() == id);
+  }
+
   public Object getProperty(final ObjectProperty objectProperty) {
     if (this.properties == null) {
       return null;


### PR DESCRIPTION
SMHE-1790: For DSMR 4.2.2 scaler unit should be retrieved dynamically, from some objects for the get actual power quality request