### PR TITLE
SMHE-1839 Voorkomen foutmelding mbus key uitlezing bij key-status gas…

### DIFF
--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/GetMbusEncryptionKeyStatusByChannelSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/GetMbusEncryptionKeyStatusByChannelSteps.java
@@ -66,8 +66,9 @@ public class GetMbusEncryptionKeyStatusByChannelSteps {
     final GetMbusEncryptionKeyStatusByChannelResponse response =
         this.smartMeterConfigurationClient.retrieveGetMbusEncryptionKeyStatusByChannelResponse(
             asyncRequest);
-    final EncryptionKeyStatus expectedEncryptionKeyStatus = EncryptionKeyStatus.valueOf(
-        settings.get(PlatformSmartmeteringKeys.KEY_DEVICE_ENCRYPTION_KEY_STATUS));
+    final EncryptionKeyStatus expectedEncryptionKeyStatus =
+        EncryptionKeyStatus.valueOf(
+            settings.get(PlatformSmartmeteringKeys.KEY_DEVICE_ENCRYPTION_KEY_STATUS));
 
     assertThat(response.getResult())
         .as(OPERATION + ", Checking result:")

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/GetMbusEncryptionKeyStatusByChannelSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/GetMbusEncryptionKeyStatusByChannelSteps.java
@@ -66,13 +66,15 @@ public class GetMbusEncryptionKeyStatusByChannelSteps {
     final GetMbusEncryptionKeyStatusByChannelResponse response =
         this.smartMeterConfigurationClient.retrieveGetMbusEncryptionKeyStatusByChannelResponse(
             asyncRequest);
+    final EncryptionKeyStatus expectedEncryptionKeyStatus = EncryptionKeyStatus.valueOf(
+        settings.get(PlatformSmartmeteringKeys.KEY_DEVICE_ENCRYPTION_KEY_STATUS));
 
     assertThat(response.getResult())
         .as(OPERATION + ", Checking result:")
         .isEqualTo(OsgpResultType.OK);
     assertThat(response.getEncryptionKeyStatus())
         .as(OPERATION + ", Checking EncryptionKeyStatus:")
-        .isEqualTo(EncryptionKeyStatus.ENCRYPTION_KEY_IN_USE);
+        .isEqualTo(expectedEncryptionKeyStatus);
   }
 
   @Then("^the get M-Bus encryption key status by channel request should return an exception$")

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/configuration/GetMbusEncryptionKeyStatusByChannel.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/configuration/GetMbusEncryptionKeyStatusByChannel.feature
@@ -50,7 +50,49 @@ Feature: SmartMetering - Configuration - M-Bus encryption key status by channel
     When a get M-Bus encryption key status by channel request is received
       | DeviceIdentification | TEST1024000000001 |
       | Channel              |                 1 |
-    Then the get M-Bus encryption key status request should return an exception
-    And a SOAP fault should have been returned
-      | Code    |                        219 |
-      | Message | NO_DEVICE_FOUND_ON_CHANNEL |
+    Then the get M-Bus encryption key status by channel response is returned
+      | DeviceIdentification | TEST1024000000001     |
+      | Channel              |                     1 |
+      | EncryptionKeyStatus  | NO_ENCRYPTION_KEY     |
+
+  Scenario: Get M-Bus encryption key status from coupled M-Bus device by using Channel id and Gateway device id
+    Given a dlms device
+      | DeviceIdentification | TEST1024000000001 |
+      | DeviceType           | SMART_METER_E     |
+    And a dlms device
+      | DeviceIdentification           | TESTG101205673101 |
+      | DeviceType                     | SMART_METER_G     |
+      | GatewayDeviceIdentification    | TEST1024000000001 |
+      | Channel                        |                 1 |
+      | MbusIdentificationNumber       |          12056731 |
+      | MbusManufacturerIdentification | LGB               |
+      | MbusVersion                    |                66 |
+      | MbusDeviceTypeIdentification   |                 3 |
+    And device simulation of "TEST1024000000001" with M-Bus client version 0 values for channel 1
+      | MbusPrimaryAddress             | 9        |
+      | MbusIdentificationNumber       | 12056731 |
+      | MbusManufacturerIdentification | LGB      |
+      | MbusVersion                    | 66       |
+      | MbusDeviceTypeIdentification   | 3        |
+      | MbusEncryptionKeyStatus        | 4        |
+    And device simulation of "TEST1024000000001" with M-Bus client version 0 values for channel 2
+      | MbusPrimaryAddress             | 0 |
+      | MbusIdentificationNumber       | 0 |
+      | MbusManufacturerIdentification | 0 |
+      | MbusVersion                    | 0 |
+      | MbusDeviceTypeIdentification   | 0 |
+      | MbusEncryptionKeyStatus        | 0 |
+    When a get M-Bus encryption key status by channel request is received
+      | DeviceIdentification | TEST1024000000001 |
+      | Channel              |                 1 |
+    Then the get M-Bus encryption key status by channel response is returned
+      | DeviceIdentification | TEST1024000000001     |
+      | Channel              |                     1 |
+      | EncryptionKeyStatus  | ENCRYPTION_KEY_IN_USE |
+    When a get M-Bus encryption key status by channel request is received
+      | DeviceIdentification | TEST1024000000001 |
+      | Channel              |                 2 |
+    Then the get M-Bus encryption key status by channel response is returned
+      | DeviceIdentification | TEST1024000000001     |
+      | Channel              |                     2 |
+      | EncryptionKeyStatus  | NO_ENCRYPTION_KEY     |

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/configuration/GetMbusEncryptionKeyStatusByChannel.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/configuration/GetMbusEncryptionKeyStatusByChannel.feature
@@ -55,7 +55,7 @@ Feature: SmartMetering - Configuration - M-Bus encryption key status by channel
       | Channel              |                     1 |
       | EncryptionKeyStatus  | NO_ENCRYPTION_KEY     |
 
-  Scenario: Get M-Bus encryption key status from coupled M-Bus device by using Channel id and Gateway device id
+  Scenario: Get M-Bus encryption key status from coupled M-Bus device with multiple channels and one channel is empty
     Given a dlms device
       | DeviceIdentification | TEST1024000000001 |
       | DeviceType           | SMART_METER_E     |

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/mbus/GetMbusEncryptionKeyStatusByChannelCommandExecutor.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/mbus/GetMbusEncryptionKeyStatusByChannelCommandExecutor.java
@@ -12,9 +12,6 @@ import org.opensmartgridplatform.dto.valueobjects.smartmetering.EncryptionKeySta
 import org.opensmartgridplatform.dto.valueobjects.smartmetering.GetMBusDeviceOnChannelRequestDataDto;
 import org.opensmartgridplatform.dto.valueobjects.smartmetering.GetMbusEncryptionKeyStatusByChannelRequestDataDto;
 import org.opensmartgridplatform.dto.valueobjects.smartmetering.GetMbusEncryptionKeyStatusByChannelResponseDto;
-import org.opensmartgridplatform.shared.exceptionhandling.ComponentType;
-import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
-import org.opensmartgridplatform.shared.exceptionhandling.FunctionalExceptionType;
 import org.opensmartgridplatform.shared.exceptionhandling.OsgpException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -53,8 +50,10 @@ public class GetMbusEncryptionKeyStatusByChannelCommandExecutor
     if (!channelElementValues.hasChannel()
         || !channelElementValues.hasDeviceTypeIdentification()
         || !channelElementValues.hasManufacturerIdentification()) {
-      throw new FunctionalException(
-          FunctionalExceptionType.NO_DEVICE_FOUND_ON_CHANNEL, ComponentType.DOMAIN_SMART_METERING);
+      return new GetMbusEncryptionKeyStatusByChannelResponseDto(
+          device.getDeviceIdentification(),
+          EncryptionKeyStatusTypeDto.NO_ENCRYPTION_KEY,
+          request.getChannel());
     }
 
     final EncryptionKeyStatusTypeDto encryptionKeyStatusType =


### PR DESCRIPTION
…meter.

do not throw exception in case of empty channel

- return EncryptionKeyStatusTypeDto.NO_ENCRYPTION_KEY
- update GetMbusEncryptionKeyStatusByChannel.feature

https://jenkins.fdp.osgp.cloud/view/SMHE-cucumber/job/gxf-smhe-cucumber-build/194/