### PR TITLE
SMHE-1602: add config_lookup_type to dlms_device

### DIFF
--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/entities/DlmsDevice.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/entities/DlmsDevice.java
@@ -72,6 +72,10 @@ public class DlmsDevice extends AbstractEntity {
   @Column(length = 40)
   private String timezone;
 
+  @Column(name = "config_lookup_type")
+  /* marking for a device type for G-meter G4,G6,G10,G16,G25,null or E-meter devicemodel.code */
+  private String configLookupType;
+
   @Column(name = "protocol", nullable = false)
   private String protocolName;
 
@@ -424,5 +428,15 @@ public class DlmsDevice extends AbstractEntity {
 
   public void setFirmwareHash(final String firmwareHash) {
     this.firmwareHash = firmwareHash;
+  }
+
+  /** get the configLookupType that will be used to lookup values in the object config service. */
+  public String getConfigLookupType() {
+    return this.configLookupType;
+  }
+
+  /** set the configLookupType that will be used to lookup values in the object config service. */
+  public void setConfigLookupType(final String configLookupType) {
+    this.configLookupType = configLookupType;
   }
 }

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/resources/db/migration/V20231004145312345__added_device_type_for_object_config.sql
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/resources/db/migration/V20231004145312345__added_device_type_for_object_config.sql
@@ -1,0 +1,1 @@
+ALTER TABLE dlms_device ADD COLUMN config_lookup_type character varying(255) DEFAULT null;

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/entities/DlmsDeviceBuilder.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/entities/DlmsDeviceBuilder.java
@@ -19,6 +19,7 @@ public class DlmsDeviceBuilder {
   private DefaultValue<Boolean> hls4Active = notSet();
   private DefaultValue<Boolean> hls5Active = notSet();
   private DefaultValue<String> protocol = notSet();
+  private DefaultValue<String> configLookupType = notSet();
   private DefaultValue<Long> invocationCounter = notSet();
   private DefaultValue<String> ipAddress = notSet();
   private DefaultValue<Boolean> ipAddressStatic = notSet();
@@ -43,7 +44,14 @@ public class DlmsDeviceBuilder {
     device.setCommunicationMethod(this.communicationMethod.orElse(null));
     device.setCommunicationProvider(this.communicationProvider.orElse(null));
     device.setVersion(this.version.orElse(0L));
+    device.setConfigLookupType(this.configLookupType.orElse(null));
     return device;
+  }
+
+  /** set the configLookupType that will be used to lookup values in the object config service. */
+  public DlmsDeviceBuilder withConfigLookupType(final String configLookupType) {
+    this.configLookupType = setTo(configLookupType);
+    return this;
   }
 
   public DlmsDeviceBuilder withDeviceIdentification(final String deviceIdentification) {

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/entities/DlmsDeviceTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/entities/DlmsDeviceTest.java
@@ -8,9 +8,34 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
-public class DlmsDeviceTest {
+class DlmsDeviceTest {
+
   @Test
-  public void returnsIfDeviceNeedsInvocationCounter() {
+  void isAbleToSetAObjectConfigLookupType() {
+    assertThat(
+            new DlmsDeviceBuilder()
+                .withHls5Active(true)
+                .withProtocol("SMR")
+                .withConfigLookupType("DUMMY")
+                .build()
+                .getConfigLookupType())
+        .isEqualTo("DUMMY");
+  }
+
+  @Test
+  void isAbleToUnSetAObjectConfigLookupType() {
+    assertThat(
+            new DlmsDeviceBuilder()
+                .withHls5Active(true)
+                .withProtocol("SMR")
+                .withConfigLookupType(null)
+                .build()
+                .getConfigLookupType())
+        .isNull();
+  }
+
+  @Test
+  void returnsIfDeviceNeedsInvocationCounter() {
     assertThat(
             new DlmsDeviceBuilder()
                 .withHls5Active(true)

--- a/osgp/shared/osgp-ws-smartmetering/src/main/resources/schemas/installation-ws-smartmetering.xsd
+++ b/osgp/shared/osgp-ws-smartmetering/src/main/resources/schemas/installation-ws-smartmetering.xsd
@@ -384,7 +384,14 @@
         minOccurs="0" />
       <xsd:element name="ChallengeLength" type="xsd:int" />
       <xsd:element name="Port" type="xsd:long" minOccurs="0" maxOccurs="1"  />
-
+      <xsd:element name="ConfigLookupType"
+        minOccurs="0">
+        <xsd:simpleType>
+          <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="255" />
+          </xsd:restriction>
+        </xsd:simpleType>
+      </xsd:element>
     </xsd:sequence>
   </xsd:complexType>
 


### PR DESCRIPTION
Add a type of meter to the dlms-device so that we can use this type to lookup specific config values from the new dlms object config service. For now it's used to type G-meters for size of connection: e.g.: G4, G6, G10, G16, G25.