### PR TITLE
Upgrade activemq version to patch security issue

### DIFF
--- a/super/pom.xml
+++ b/super/pom.xml
@@ -101,7 +101,7 @@ SPDX-License-Identifier: Apache-2.0
     <dependency-check.maven.plugin.version>7.0.2</dependency-check.maven.plugin.version>
     <versions.maven.plugin.version>2.10.0</versions.maven.plugin.version>
     <fmt-maven-plugin.version>2.19</fmt-maven-plugin.version>
-    <apache.activemq.version>5.17.6</apache.activemq.version>
+    <apache.activemq.version>5.18.3</apache.activemq.version>
     <logback.version>1.2.11</logback.version>
     <apache.commons.schema>2.2.5</apache.commons.schema>
     <maven.clean.plugin.version>3.1.0</maven.clean.plugin.version>

--- a/super/pom.xml
+++ b/super/pom.xml
@@ -101,7 +101,7 @@ SPDX-License-Identifier: Apache-2.0
     <dependency-check.maven.plugin.version>7.0.2</dependency-check.maven.plugin.version>
     <versions.maven.plugin.version>2.10.0</versions.maven.plugin.version>
     <fmt-maven-plugin.version>2.19</fmt-maven-plugin.version>
-    <apache.activemq.version>5.17.2</apache.activemq.version>
+    <apache.activemq.version>5.17.6</apache.activemq.version>
     <logback.version>1.2.11</logback.version>
     <apache.commons.schema>2.2.5</apache.commons.schema>
     <maven.clean.plugin.version>3.1.0</maven.clean.plugin.version>


### PR DESCRIPTION
Upgrade activemq version to patch security issue: https://activemq.apache.org/news/cve-2023-46604

The Java OpenWire protocol marshaller is vulnerable to Remote Code Execution. This vulnerability may allow a remote attacker with network access to either a Java-based OpenWire broker or client to run arbitrary shell commands by manipulating serialized class types in the OpenWire protocol to cause either the client or the broker (respectively) to instantiate any class on the classpath.