### PR TITLE
Max wait for default

### DIFF
--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/resources/osgp-adapter-protocol-dlms.properties
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/resources/osgp-adapter-protocol-dlms.properties
@@ -194,7 +194,7 @@ throttling.rejected.max.delay=PT70S
 throttling.rejected.high.prio.delay=PT2S
 # Configuration for the throttling service on the GPRS network
 throttling.max.open.connections=1000
-throttling.max.wait.high.prio=10000
+throttling.max.wait.for.permit=60000
 throttling.max.new.connection.reset.time=1000
 throttling.max.new.connection.requests=30
 


### PR DESCRIPTION
Connections should always wait for a permit, also for low prio requests.
There needs something to be implemented for high prio throttling