### PR TITLE
SMHE-1819: restore LLS0 test for simulator on port 1025

### DIFF
--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/ConnectionSecurity.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/ConnectionSecurity.feature
@@ -26,8 +26,6 @@ Feature: SmartMetering Connection security
       | DeviceIdentification | TEST1026000000001 |
 
   # Needs a DlmsDevice simulator with security level 0 on port 1025
-  # TODO solve Jenkins build image problem with port 1025
-  @Skip
   Scenario: Communicate with LLS0 with simulator supporting unencrypted communication
     Given a dlms device
       | DeviceIdentification | TEST1025000000001 |


### PR DESCRIPTION
Restore the LLS0 test for the simulator on port 1025