### PR TITLE
SMHE-1602: improve CombinedDeviceModelCode

### DIFF
--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/valueobjects/CombinedDeviceModelCodeTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/valueobjects/CombinedDeviceModelCodeTest.java
@@ -6,9 +6,10 @@ package org.opensmartgridplatform.adapter.protocol.dlms.domain.valueobjects;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.valueobjects.CombinedDeviceModelCode.CombinedDeviceModelCodeBuilder;
 
@@ -43,11 +44,26 @@ class CombinedDeviceModelCodeTest {
   }
 
   @Test
-  void parseShouldReturnEmptyCombinedDeviceModelCode() {
-    final CombinedDeviceModelCode combinedDeviceModelCode =
-        CombinedDeviceModelCode.parse("invalid");
+  void parseShouldGetEmptyResponse() {
 
-    Assertions.assertEquals("", combinedDeviceModelCode.getGatewayDeviceModelCode());
+    final CombinedDeviceModelCode combinedDeviceModelCode = CombinedDeviceModelCode.parse(",,,,");
+
+    assertNull(combinedDeviceModelCode.getGatewayDeviceModelCode());
+    assertNull(combinedDeviceModelCode.getCodeFromChannel(1));
+    assertNull(combinedDeviceModelCode.getCodeFromChannel(2));
+    assertNull(combinedDeviceModelCode.getCodeFromChannel(3));
+    assertNull(combinedDeviceModelCode.getCodeFromChannel(4));
+  }
+
+  @ParameterizedTest
+  @CsvSource(
+      value = {"invalid", ",", ",,", ",,,", ",,,,", ",,,,,"},
+      delimiterString = ";")
+  void parseShouldReturnEmptyCombinedDeviceModelCode(final String noCombinedDeviceModelCode) {
+    final CombinedDeviceModelCode combinedDeviceModelCode =
+        CombinedDeviceModelCode.parse(noCombinedDeviceModelCode);
+
+    assertNull(combinedDeviceModelCode.getGatewayDeviceModelCode());
     assertNull(combinedDeviceModelCode.getCodeFromChannel(1));
     assertNull(combinedDeviceModelCode.getCodeFromChannel(2));
     assertNull(combinedDeviceModelCode.getCodeFromChannel(3));


### PR DESCRIPTION
Fix a problem when there is no device model code for the gateway device when the format of the combined device model code is correct. Added a validation that the device model codes has at least content before parsing the combined device model codes. 