### PR TITLE
SMHE-1766: exclude G4SRT 1.2L for scale mapping from object config pr…

### DIFF
--- a/osgp/protocol-adapter-dlms/osgp-dlms/src/main/resources/dlmsprofiles/configlookup.json
+++ b/osgp/protocol-adapter-dlms/osgp-dlms/src/main/resources/dlmsprofiles/configlookup.json
@@ -21,7 +21,8 @@
         "type": "unknown gas meter type",
         "match": [
           "elster-instromet",
-          "flonidan-gasmeter"
+          "flonidan-gasmeter",
+          "G4SRT 1.2L"
         ]
       }
     ],


### PR DESCRIPTION
Exclude G4SRT 1.2L for scale mapping from object config profile. So read the incorrect scale from the meter with faulty firmware.