### PR TITLE
SMHE-1841: Make get/set WithList more efficient

### DIFF
--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/PlatformSmartmeteringDefaults.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/PlatformSmartmeteringDefaults.java
@@ -95,7 +95,7 @@ public class PlatformSmartmeteringDefaults
   public static final Instant TECHNICAL_INSTALLATION_DATE = Instant.now();
   public static final Date VALID_TO = null;
   public static final Long VERSION = 0L;
-  public static final boolean WITH_LIST_SUPPORTED = false;
+  public static final Integer WITH_LIST_MAX = 32;
 
   public static final String DAYLIGHT_SAVINGS_BEGIN = "FFFF03FE0702000000FFC400";
   public static final String DAYLIGHT_SAVINGS_END = "FFFF0AFE0703000000FF8880";

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/PlatformSmartmeteringKeys.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/PlatformSmartmeteringKeys.java
@@ -95,7 +95,7 @@ public class PlatformSmartmeteringKeys
   public static final String TECHNICAL_INSTALLATION_DATE = "TechnicalInstallationDate";
   public static final String VALID_FROM = "ValidFrom";
   public static final String VERSION = "Version";
-  public static final String WITH_LIST_SUPPORTED = "WithListSupported";
+  public static final String WITH_LIST_MAX = "WithListMax";
   public static final String MODULE_ACTIVE_FIRMWARE_VERSION = "ModuleActiveFirmwareVersion";
 
   public static final String DAYLIGHT_SAVINGS_BEGIN = "DaylightSavingsBegin";

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/builders/entities/DlmsDeviceBuilder.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/builders/entities/DlmsDeviceBuilder.java
@@ -29,7 +29,7 @@ public class DlmsDeviceBuilder implements CucumberBuilder<DlmsDevice> {
   private boolean useHdlc = PlatformSmartmeteringDefaults.USE_HDLC;
   private boolean polyphase = PlatformSmartmeteringDefaults.POLYPHASE;
   private Integer challengeLength = PlatformSmartmeteringDefaults.CHALLENGE_LENGTH;
-  private boolean withListSupported = PlatformSmartmeteringDefaults.WITH_LIST_SUPPORTED;
+  private Integer withListMax = PlatformSmartmeteringDefaults.WITH_LIST_MAX;
   private boolean selectiveAccessSupported =
       PlatformSmartmeteringDefaults.SELECTIVE_ACCESS_SUPPORTED;
   private boolean ipAddressIsStatic = PlatformSmartmeteringDefaults.IP_ADDRESS_IS_STATIC;
@@ -111,8 +111,8 @@ public class DlmsDeviceBuilder implements CucumberBuilder<DlmsDevice> {
     return this;
   }
 
-  public DlmsDeviceBuilder setWithListSupported(final boolean withListSupported) {
-    this.withListSupported = withListSupported;
+  public DlmsDeviceBuilder setWithListMax(final Integer withListMax) {
+    this.withListMax = withListMax;
     return this;
   }
 
@@ -222,9 +222,9 @@ public class DlmsDeviceBuilder implements CucumberBuilder<DlmsDevice> {
       this.setChallengeLength(
           Integer.parseInt(inputSettings.get(PlatformSmartmeteringKeys.CHALLENGE_LENGTH)));
     }
-    if (inputSettings.containsKey(PlatformSmartmeteringKeys.WITH_LIST_SUPPORTED)) {
-      this.setWithListSupported(
-          Boolean.parseBoolean(inputSettings.get(PlatformSmartmeteringKeys.WITH_LIST_SUPPORTED)));
+    if (inputSettings.containsKey(PlatformSmartmeteringKeys.WITH_LIST_MAX)) {
+      this.setWithListMax(
+          Integer.parseInt(inputSettings.get(PlatformSmartmeteringKeys.WITH_LIST_MAX)));
     }
     if (inputSettings.containsKey(PlatformSmartmeteringKeys.SELECTIVE_ACCESS_SUPPORTED)) {
       this.setSelectiveAccessSupported(
@@ -311,7 +311,7 @@ public class DlmsDeviceBuilder implements CucumberBuilder<DlmsDevice> {
     dlmsDevice.setUseSn(this.useSn);
     dlmsDevice.setPolyphase(this.polyphase);
     dlmsDevice.setChallengeLength(this.challengeLength);
-    dlmsDevice.setWithListSupported(this.withListSupported);
+    dlmsDevice.setWithListMax(this.withListMax);
     dlmsDevice.setSelectiveAccessSupported(this.selectiveAccessSupported);
     dlmsDevice.setIpAddressIsStatic(this.ipAddressIsStatic);
     dlmsDevice.setPort(this.port);

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringmanagement/SetDeviceCommunicationSettingsSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringmanagement/SetDeviceCommunicationSettingsSteps.java
@@ -83,18 +83,24 @@ public class SetDeviceCommunicationSettingsSteps {
     final DlmsDevice device =
         this.dlmsDeviceRepository.findByDeviceIdentification(deviceIdentification);
 
-    final int expectedResult =
+    final int expectedResultChallengeLength =
         getInteger(
             settings,
             PlatformSmartmeteringKeys.CHALLENGE_LENGTH,
             PlatformSmartmeteringDefaults.CHALLENGE_LENGTH);
 
+    final int expectedResultGetWithListMax =
+        getInteger(
+            settings,
+            PlatformSmartmeteringKeys.WITH_LIST_MAX,
+            PlatformSmartmeteringDefaults.WITH_LIST_MAX);
+
     assertThat(device.getChallengeLength().intValue())
         .as("Number of challenge length should match")
-        .isEqualTo(expectedResult);
-    assertThat(device.isWithListSupported())
-        .as("With list supported should match")
-        .isEqualTo(getBoolean(settings, PlatformSmartmeteringKeys.WITH_LIST_SUPPORTED));
+        .isEqualTo(expectedResultChallengeLength);
+    assertThat(device.getWithListMax().intValue())
+        .as("With list max should match")
+        .isEqualTo(expectedResultGetWithListMax);
     assertThat(device.isSelectiveAccessSupported())
         .as("Selective access supported should match")
         .isEqualTo(getBoolean(settings, PlatformSmartmeteringKeys.SELECTIVE_ACCESS_SUPPORTED));

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/support/ws/smartmetering/management/SetDeviceCommunicationSettingsRequestDataFactory.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/support/ws/smartmetering/management/SetDeviceCommunicationSettingsRequestDataFactory.java
@@ -22,11 +22,12 @@ public class SetDeviceCommunicationSettingsRequestDataFactory {
 
     setDeviceCommunicationSettingsData.setChallengeLength(
         BigInteger.valueOf(getInteger(parameters, PlatformSmartmeteringKeys.CHALLENGE_LENGTH)));
-    setDeviceCommunicationSettingsData.setWithListSupported(
-        getBoolean(
-            parameters,
-            PlatformSmartmeteringKeys.WITH_LIST_SUPPORTED,
-            PlatformSmartmeteringDefaults.WITH_LIST_SUPPORTED));
+    setDeviceCommunicationSettingsData.setWithListMax(
+        BigInteger.valueOf(
+            getInteger(
+                parameters,
+                PlatformSmartmeteringKeys.WITH_LIST_MAX,
+                PlatformSmartmeteringDefaults.WITH_LIST_MAX)));
     setDeviceCommunicationSettingsData.setSelectiveAccessSupported(
         getBoolean(
             parameters,

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/management/SetDeviceCommunicationSettings.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/management/SetDeviceCommunicationSettings.feature
@@ -13,7 +13,7 @@ Feature: SmartMetering Management - Set Device Communication Settings
       | DeviceIdentification     | TEST1024000000001 |
       | DeviceType               | SMART_METER_E     |
       | ChallengeLength          | 8                 |
-      | WithListSupported        | true              |
+      | WithListMax              | 32                |
       | SelectiveAccessSupported | true              |
       | IpAddressIsStatic        | true              |
       | UseSn                    | true              |
@@ -22,7 +22,7 @@ Feature: SmartMetering Management - Set Device Communication Settings
     When the set device communication settings request is received
       | DeviceIdentification     | TEST1024000000001 |
       | ChallengeLength          | 16                |
-      | WithListSupported        | false             |
+      | WithListMax              | 1                 |
       | SelectiveAccessSupported | false             |
       | IpAddressIsStatic        | false             |
       | UseSn                    | false             |
@@ -31,7 +31,7 @@ Feature: SmartMetering Management - Set Device Communication Settings
     Then the set device communication settings response should be "OK"
     And the device "TEST1024000000001" should be in the database with attributes
       | ChallengeLength          | 16    |
-      | WithListSupported        | false |
+      | WithListMax              | 1     |
       | SelectiveAccessSupported | false |
       | IpAddressIsStatic        | false |
       | UseSn                    | false |

--- a/osgp/platform/osgp-adapter-ws-smartmetering/src/test/java/org/opensmartgridplatform/adapter/ws/smartmetering/application/mapping/DeviceMappingTest.java
+++ b/osgp/platform/osgp-adapter-ws-smartmetering/src/test/java/org/opensmartgridplatform/adapter/ws/smartmetering/application/mapping/DeviceMappingTest.java
@@ -30,6 +30,7 @@ class DeviceMappingTest {
   private static final String SUPPLIER = "supplier1";
   private static final Long PORT = 3000L;
   private static final int CHALLENGE_LENGTH = 15;
+  private static final int WITH_LIST_MAX = 32;
   private static final boolean IS_ACTIVE = true;
   private static final boolean LLS1_ACTIVE = true;
 
@@ -62,7 +63,7 @@ class DeviceMappingTest {
     assertThat(smartMeteringDevice.isPolyphase()).isEqualTo(IS_ACTIVE);
     assertThat(smartMeteringDevice.isIpAddressIsStatic()).isEqualTo(IS_ACTIVE);
     assertThat(smartMeteringDevice.isSelectiveAccessSupported()).isEqualTo(IS_ACTIVE);
-    assertThat(smartMeteringDevice.isWithListSupported()).isEqualTo(IS_ACTIVE);
+    assertThat(smartMeteringDevice.getWithListMax()).isEqualTo(WITH_LIST_MAX);
     assertThat(smartMeteringDevice.getChallengeLength()).isEqualTo(CHALLENGE_LENGTH);
 
     // convert a Date object to a joda DateTime object, because the
@@ -136,7 +137,7 @@ class DeviceMappingTest {
     device.setChallengeLength(CHALLENGE_LENGTH);
     device.setIpAddressIsStatic(IS_ACTIVE);
     device.setSelectiveAccessSupported(IS_ACTIVE);
-    device.setWithListSupported(IS_ACTIVE);
+    device.setWithListMax(WITH_LIST_MAX);
     return device;
   }
 
@@ -165,7 +166,7 @@ class DeviceMappingTest {
     smartMeteringDevice.setPort(PORT);
     smartMeteringDevice.setChallengeLength(CHALLENGE_LENGTH);
     smartMeteringDevice.setIpAddressIsStatic(IS_ACTIVE);
-    smartMeteringDevice.setWithListSupported(IS_ACTIVE);
+    smartMeteringDevice.setWithListMax(WITH_LIST_MAX);
     smartMeteringDevice.setSelectiveAccessSupported(IS_ACTIVE);
 
     return smartMeteringDevice;

--- a/osgp/platform/osgp-domain-core/src/main/java/org/opensmartgridplatform/domain/core/valueobjects/smartmetering/SetDeviceCommunicationSettingsData.java
+++ b/osgp/platform/osgp-domain-core/src/main/java/org/opensmartgridplatform/domain/core/valueobjects/smartmetering/SetDeviceCommunicationSettingsData.java
@@ -13,7 +13,7 @@ public class SetDeviceCommunicationSettingsData implements Serializable, ActionR
   private static final long serialVersionUID = -6825967173128763377L;
 
   private final int challengeLength;
-  private final boolean withListSupported;
+  private final int withListMax;
   private final boolean selectiveAccessSupported;
   private final boolean ipAddressIsStatic;
   private final boolean useSn;
@@ -22,14 +22,14 @@ public class SetDeviceCommunicationSettingsData implements Serializable, ActionR
 
   public SetDeviceCommunicationSettingsData(
       final int challengeLength,
-      final boolean withListSupported,
+      final int withListMax,
       final boolean selectiveAccessSupported,
       final boolean ipAddressIsStatic,
       final boolean useSn,
       final boolean useHdlc,
       final boolean polyphase) {
     this.challengeLength = challengeLength;
-    this.withListSupported = withListSupported;
+    this.withListMax = withListMax;
     this.selectiveAccessSupported = selectiveAccessSupported;
     this.ipAddressIsStatic = ipAddressIsStatic;
     this.useSn = useSn;
@@ -41,8 +41,8 @@ public class SetDeviceCommunicationSettingsData implements Serializable, ActionR
     return this.challengeLength;
   }
 
-  public boolean isWithListSupported() {
-    return this.withListSupported;
+  public int getWithListMax() {
+    return this.withListMax;
   }
 
   public boolean isSelectiveAccessSupported() {

--- a/osgp/platform/osgp-domain-core/src/main/java/org/opensmartgridplatform/domain/core/valueobjects/smartmetering/SmartMeteringDevice.java
+++ b/osgp/platform/osgp-domain-core/src/main/java/org/opensmartgridplatform/domain/core/valueobjects/smartmetering/SmartMeteringDevice.java
@@ -63,6 +63,6 @@ public class SmartMeteringDevice implements Serializable {
   private Long port;
   private Integer challengeLength;
   private boolean ipAddressIsStatic;
-  private boolean withListSupported;
+  private Integer withListMax;
   private boolean selectiveAccessSupported;
 }

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/mapping/DeviceConverter.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/mapping/DeviceConverter.java
@@ -31,7 +31,7 @@ public class DeviceConverter extends BidirectionalConverter<SmartMeteringDeviceD
     dlmsDevice.setProtocol(source.getProtocolName(), source.getProtocolVersion());
     dlmsDevice.setTimezone(source.getTimezone());
     dlmsDevice.setIpAddressIsStatic(source.isIpAddressIsStatic());
-    dlmsDevice.setWithListSupported(source.isWithListSupported());
+    dlmsDevice.setWithListMax(source.getWithListMax());
     dlmsDevice.setSelectiveAccessSupported(source.isSelectiveAccessSupported());
     dlmsDevice.setPolyphase(source.isPolyphase());
     if (source.getPort() != null) {

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/services/ManagementService.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/services/ManagementService.java
@@ -107,7 +107,7 @@ public class ManagementService {
       final DlmsDevice device,
       final SetDeviceCommunicationSettingsRequestDataDto setCommunicationSettingsDataDto) {
     device.setChallengeLength(setCommunicationSettingsDataDto.getChallengeLength());
-    device.setWithListSupported(setCommunicationSettingsDataDto.isWithListSupported());
+    device.setWithListMax(setCommunicationSettingsDataDto.getWithListMax());
     device.setSelectiveAccessSupported(
         setCommunicationSettingsDataDto.isSelectiveAccessSupported());
     device.setIpAddressIsStatic(setCommunicationSettingsDataDto.isIpAddressIsStatic());

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/utils/DlmsHelper.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/utils/DlmsHelper.java
@@ -70,8 +70,6 @@ public class DlmsHelper {
   private static final Map<Integer, TransportServiceTypeDto> TRANSPORT_SERVICE_TYPE_PER_ENUM_VALUE =
       new TreeMap<>();
 
-  private static final int MAX_CONCURRENT_ATTRIBUTE_ADDRESSES = 32;
-
   static {
     TRANSPORT_SERVICE_TYPE_PER_ENUM_VALUE.put(0, TransportServiceTypeDto.TCP);
     TRANSPORT_SERVICE_TYPE_PER_ENUM_VALUE.put(1, TransportServiceTypeDto.UDP);

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/entities/DlmsDevice.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/entities/DlmsDevice.java
@@ -38,7 +38,7 @@ public class DlmsDevice extends AbstractEntity {
 
   @Column private Integer challengeLength;
 
-  @Column private boolean withListSupported;
+  @Column private Integer withListMax;
 
   @Column private boolean selectiveAccessSupported;
 
@@ -229,12 +229,12 @@ public class DlmsDevice extends AbstractEntity {
     this.challengeLength = challengeLength;
   }
 
-  public boolean isWithListSupported() {
-    return this.withListSupported;
+  public Integer getWithListMax() {
+    return this.withListMax;
   }
 
-  public void setWithListSupported(final boolean withListSupported) {
-    this.withListSupported = withListSupported;
+  public void setWithListMax(final Integer withListMax) {
+    this.withListMax = withListMax;
   }
 
   public boolean isSelectiveAccessSupported() {

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/resources/db/migration/V20240215112630001__change_withlistsupported_to_withlistmax.sql
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/resources/db/migration/V20240215112630001__change_withlistsupported_to_withlistmax.sql
@@ -1,0 +1,11 @@
+ALTER TABLE dlms_device ADD COLUMN with_list_max integer DEFAULT 1;
+
+UPDATE dlms_device
+SET with_list_max = 32
+WHERE with_list_supported = true;
+
+UPDATE dlms_device
+SET with_list_max = 1
+WHERE with_list_supported = false;
+
+ALTER TABLE dlms_device DROP COLUMN with_list_supported;

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/application/mapping/DeviceConverterTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/application/mapping/DeviceConverterTest.java
@@ -54,7 +54,7 @@ class DeviceConverterTest {
     dlmsDevice.setPort(dto.getPort());
     dlmsDevice.setChallengeLength(dto.getChallengeLength());
     dlmsDevice.setIpAddressIsStatic(dto.isIpAddressIsStatic());
-    dlmsDevice.setWithListSupported(dto.isWithListSupported());
+    dlmsDevice.setWithListMax(dto.getWithListMax());
     dlmsDevice.setSelectiveAccessSupported(dto.isSelectiveAccessSupported());
     return dlmsDevice;
   }

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/mbus/DeviceChannelsHelperTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/mbus/DeviceChannelsHelperTest.java
@@ -178,7 +178,6 @@ public class DeviceChannelsHelperTest {
                 this.manufacturerIdentification,
                 this.version,
                 this.deviceType));
-    when(this.device.isWithListSupported()).thenReturn(true);
     when(this.conn.getDlmsMessageListener()).thenReturn(this.dlmsMessageListener);
     when(this.conn.getConnection()).thenReturn(this.dlmsConnection);
     when(this.dlmsConnection.get(anyList())).thenReturn(resultList);
@@ -206,7 +205,6 @@ public class DeviceChannelsHelperTest {
                 this.manufacturerIdentification,
                 this.version,
                 this.deviceType));
-    when(this.device.isWithListSupported()).thenReturn(true);
     when(this.conn.getDlmsMessageListener()).thenReturn(this.dlmsMessageListener);
     when(this.conn.getConnection()).thenReturn(this.dlmsConnection);
     when(this.dlmsConnection.get(anyList())).thenReturn(resultList);
@@ -238,7 +236,6 @@ public class DeviceChannelsHelperTest {
                 manufacturerIdentificationInvalid,
                 this.version,
                 this.deviceType));
-    when(this.device.isWithListSupported()).thenReturn(true);
     when(this.conn.getDlmsMessageListener()).thenReturn(this.dlmsMessageListener);
     when(this.conn.getConnection()).thenReturn(this.dlmsConnection);
     when(this.dlmsConnection.get(anyList())).thenReturn(resultList);
@@ -263,7 +260,6 @@ public class DeviceChannelsHelperTest {
                 this.manufacturerIdentification,
                 this.version,
                 this.deviceType));
-    when(this.device.isWithListSupported()).thenReturn(true);
     when(this.conn.getDlmsMessageListener()).thenReturn(this.dlmsMessageListener);
     when(this.conn.getConnection()).thenReturn(this.dlmsConnection);
     when(this.dlmsConnection.get(anyList())).thenReturn(resultList);

--- a/osgp/shared/osgp-dto/src/main/java/org/opensmartgridplatform/dto/valueobjects/smartmetering/SetDeviceCommunicationSettingsRequestDataDto.java
+++ b/osgp/shared/osgp-dto/src/main/java/org/opensmartgridplatform/dto/valueobjects/smartmetering/SetDeviceCommunicationSettingsRequestDataDto.java
@@ -9,7 +9,7 @@ public class SetDeviceCommunicationSettingsRequestDataDto implements ActionReque
   private static final long serialVersionUID = 3283815451328003248L;
 
   private final int challengeLength;
-  private final boolean withListSupported;
+  private final int withListMax;
   private final boolean selectiveAccessSupported;
   private final boolean ipAddressIsStatic;
   private final boolean useSn;
@@ -18,14 +18,14 @@ public class SetDeviceCommunicationSettingsRequestDataDto implements ActionReque
 
   public SetDeviceCommunicationSettingsRequestDataDto(
       final int challengeLength,
-      final boolean withListSupported,
+      final int withListMax,
       final boolean selectiveAccessSupported,
       final boolean ipAddressIsStatic,
       final boolean useSn,
       final boolean useHdlc,
       final boolean polyphase) {
     this.challengeLength = challengeLength;
-    this.withListSupported = withListSupported;
+    this.withListMax = withListMax;
     this.selectiveAccessSupported = selectiveAccessSupported;
     this.ipAddressIsStatic = ipAddressIsStatic;
     this.useSn = useSn;
@@ -37,8 +37,8 @@ public class SetDeviceCommunicationSettingsRequestDataDto implements ActionReque
     return this.challengeLength;
   }
 
-  public boolean isWithListSupported() {
-    return this.withListSupported;
+  public int getWithListMax() {
+    return this.withListMax;
   }
 
   public boolean isSelectiveAccessSupported() {

--- a/osgp/shared/osgp-dto/src/main/java/org/opensmartgridplatform/dto/valueobjects/smartmetering/SmartMeteringDeviceDto.java
+++ b/osgp/shared/osgp-dto/src/main/java/org/opensmartgridplatform/dto/valueobjects/smartmetering/SmartMeteringDeviceDto.java
@@ -64,6 +64,6 @@ public class SmartMeteringDeviceDto implements Serializable {
   private Long port;
   private Integer challengeLength;
   private boolean ipAddressIsStatic;
-  private boolean withListSupported;
+  private Integer withListMax;
   private boolean selectiveAccessSupported;
 }

--- a/osgp/shared/osgp-dto/src/test/java/org/opensmartgridplatform/dto/valueobjects/smartmetering/SmartMeteringDeviceDtoBuilder.java
+++ b/osgp/shared/osgp-dto/src/test/java/org/opensmartgridplatform/dto/valueobjects/smartmetering/SmartMeteringDeviceDtoBuilder.java
@@ -38,7 +38,7 @@ public class SmartMeteringDeviceDtoBuilder {
     dto.setPort(4000L);
     dto.setChallengeLength(15);
     dto.setIpAddressIsStatic(false);
-    dto.setWithListSupported(true);
+    dto.setWithListMax(32);
     dto.setSelectiveAccessSupported(false);
     return dto;
   }

--- a/osgp/shared/osgp-ws-smartmetering/src/main/resources/schemas/installation-ws-smartmetering.xsd
+++ b/osgp/shared/osgp-ws-smartmetering/src/main/resources/schemas/installation-ws-smartmetering.xsd
@@ -378,7 +378,7 @@
         minOccurs="0" />
       <xsd:element name="IpAddressIsStatic" type="xsd:boolean"
         minOccurs="0" />
-      <xsd:element name="WithListSupported" type="xsd:boolean"
+      <xsd:element name="WithListMax" type="xsd:int"
         minOccurs="0" />
       <xsd:element name="SelectiveAccessSupported" type="xsd:boolean"
         minOccurs="0" />

--- a/osgp/shared/osgp-ws-smartmetering/src/main/resources/schemas/management-ws-smartmetering.xsd
+++ b/osgp/shared/osgp-ws-smartmetering/src/main/resources/schemas/management-ws-smartmetering.xsd
@@ -998,8 +998,7 @@
   <xsd:complexType name="SetDeviceCommunicationSettingsData">
     <xsd:sequence>
       <xsd:element type="xsd:integer" name="ChallengeLength"/>
-      <xsd:element type="xsd:boolean" name="WithListSupported"
-                   default="false"/>
+      <xsd:element type="xsd:integer" name="WithListMax"/>
       <xsd:element type="xsd:boolean" name="SelectiveAccessSupported"
                    default="false"/>
       <xsd:element type="xsd:boolean" name="IpAddressIsStatic"


### PR DESCRIPTION
This PR updates the withListSupported property of a device to withListMax. This new property is the maximum amount of items in a request. The getWithList function in the DlmsHelper automatically divides the list of addresses in to sublists of the maximum amount. If only 1 address is provided or if withListMax is 1, then it will use a normal DLMS GetRequest instead of GetWithList.
The database is updated. All devices with withListSupported to false are set to withListMax = 1. All devices with withListSupported to true are set to withListMax = 32, which is the default that was already used.