### PR TITLE
Feature/scheduled task has no devicemodelcode

### DIFF
--- a/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/application/tasks/ScheduledTaskExecutorService.java
+++ b/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/application/tasks/ScheduledTaskExecutorService.java
@@ -172,6 +172,7 @@ public class ScheduledTaskExecutorService {
         .withNetworkAddress(getIpAddress(device))
         .withNetworkSegmentIds(device.getBtsId(), device.getCellId())
         .withMessagePriority(scheduledTask.getMessagePriority())
+        .withDeviceModelCode(scheduledTask.getDeviceModelCode())
         .withScheduled(true)
         .withMaxScheduleTime(
             scheduledTask.getMaxScheduleTime() == null

--- a/osgp/platform/osgp-core/src/main/resources/db/migration/V20240213105843728__Added_device_model_code_to_scheduled_task.sql
+++ b/osgp/platform/osgp-core/src/main/resources/db/migration/V20240213105843728__Added_device_model_code_to_scheduled_task.sql
@@ -1,0 +1,13 @@
+DO
+$$
+BEGIN
+    IF NOT EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE TABLE_SCHEMA = current_schema AND TABLE_NAME = 'scheduled_task' AND COLUMN_NAME = 'device_model_code')
+    THEN
+        ALTER TABLE scheduled_task ADD COLUMN device_model_code VARCHAR(1279);
+    END IF;
+
+    COMMENT ON COLUMN scheduled_task.device_model_code IS 'comma separated list of devicemodel codes. First modelcode is the gateway device and subsequently the mbus devicess on channel 1 to 4 (size:(5*255)+4)';
+END;
+$$

--- a/osgp/platform/osgp-domain-core/src/main/java/org/opensmartgridplatform/domain/core/entities/AbstractScheduledTask.java
+++ b/osgp/platform/osgp-domain-core/src/main/java/org/opensmartgridplatform/domain/core/entities/AbstractScheduledTask.java
@@ -57,6 +57,9 @@ public abstract class AbstractScheduledTask extends AbstractEntity {
   @Column(name = "retry")
   protected int retry;
 
+  @Column(name = "device_model_code", length = 1279)
+  protected String deviceModelCode;
+
   AbstractScheduledTask() {
     // Default empty constructor for Hibernate.
   }
@@ -73,6 +76,7 @@ public abstract class AbstractScheduledTask extends AbstractEntity {
     this.deviceIdentification = messageMetadata.getDeviceIdentification();
     this.messageType = messageMetadata.getMessageType();
     this.messagePriority = messageMetadata.getMessagePriority();
+    this.deviceModelCode = messageMetadata.getDeviceModelCode();
     this.domain = domain;
     this.domainVersion = domainVersion;
     this.scheduledTime = (Timestamp) scheduledTime.clone();
@@ -103,6 +107,10 @@ public abstract class AbstractScheduledTask extends AbstractEntity {
 
   public String getDeviceIdentification() {
     return this.deviceIdentification;
+  }
+
+  public String getDeviceModelCode() {
+    return this.deviceModelCode;
   }
 
   public String getErrorLog() {

--- a/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/infra/jms/ProtocolResponseMessage.java
+++ b/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/infra/jms/ProtocolResponseMessage.java
@@ -97,6 +97,11 @@ public class ProtocolResponseMessage extends ResponseMessage {
       return this;
     }
 
+    public Builder deviceModelCode(final String deviceModelCode) {
+      this.superBuilder.withDeviceModelCode(deviceModelCode);
+      return this;
+    }
+
     public Builder retryCount(final int retryCount) {
       this.retryCount = retryCount;
       return this;

--- a/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/infra/jms/ResponseMessage.java
+++ b/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/infra/jms/ResponseMessage.java
@@ -24,6 +24,7 @@ public class ResponseMessage implements Serializable {
   private final int messagePriority;
   private final boolean scheduled;
   private final Long maxScheduleTime;
+  private final String deviceModelCode;
   private final boolean bypassRetry;
 
   private final RetryHeader retryHeader;
@@ -42,6 +43,7 @@ public class ResponseMessage implements Serializable {
     this.messagePriority = builder.messagePriority;
     this.scheduled = builder.scheduled;
     this.maxScheduleTime = builder.maxScheduleTime;
+    this.deviceModelCode = builder.deviceModelCode;
     this.bypassRetry = builder.bypassRetry;
     this.retryHeader = builder.retryHeader;
     this.result = builder.result;
@@ -85,6 +87,7 @@ public class ResponseMessage implements Serializable {
         .withMessagePriority(this.messagePriority)
         .withScheduled(this.scheduled)
         .withMaxScheduleTime(this.maxScheduleTime)
+        .withDeviceModelCode(this.deviceModelCode)
         .withBypassRetry(this.bypassRetry)
         .withTopic(this.topic)
         .build();
@@ -106,6 +109,7 @@ public class ResponseMessage implements Serializable {
     private int messagePriority = MessagePriorityEnum.DEFAULT.getPriority();
     private boolean scheduled = false;
     private Long maxScheduleTime = null;
+    private String deviceModelCode = null;
     private boolean bypassRetry = DEFAULT_BYPASS_RETRY;
     private RetryHeader retryHeader;
     private String topic = null;
@@ -172,6 +176,11 @@ public class ResponseMessage implements Serializable {
       return this;
     }
 
+    public Builder withDeviceModelCode(final String deviceModelCode) {
+      this.deviceModelCode = deviceModelCode;
+      return this;
+    }
+
     public Builder withRetryHeader(final RetryHeader retryHeader) {
       this.retryHeader = retryHeader;
       return this;
@@ -190,6 +199,7 @@ public class ResponseMessage implements Serializable {
       this.messagePriority = messageMetadata.getMessagePriority();
       this.scheduled = messageMetadata.isScheduled();
       this.maxScheduleTime = messageMetadata.getMaxScheduleTime();
+      this.deviceModelCode = messageMetadata.getDeviceModelCode();
       this.bypassRetry = messageMetadata.isBypassRetry();
       this.retryHeader = new RetryHeader();
       this.topic = messageMetadata.getTopic();


### PR DESCRIPTION
Metadata of the requestmessage in retry was missing devicemodelcode which is needed for some requests.
devicemodelcode is now stored in the scheduled task in core database.