### PR TITLE
Bundle requests for G-meter devices without a gateway device are not …

### DIFF
--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/functional/exceptions/FunctionalExceptionsSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/functional/exceptions/FunctionalExceptionsSteps.java
@@ -10,6 +10,7 @@ import io.cucumber.java.Before;
 import io.cucumber.java.Scenario;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
+import java.util.HashMap;
 import java.util.Map;
 import org.opensmartgridplatform.adapter.ws.schema.smartmetering.adhoc.GetSpecificAttributeValueAsyncRequest;
 import org.opensmartgridplatform.adapter.ws.schema.smartmetering.adhoc.GetSpecificAttributeValueAsyncResponse;
@@ -237,5 +238,10 @@ public class FunctionalExceptionsSteps {
     } catch (final Exception exception) {
       ScenarioContext.current().put(PlatformKeys.RESPONSE, exception);
     }
+  }
+
+  @When("^the bundle request generating an error is received$")
+  public void theBundleRequestGeneratingAnErrorIsReceived() throws Throwable {
+    this.theBundleRequestGeneratingAnErrorIsReceivedWithHeaders(new HashMap<>());
   }
 }

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/bundle/BundledGetActualMeterReads.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/bundle/BundledGetActualMeterReads.feature
@@ -94,3 +94,36 @@ Feature: SmartMetering Bundle - GetActualMeterReads
       | Message      | VALIDATION_ERROR                                      |
       | InnerMessage | Meter for gas reads should have a channel configured. |
 
+  Scenario: Get actual meter reads of a G device without a gateway device
+    Given a dlms device
+      | DeviceIdentification        | TESTG102400000001 |
+      | DeviceType                  | SMART_METER_G     |
+      | Channel                     |                 1 |
+    And a bundle request
+      | DeviceIdentification | TESTG102400000001 |
+    And the bundle request contains a get actual meter reads gas action
+      | DeviceIdentification | TESTG102400000001 |
+    When the bundle request is received
+    When the bundle request generating an error is received
+    Then a SOAP fault should have been returned
+      | Code         |                                         401 |
+      | Message      | VALIDATION_ERROR                            |
+      | Component    | DOMAIN_SMART_METERING                       |
+      | InnerMessage | Bundle request is not allowed for gas meter |
+
+  Scenario: Get actual meter reads of a G device without a gateway device and bundle device is E meter
+    Given a dlms device
+      | DeviceIdentification | TEST1024000000001 |
+      | DeviceType           | SMART_METER_E     |
+    And a dlms device
+      | DeviceIdentification        | TESTG102400000001 |
+      | DeviceType                  | SMART_METER_G     |
+      | Channel                     |                 1 |
+    And a bundle request
+      | DeviceIdentification | TEST1024000000001 |
+    And the bundle request contains a get actual meter reads gas action
+      | DeviceIdentification | TESTG102400000001 |
+    When the bundle request is received
+    Then the bundle response should contain a fault response
+      | Message      | VALIDATION_ERROR                                                   |
+      | InnerMessage | Meter for gas reads should have an energy meter as gateway device. |


### PR DESCRIPTION
SMHE-1767: Bundle requests for G-meter devices without a gateway device are not allowed.
Do not send requests to the protocol-adapter but fail with a FunctionalException