### PR TITLE
When firmware file is not available device connection is not required.

### DIFF
--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/DeviceRequestMessageProcessor.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/DeviceRequestMessageProcessor.java
@@ -91,7 +91,7 @@ public abstract class DeviceRequestMessageProcessor extends DlmsConnectionMessag
       } else {
         device = null;
       }
-      if (this.usesDeviceConnection()) {
+      if (this.usesDeviceConnection(messageObject)) {
         /*
          * Set up a consumer to be called back with a DlmsConnectionManager for which the connection
          * with the device has been created. Note that when usesDeviceConnection is true, in this
@@ -249,7 +249,7 @@ public abstract class DeviceRequestMessageProcessor extends DlmsConnectionMessag
    *
    * @return Use device connection in handleMessage.
    */
-  protected boolean usesDeviceConnection() {
+  protected boolean usesDeviceConnection(final Serializable messageObject) {
     return true;
   }
 

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/processors/AddMeterRequestMessageProcessor.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/processors/AddMeterRequestMessageProcessor.java
@@ -26,7 +26,7 @@ public class AddMeterRequestMessageProcessor extends DeviceRequestMessageProcess
   }
 
   @Override
-  protected boolean usesDeviceConnection() {
+  protected boolean usesDeviceConnection(final Serializable messageObject) {
     return false;
   }
 

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/processors/DisableDebuggingRequestMessageProcessor.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/processors/DisableDebuggingRequestMessageProcessor.java
@@ -24,7 +24,7 @@ public class DisableDebuggingRequestMessageProcessor extends DeviceRequestMessag
   }
 
   @Override
-  protected boolean usesDeviceConnection() {
+  protected boolean usesDeviceConnection(final Serializable messageObject) {
     return false;
   }
 

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/processors/EnableDebuggingRequestMessageProcessor.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/processors/EnableDebuggingRequestMessageProcessor.java
@@ -24,7 +24,7 @@ public class EnableDebuggingRequestMessageProcessor extends DeviceRequestMessage
   }
 
   @Override
-  protected boolean usesDeviceConnection() {
+  protected boolean usesDeviceConnection(final Serializable messageObject) {
     return false;
   }
 

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/processors/GetKeysRequestMessageProcessor.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/processors/GetKeysRequestMessageProcessor.java
@@ -25,7 +25,7 @@ public class GetKeysRequestMessageProcessor extends DeviceRequestMessageProcesso
   }
 
   @Override
-  protected boolean usesDeviceConnection() {
+  protected boolean usesDeviceConnection(final Serializable messageObject) {
     return false;
   }
 

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/processors/SetDeviceCommunicationSettingsRequestMessageProcessor.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/processors/SetDeviceCommunicationSettingsRequestMessageProcessor.java
@@ -26,7 +26,7 @@ public class SetDeviceCommunicationSettingsRequestMessageProcessor
   }
 
   @Override
-  protected boolean usesDeviceConnection() {
+  protected boolean usesDeviceConnection(final Serializable messageObject) {
     return false;
   }
 

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/processors/UpdateFirmwareRequestMessageProcessor.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/processors/UpdateFirmwareRequestMessageProcessor.java
@@ -38,6 +38,23 @@ public class UpdateFirmwareRequestMessageProcessor extends DeviceRequestMessageP
   }
 
   @Override
+  protected boolean usesDeviceConnection(final Serializable messageObject) {
+    if (messageObject instanceof final UpdateFirmwareRequestDto requestDto) {
+      final String firmwareIdentification = requestDto.getFirmwareIdentification();
+      final boolean usesDeviceConnection =
+          this.firmwareService.isFirmwareFileAvailable(firmwareIdentification);
+      if (!usesDeviceConnection) {
+        LOGGER.info(
+            "Firmware file [{}] not available for device {}. So no device connection required for sending GetFirmwareFile request to core.",
+            firmwareIdentification,
+            requestDto.getDeviceIdentification());
+      }
+      return usesDeviceConnection;
+    }
+    return super.usesDeviceConnection(messageObject);
+  }
+
+  @Override
   protected Serializable handleMessage(
       final DlmsConnectionManager conn,
       final DlmsDevice device,

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/processors/UpdateProtocolRequestMessageProcessor.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/processors/UpdateProtocolRequestMessageProcessor.java
@@ -25,7 +25,7 @@ public class UpdateProtocolRequestMessageProcessor extends DeviceRequestMessageP
   }
 
   @Override
-  protected boolean usesDeviceConnection() {
+  protected boolean usesDeviceConnection(final Serializable messageObject) {
     return false;
   }
 

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/processors/UpdateFirmwareRequestMessageProcessorTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/processors/UpdateFirmwareRequestMessageProcessorTest.java
@@ -4,6 +4,7 @@
 
 package org.opensmartgridplatform.adapter.protocol.dlms.infra.messaging.processors;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.ArgumentMatchers.same;
@@ -19,6 +20,8 @@ import javax.jms.ObjectMessage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -200,5 +203,20 @@ class UpdateFirmwareRequestMessageProcessorTest {
             same(this.device),
             same(updateFirmwareRequestDto),
             any(MessageMetadata.class));
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void testUsesDeviceConnection(final boolean isFirmwareFileAvailable) {
+    final String firmwareIdentification = "unavailable";
+    final String deviceIdentification = "unavailableEither";
+    final UpdateFirmwareRequestDto updateFirmwareRequestDto =
+        new UpdateFirmwareRequestDto(firmwareIdentification, deviceIdentification);
+
+    when(this.firmwareService.isFirmwareFileAvailable(firmwareIdentification))
+        .thenReturn(isFirmwareFileAvailable);
+
+    assertThat(this.processor.usesDeviceConnection(updateFirmwareRequestDto))
+        .isEqualTo(isFirmwareFileAvailable);
   }
 }


### PR DESCRIPTION
When firmware file is not available device connection is not required, because then first the firmware file needs to be retrieved form osgp-core. When a device connection is not required, there will not be send a SMS for devices without static ip-address (GPRS).