### PR TITLE
SMHE-1622: Set parallel_requests_allowed to false

### DIFF
--- a/osgp/platform/osgp-core/src/main/resources/db/migration/V20231116104345421__Set_parallel_requests_allowed_to_false.sql
+++ b/osgp/platform/osgp-core/src/main/resources/db/migration/V20231116104345421__Set_parallel_requests_allowed_to_false.sql
@@ -1,0 +1,8 @@
+DO
+$$
+BEGIN
+
+    UPDATE protocol_info SET parallel_requests_allowed = false WHERE protocol = 'DSMR' OR protocol = 'SMR';
+
+END;
+$$


### PR DESCRIPTION
When an operation takes a long time (for example a firmware update), it was possible that it was interrupted by a new connection for another operation. This causes problems for meters that can handle only one connection simultaneously, as is the case for (D)SMR meters. This is solved by setting the `parallel_requests_allowed` option to false.