### PR TITLE
SMHE-1613: correct mapping to the unknown gas meter type for G4/G6/G1…

### DIFF
--- a/osgp/protocol-adapter-dlms/osgp-dlms/src/main/resources/dlmsprofiles/configlookup.json
+++ b/osgp/protocol-adapter-dlms/osgp-dlms/src/main/resources/dlmsprofiles/configlookup.json
@@ -20,7 +20,8 @@
       {
         "type": "unknown gas meter type",
         "match": [
-          "Pre-NTA"
+          "elster-instromet",
+          "flonidan-gasmeter"
         ]
       }
     ],


### PR DESCRIPTION
correct mapping to the unknown gas meter type for G4/G6/G16/G25 meters and replace Pre-NTA with  elster-instromet and flonidan-gasmeter