### PR TITLE
Feature/throttling rpm

### DIFF
--- a/osgp/platform/osgp-throttling-service/src/main/java/org/opensmartgridplatform/throttling/NewConnectionRequestThrottler.java
+++ b/osgp/platform/osgp-throttling-service/src/main/java/org/opensmartgridplatform/throttling/NewConnectionRequestThrottler.java
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: Copyright Contributors to the GXF project
+//
+// SPDX-License-Identifier: Apache-2.0
+package org.opensmartgridplatform.throttling;
+
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class NewConnectionRequestThrottler {
+  private final Semaphore semaphore;
+  private final int maxNewConnectionRequests;
+  private final long resetTimeInMs;
+  private final long maxWaitForNewConnectionRequestInMs;
+  private final Timer resetNewConnectionRequestsTimer;
+
+  public NewConnectionRequestThrottler(
+      final int maxNewConnectionRequests,
+      final long resetTimeInMs,
+      final long maxWaitForNewConnectionRequestInMs) {
+    this.maxNewConnectionRequests = maxNewConnectionRequests;
+    this.resetTimeInMs = resetTimeInMs;
+    this.maxWaitForNewConnectionRequestInMs = maxWaitForNewConnectionRequestInMs;
+
+    this.semaphore = new Semaphore(maxNewConnectionRequests);
+
+    this.resetNewConnectionRequestsTimer = new Timer();
+    this.resetNewConnectionRequestsTimer.schedule(
+        new ResetNewConnectionRequestsTask(), this.resetTimeInMs, this.resetTimeInMs);
+  }
+
+  public boolean isNewConnectionRequestAllowed(final int priority) {
+    log.debug("isNewRequestAllowed: available = {} ", this.semaphore.availablePermits());
+    try {
+      if (!this.semaphore.tryAcquire(
+          this.maxWaitForNewConnectionRequestInMs, TimeUnit.MILLISECONDS)) {
+        log.debug(
+            "isNewRequestAllowed: could not acquire permit for request with priority {} within {} ms",
+            priority,
+            this.maxWaitForNewConnectionRequestInMs);
+        return false;
+      }
+      log.debug(
+          "isNewRequestAllowed:  granted. available = {} ", this.semaphore.availablePermits());
+    } catch (final InterruptedException e) {
+      log.warn("isNewRequestAllowed: unable to acquire permit", e);
+      Thread.currentThread().interrupt();
+    }
+    return true;
+  }
+
+  private class ResetNewConnectionRequestsTask extends TimerTask {
+    @Override
+    public void run() {
+      final int nrOfPermitsToBeReleased =
+          NewConnectionRequestThrottler.this.maxNewConnectionRequests
+              - NewConnectionRequestThrottler.this.semaphore.availablePermits();
+
+      log.debug("releasing {} permits on newConnectionRequests semaphore", nrOfPermitsToBeReleased);
+
+      NewConnectionRequestThrottler.this.semaphore.release(nrOfPermitsToBeReleased);
+
+      log.debug(
+          "ThrottlingService - Timer Reset and Unlocking, newConnectionRequests available = {}  ",
+          NewConnectionRequestThrottler.this.semaphore.availablePermits());
+    }
+  }
+}

--- a/osgp/platform/osgp-throttling-service/src/main/java/org/opensmartgridplatform/throttling/NewConnectionRequestThrottler.java
+++ b/osgp/platform/osgp-throttling-service/src/main/java/org/opensmartgridplatform/throttling/NewConnectionRequestThrottler.java
@@ -13,7 +13,6 @@ import lombok.extern.slf4j.Slf4j;
 public class NewConnectionRequestThrottler {
   private final Semaphore semaphore;
   private final int maxNewConnections;
-  private final long resetTimeInMs;
   private final long maxWaitForNewConnectionsInMs;
   private final Timer resetNewConnectionRequestsTimer;
 
@@ -22,14 +21,13 @@ public class NewConnectionRequestThrottler {
       final long resetTimeInMs,
       final long maxWaitForNewConnectionsInMs) {
     this.maxNewConnections = maxNewConnections;
-    this.resetTimeInMs = resetTimeInMs;
     this.maxWaitForNewConnectionsInMs = maxWaitForNewConnectionsInMs;
 
     this.semaphore = new Semaphore(this.maxNewConnections);
 
     this.resetNewConnectionRequestsTimer = new Timer();
     this.resetNewConnectionRequestsTimer.schedule(
-        new ResetNewConnectionRequestsTask(), this.resetTimeInMs, this.resetTimeInMs);
+        new ResetNewConnectionRequestsTask(), resetTimeInMs, resetTimeInMs);
   }
 
   public boolean isNewConnectionRequestAllowed(final int priority) {
@@ -47,6 +45,7 @@ public class NewConnectionRequestThrottler {
     } catch (final InterruptedException e) {
       log.warn("isNewRequestAllowed: unable to acquire permit", e);
       Thread.currentThread().interrupt();
+      return false;
     }
     return true;
   }

--- a/osgp/platform/osgp-throttling-service/src/main/java/org/opensmartgridplatform/throttling/PermitsByThrottlingConfig.java
+++ b/osgp/platform/osgp-throttling-service/src/main/java/org/opensmartgridplatform/throttling/PermitsByThrottlingConfig.java
@@ -11,6 +11,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import javax.annotation.PostConstruct;
 import org.opensmartgridplatform.throttling.entities.ThrottlingConfig;
+import org.opensmartgridplatform.throttling.model.ThrottlingSettings;
 import org.opensmartgridplatform.throttling.repositories.PermitRepository;
 import org.opensmartgridplatform.throttling.repositories.ThrottlingConfigRepository;
 import org.opensmartgridplatform.throttling.service.PermitReleasedNotifier;
@@ -93,7 +94,7 @@ public class PermitsByThrottlingConfig {
       final int cellId,
       final int requestId,
       final int priority,
-      final int maxConcurrency) {
+      final ThrottlingSettings throttlingSettings) {
 
     final PermitsPerNetworkSegment permitsPerNetworkSegment =
         this.permitsPerSegmentByConfig.computeIfAbsent(
@@ -106,7 +107,7 @@ public class PermitsByThrottlingConfig {
         cellId,
         requestId,
         priority,
-        maxConcurrency);
+        throttlingSettings);
   }
 
   private PermitsPerNetworkSegment createAndInitialize(final short throttlingConfigId) {

--- a/osgp/platform/osgp-throttling-service/src/main/java/org/opensmartgridplatform/throttling/PermitsByThrottlingConfig.java
+++ b/osgp/platform/osgp-throttling-service/src/main/java/org/opensmartgridplatform/throttling/PermitsByThrottlingConfig.java
@@ -33,23 +33,19 @@ public class PermitsByThrottlingConfig {
   private final PermitReleasedNotifier permitReleasedNotifier;
   private final boolean highPrioPoolEnabled;
   private final int maxWaitForHighPrioInMs;
-  private final int maxWaitForNewConnectionRequestInMs;
 
   public PermitsByThrottlingConfig(
       final ThrottlingConfigRepository throttlingConfigRepository,
       final PermitRepository permitRepository,
       final PermitReleasedNotifier permitReleasedNotifier,
       @Value("${wait.for.high.prio.enabled:true}") final boolean highPrioPoolEnabled,
-      @Value("${wait.for.high.prio.max.in.ms:10000}") final int maxWaitForHighPrioInMs,
-      @Value("${wait.for.new.connection.request.max.in.ms:60000}")
-          final int maxWaitForNewConnectionRequestInMs) {
+      @Value("${wait.for.high.prio.max.in.ms:10000}") final int maxWaitForHighPrioInMs) {
 
     this.throttlingConfigRepository = throttlingConfigRepository;
     this.permitRepository = permitRepository;
     this.permitReleasedNotifier = permitReleasedNotifier;
     this.highPrioPoolEnabled = highPrioPoolEnabled;
     this.maxWaitForHighPrioInMs = maxWaitForHighPrioInMs;
-    this.maxWaitForNewConnectionRequestInMs = maxWaitForNewConnectionRequestInMs;
   }
 
   /** Clears all cached permit counts and initializes the cached information from the database. */
@@ -70,8 +66,7 @@ public class PermitsByThrottlingConfig {
                     this.permitRepository,
                     this.permitReleasedNotifier,
                     this.highPrioPoolEnabled,
-                    this.maxWaitForHighPrioInMs,
-                    this.maxWaitForNewConnectionRequestInMs)));
+                    this.maxWaitForHighPrioInMs)));
 
     /* Update config */
     this.permitsPerSegmentByConfig.entrySet().parallelStream()
@@ -121,8 +116,7 @@ public class PermitsByThrottlingConfig {
             this.permitRepository,
             this.permitReleasedNotifier,
             this.highPrioPoolEnabled,
-            this.maxWaitForHighPrioInMs,
-            this.maxWaitForNewConnectionRequestInMs);
+            this.maxWaitForHighPrioInMs);
     permitsPerNetworkSegment.initialize(throttlingConfigId);
     return permitsPerNetworkSegment;
   }
@@ -139,8 +133,7 @@ public class PermitsByThrottlingConfig {
             this.permitRepository,
             this.permitReleasedNotifier,
             this.highPrioPoolEnabled,
-            this.maxWaitForHighPrioInMs,
-            this.maxWaitForNewConnectionRequestInMs));
+            this.maxWaitForHighPrioInMs));
   }
 
   public boolean releasePermit(

--- a/osgp/platform/osgp-throttling-service/src/main/java/org/opensmartgridplatform/throttling/PermitsByThrottlingConfig.java
+++ b/osgp/platform/osgp-throttling-service/src/main/java/org/opensmartgridplatform/throttling/PermitsByThrottlingConfig.java
@@ -33,19 +33,23 @@ public class PermitsByThrottlingConfig {
   private final PermitReleasedNotifier permitReleasedNotifier;
   private final boolean highPrioPoolEnabled;
   private final int maxWaitForHighPrioInMs;
+  private final int maxWaitForNewConnectionRequestInMs;
 
   public PermitsByThrottlingConfig(
       final ThrottlingConfigRepository throttlingConfigRepository,
       final PermitRepository permitRepository,
       final PermitReleasedNotifier permitReleasedNotifier,
       @Value("${wait.for.high.prio.enabled:true}") final boolean highPrioPoolEnabled,
-      @Value("${wait.for.high.prio.max.in.ms:10000}") final int maxWaitForHighPrioInMs) {
+      @Value("${wait.for.high.prio.max.in.ms:10000}") final int maxWaitForHighPrioInMs,
+      @Value("${wait.for.new.connection.request.max.in.ms:60000}")
+          final int maxWaitForNewConnectionRequestInMs) {
 
     this.throttlingConfigRepository = throttlingConfigRepository;
     this.permitRepository = permitRepository;
     this.permitReleasedNotifier = permitReleasedNotifier;
     this.highPrioPoolEnabled = highPrioPoolEnabled;
     this.maxWaitForHighPrioInMs = maxWaitForHighPrioInMs;
+    this.maxWaitForNewConnectionRequestInMs = maxWaitForNewConnectionRequestInMs;
   }
 
   /** Clears all cached permit counts and initializes the cached information from the database. */
@@ -66,7 +70,8 @@ public class PermitsByThrottlingConfig {
                     this.permitRepository,
                     this.permitReleasedNotifier,
                     this.highPrioPoolEnabled,
-                    this.maxWaitForHighPrioInMs)));
+                    this.maxWaitForHighPrioInMs,
+                    this.maxWaitForNewConnectionRequestInMs)));
 
     /* Update config */
     this.permitsPerSegmentByConfig.entrySet().parallelStream()
@@ -116,7 +121,8 @@ public class PermitsByThrottlingConfig {
             this.permitRepository,
             this.permitReleasedNotifier,
             this.highPrioPoolEnabled,
-            this.maxWaitForHighPrioInMs);
+            this.maxWaitForHighPrioInMs,
+            this.maxWaitForNewConnectionRequestInMs);
     permitsPerNetworkSegment.initialize(throttlingConfigId);
     return permitsPerNetworkSegment;
   }
@@ -133,7 +139,8 @@ public class PermitsByThrottlingConfig {
             this.permitRepository,
             this.permitReleasedNotifier,
             this.highPrioPoolEnabled,
-            this.maxWaitForHighPrioInMs));
+            this.maxWaitForHighPrioInMs,
+            this.maxWaitForNewConnectionRequestInMs));
   }
 
   public boolean releasePermit(

--- a/osgp/platform/osgp-throttling-service/src/main/java/org/opensmartgridplatform/throttling/PermitsPerNetworkSegment.java
+++ b/osgp/platform/osgp-throttling-service/src/main/java/org/opensmartgridplatform/throttling/PermitsPerNetworkSegment.java
@@ -103,7 +103,7 @@ public class PermitsPerNetworkSegment {
                 TreeMap::new));
   }
 
-  public ConcurrentMap<Integer, ConcurrentMap<Integer, NewConnectionRequestThrottler>>
+  ConcurrentMap<Integer, ConcurrentMap<Integer, NewConnectionRequestThrottler>>
       newConnectionRequestThrottlerPerSegment() {
     return this.newConnectionRequestThrottlerPerSegment;
   }

--- a/osgp/platform/osgp-throttling-service/src/main/java/org/opensmartgridplatform/throttling/PermitsPerNetworkSegment.java
+++ b/osgp/platform/osgp-throttling-service/src/main/java/org/opensmartgridplatform/throttling/PermitsPerNetworkSegment.java
@@ -11,6 +11,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import org.opensmartgridplatform.shared.wsheaderattribute.priority.MessagePriorityEnum;
+import org.opensmartgridplatform.throttling.model.ThrottlingSettings;
 import org.opensmartgridplatform.throttling.repositories.PermitRepository;
 import org.opensmartgridplatform.throttling.repositories.PermitRepository.PermitCountByNetworkSegment;
 import org.opensmartgridplatform.throttling.service.PermitReleasedNotifier;
@@ -107,8 +108,9 @@ public class PermitsPerNetworkSegment {
       final int cellId,
       final int requestId,
       final int priority,
-      final int maxConcurrency) {
-    if (!this.isPermitAvailable(baseTransceiverStationId, cellId, priority, maxConcurrency)) {
+      final ThrottlingSettings throttlingSettings) {
+    if (!this.isPermitAvailable(
+        baseTransceiverStationId, cellId, priority, throttlingSettings.getMaxConcurrency())) {
       return false;
     }
 

--- a/osgp/platform/osgp-throttling-service/src/main/java/org/opensmartgridplatform/throttling/PermitsPerNetworkSegment.java
+++ b/osgp/platform/osgp-throttling-service/src/main/java/org/opensmartgridplatform/throttling/PermitsPerNetworkSegment.java
@@ -32,19 +32,16 @@ public class PermitsPerNetworkSegment {
   private final PermitReleasedNotifier permitReleasedNotifier;
   private final boolean highPrioPoolEnabled;
   private final int maxWaitForHighPrioInMs;
-  private final int maxWaitForNewConnectionRequestInMs;
 
   public PermitsPerNetworkSegment(
       final PermitRepository permitRepository,
       final PermitReleasedNotifier permitReleasedNotifier,
       final boolean highPrioPoolEnabled,
-      final int maxWaitForHighPrioInMs,
-      final int maxWaitForNewConnectionRequestInMs) {
+      final int maxWaitForHighPrioInMs) {
     this.permitRepository = permitRepository;
     this.permitReleasedNotifier = permitReleasedNotifier;
     this.highPrioPoolEnabled = highPrioPoolEnabled;
     this.maxWaitForHighPrioInMs = maxWaitForHighPrioInMs;
-    this.maxWaitForNewConnectionRequestInMs = maxWaitForNewConnectionRequestInMs;
   }
 
   public void initialize(final short throttlingConfigId) {
@@ -140,9 +137,9 @@ public class PermitsPerNetworkSegment {
                 cellId,
                 key ->
                     new NewConnectionRequestThrottler(
-                        throttlingSettings.getMaxNewConnectionRequests(),
-                        throttlingSettings.getMaxNewConnectionResetTimeInMs(),
-                        this.maxWaitForNewConnectionRequestInMs));
+                        throttlingSettings.getMaxNewConnections(),
+                        throttlingSettings.getMaxNewConnectionsResetTimeInMs(),
+                        throttlingSettings.getMaxNewConnectionsWaitTimeInMs()));
 
     return newConnectionRequestThrottler.isNewConnectionRequestAllowed(priority);
   }

--- a/osgp/platform/osgp-throttling-service/src/main/java/org/opensmartgridplatform/throttling/PermitsPerNetworkSegment.java
+++ b/osgp/platform/osgp-throttling-service/src/main/java/org/opensmartgridplatform/throttling/PermitsPerNetworkSegment.java
@@ -103,6 +103,11 @@ public class PermitsPerNetworkSegment {
                 TreeMap::new));
   }
 
+  public ConcurrentMap<Integer, ConcurrentMap<Integer, NewConnectionRequestThrottler>>
+      newConnectionRequestThrottlerPerSegment() {
+    return this.newConnectionRequestThrottlerPerSegment;
+  }
+
   public boolean requestPermit(
       final short throttlingConfigId,
       final int clientId,
@@ -130,6 +135,11 @@ public class PermitsPerNetworkSegment {
       final int cellId,
       final int priority,
       final ThrottlingSettings throttlingSettings) {
+    if (throttlingSettings.getMaxNewConnections() < 0) {
+      return true;
+    } else if (throttlingSettings.getMaxNewConnections() == 0) {
+      return false;
+    }
     final NewConnectionRequestThrottler newConnectionRequestThrottler =
         this.newConnectionRequestThrottlerPerSegment
             .computeIfAbsent(baseTransceiverStationId, key -> new ConcurrentHashMap<>())
@@ -174,6 +184,11 @@ public class PermitsPerNetworkSegment {
       final int cellId,
       final int priority,
       final int maxConcurrency) {
+    if (maxConcurrency < 0) {
+      return true;
+    } else if (maxConcurrency == 0) {
+      return false;
+    }
     final AtomicInteger permitCounter = this.getPermitCounter(baseTransceiverStationId, cellId);
 
     final int numberOfPermitsIfGranted = permitCounter.incrementAndGet();

--- a/osgp/platform/osgp-throttling-service/src/main/java/org/opensmartgridplatform/throttling/SegmentedNetworkThrottler.java
+++ b/osgp/platform/osgp-throttling-service/src/main/java/org/opensmartgridplatform/throttling/SegmentedNetworkThrottler.java
@@ -36,9 +36,6 @@ public class SegmentedNetworkThrottler {
 
     final ThrottlingSettings throttlingSettings =
         this.getThrottlingSettings(throttlingConfigId, baseTransceiverStationId, cellId);
-    if (throttlingSettings.getMaxConcurrency() < 1) {
-      return false;
-    }
 
     return this.permitsByThrottlingConfig.requestPermit(
         throttlingConfigId,

--- a/osgp/platform/osgp-throttling-service/src/main/java/org/opensmartgridplatform/throttling/SegmentedNetworkThrottler.java
+++ b/osgp/platform/osgp-throttling-service/src/main/java/org/opensmartgridplatform/throttling/SegmentedNetworkThrottler.java
@@ -5,21 +5,22 @@
 package org.opensmartgridplatform.throttling;
 
 import java.util.Optional;
+import org.opensmartgridplatform.throttling.entities.ThrottlingConfig;
 import org.springframework.stereotype.Component;
 
 @Component
 public class SegmentedNetworkThrottler {
 
-  private final MaxConcurrencyByThrottlingConfig maxConcurrencyByThrottlingConfig;
+  private final ThrottlingConfigCache throttlingConfigCache;
   private final MaxConcurrencyByBtsCellConfig maxConcurrencyByBtsCellConfig;
   private final PermitsByThrottlingConfig permitsByThrottlingConfig;
 
   public SegmentedNetworkThrottler(
-      final MaxConcurrencyByThrottlingConfig maxConcurrencyByThrottlingConfig,
+      final ThrottlingConfigCache throttlingConfigCache,
       final MaxConcurrencyByBtsCellConfig maxConcurrencyByBtsCellConfig,
       final PermitsByThrottlingConfig permitsByThrottlingConfig) {
 
-    this.maxConcurrencyByThrottlingConfig = maxConcurrencyByThrottlingConfig;
+    this.throttlingConfigCache = throttlingConfigCache;
     this.maxConcurrencyByBtsCellConfig = maxConcurrencyByBtsCellConfig;
     this.permitsByThrottlingConfig = permitsByThrottlingConfig;
   }
@@ -32,14 +33,18 @@ public class SegmentedNetworkThrottler {
       final int requestId,
       final int priority) {
 
+    final ThrottlingConfig throttlingConfig =
+        this.throttlingConfigCache.getThrottlingConfig(throttlingConfigId);
+
     final Optional<Integer> maxConcurrencyBtsCell =
         this.maxConcurrencyByBtsCellConfig.getMaxConcurrency(baseTransceiverStationId, cellId);
-    final int maxConcurrency =
-        maxConcurrencyBtsCell.orElse(
-            this.maxConcurrencyByThrottlingConfig.getMaxConcurrency(throttlingConfigId));
+    final int maxConcurrency = maxConcurrencyBtsCell.orElse(throttlingConfig.getMaxConcurrency());
     if (maxConcurrency < 1) {
       return false;
     }
+
+    final int maxNewConnectionRequests = throttlingConfig.getMaxNewConnectionRequests();
+    final long maxNewConnectionResetTimeInMs = throttlingConfig.getMaxNewConnectionResetTimeInMs();
 
     return this.permitsByThrottlingConfig.requestPermit(
         throttlingConfigId,

--- a/osgp/platform/osgp-throttling-service/src/main/java/org/opensmartgridplatform/throttling/SegmentedNetworkThrottler.java
+++ b/osgp/platform/osgp-throttling-service/src/main/java/org/opensmartgridplatform/throttling/SegmentedNetworkThrottler.java
@@ -59,8 +59,10 @@ public class SegmentedNetworkThrottler {
         this.maxConcurrencyByBtsCellConfig.getMaxConcurrency(baseTransceiverStationId, cellId);
     final int maxConcurrency = maxConcurrencyBtsCell.orElse(throttlingConfig.getMaxConcurrency());
 
-    final int maxNewConnectionRequests = throttlingConfig.getMaxNewConnectionRequests();
-    final long maxNewConnectionResetTimeInMs = throttlingConfig.getMaxNewConnectionResetTimeInMs();
+    final int maxNewConnections = throttlingConfig.getMaxNewConnections();
+    final long maxNewConnectionsResetTimeInMs =
+        throttlingConfig.getMaxNewConnectionsResetTimeInMs();
+    final long maxNewConnectionsWaitTimeInMs = throttlingConfig.getMaxNewConnectionsWaitTimeInMs();
 
     return new ThrottlingSettings() {
       @Override
@@ -69,13 +71,18 @@ public class SegmentedNetworkThrottler {
       }
 
       @Override
-      public int getMaxNewConnectionRequests() {
-        return maxNewConnectionRequests;
+      public int getMaxNewConnections() {
+        return maxNewConnections;
       }
 
       @Override
-      public long getMaxNewConnectionResetTimeInMs() {
-        return maxNewConnectionResetTimeInMs;
+      public long getMaxNewConnectionsResetTimeInMs() {
+        return maxNewConnectionsResetTimeInMs;
+      }
+
+      @Override
+      public long getMaxNewConnectionsWaitTimeInMs() {
+        return maxNewConnectionsWaitTimeInMs;
       }
     };
   }

--- a/osgp/platform/osgp-throttling-service/src/main/java/org/opensmartgridplatform/throttling/entities/ThrottlingConfig.java
+++ b/osgp/platform/osgp-throttling-service/src/main/java/org/opensmartgridplatform/throttling/entities/ThrottlingConfig.java
@@ -10,9 +10,11 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import lombok.Getter;
 import org.hibernate.annotations.NaturalId;
 
 @Entity
+@Getter
 public class ThrottlingConfig {
 
   @Id
@@ -26,48 +28,76 @@ public class ThrottlingConfig {
   @Column(nullable = false)
   private int maxConcurrency;
 
+  @Column(nullable = false)
+  private int maxNewConnectionRequests;
+
+  @Column(nullable = false)
+  private long maxNewConnectionResetTimeInMs;
+
   public ThrottlingConfig() {
     // no-arg constructor required by JPA specification
   }
 
-  public ThrottlingConfig(final String name, final int maxConcurrency) {
-    this(null, name, maxConcurrency);
+  public ThrottlingConfig(
+      final String name,
+      final int maxConcurrency,
+      final int maxNewConnectionRequests,
+      final long maxNewConnectionResetTimeInMs) {
+    this(null, name, maxConcurrency, maxNewConnectionRequests, maxNewConnectionResetTimeInMs);
   }
 
-  public ThrottlingConfig(final Short id, final String name, final int maxConcurrency) {
+  public ThrottlingConfig(
+      final Short id,
+      final String name,
+      final int maxConcurrency,
+      final int maxNewConnectionRequests,
+      final long maxNewConnectionResetTimeInMs) {
     this.id = id;
     this.name = Objects.requireNonNull(name, "name must not be null");
-    this.maxConcurrency = this.requireNonNegativeMaxConcurrency(maxConcurrency);
+    this.maxConcurrency = this.requireNonNegative("maxConcurrency", maxConcurrency);
+    this.maxNewConnectionRequests =
+        this.requireNonNegative("maxNewConnectionRequests", maxNewConnectionRequests);
+    this.maxNewConnectionResetTimeInMs =
+        this.requireNonNegative("maxNewConnectionResetTimeInMs", maxNewConnectionResetTimeInMs);
   }
 
-  private int requireNonNegativeMaxConcurrency(final int maxConcurrency) {
-    if (maxConcurrency < 0) {
-      throw new IllegalArgumentException("maxConcurrency must be non-negative: " + maxConcurrency);
+  private int requireNonNegative(final String fieldName, final int value) {
+    if (value < 0) {
+      throw new IllegalArgumentException(fieldName + " must be non-negative: " + value);
     }
-    return maxConcurrency;
+    return value;
   }
 
-  public Short getId() {
-    return this.id;
-  }
-
-  public String getName() {
-    return this.name;
-  }
-
-  public int getMaxConcurrency() {
-    return this.maxConcurrency;
+  private long requireNonNegative(final String fieldName, final long value) {
+    if (value < 0) {
+      throw new IllegalArgumentException(fieldName + " must be non-negative: " + value);
+    }
+    return value;
   }
 
   public void setMaxConcurrency(final int maxConcurrency) {
-    this.maxConcurrency = this.requireNonNegativeMaxConcurrency(maxConcurrency);
+    this.maxConcurrency = this.requireNonNegative("maxConcurrency", maxConcurrency);
+  }
+
+  public void setMaxNewConnectionRequests(final int maxNewConnectionRequests) {
+    this.maxNewConnectionRequests =
+        this.requireNonNegative("maxNewConnectionRequests", maxNewConnectionRequests);
+  }
+
+  public void setMaxNewConnectionResetTimeInMs(final long maxNewConnectionResetTimeInMs) {
+    this.maxNewConnectionResetTimeInMs = maxNewConnectionResetTimeInMs;
   }
 
   @Override
   public String toString() {
     return String.format(
-        "%s[id=%s, name=%s, maxConcurrency=%d]",
-        ThrottlingConfig.class.getSimpleName(), this.id, this.name, this.maxConcurrency);
+        "%s[id=%s, name=%s, maxConcurrency=%d, maxNewConnectionRequests=%d, maxNewConnectionResetTimeInMs=%s]",
+        ThrottlingConfig.class.getSimpleName(),
+        this.id,
+        this.name,
+        this.maxConcurrency,
+        this.maxNewConnectionRequests,
+        this.maxNewConnectionResetTimeInMs);
   }
 
   @Override

--- a/osgp/platform/osgp-throttling-service/src/main/java/org/opensmartgridplatform/throttling/entities/ThrottlingConfig.java
+++ b/osgp/platform/osgp-throttling-service/src/main/java/org/opensmartgridplatform/throttling/entities/ThrottlingConfig.java
@@ -10,30 +10,42 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.Setter;
 import org.hibernate.annotations.NaturalId;
 
 @Entity
 @Getter
+@Setter
 public class ThrottlingConfig {
 
+  @Setter(AccessLevel.NONE)
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Short id;
 
+  @Setter(AccessLevel.NONE)
+  @NotNull
   @NaturalId
   @Column(nullable = false, updatable = false, unique = true)
   private String name;
 
+  @Min(-1)
   @Column(nullable = false)
   private int maxConcurrency;
 
+  @Min(-1)
   @Column(nullable = false)
   private int maxNewConnections;
 
+  @Min(0)
   @Column(nullable = false)
   private long maxNewConnectionsResetTimeInMs;
 
+  @Min(0)
   @Column(nullable = false)
   private long maxNewConnectionsWaitTimeInMs;
 
@@ -64,42 +76,10 @@ public class ThrottlingConfig {
       final long maxNewConnectionsResetTimeInMs,
       final long maxNewConnectionsWaitTimeInMs) {
     this.id = id;
-    this.name = Objects.requireNonNull(name, "name must not be null");
-    this.maxConcurrency = this.requireMinMinusOne("maxConcurrency", maxConcurrency);
-    this.maxNewConnections = this.requireMinMinusOne("maxNewConnections", maxNewConnections);
-    this.maxNewConnectionsResetTimeInMs =
-        this.requireNonNegative("maxNewConnectionsResetTimeInMs", maxNewConnectionsResetTimeInMs);
-    this.maxNewConnectionsWaitTimeInMs =
-        this.requireNonNegative("maxNewConnectionsWaitTimeInMs", maxNewConnectionsWaitTimeInMs);
-  }
-
-  private int requireMinMinusOne(final String fieldName, final int value) {
-    if (value < -1) {
-      throw new IllegalArgumentException(fieldName + " must be minimal -1: " + value);
-    }
-    return value;
-  }
-
-  private long requireNonNegative(final String fieldName, final long value) {
-    if (value < 0) {
-      throw new IllegalArgumentException(fieldName + " must be non-negative: " + value);
-    }
-    return value;
-  }
-
-  public void setMaxConcurrency(final int maxConcurrency) {
-    this.maxConcurrency = this.requireMinMinusOne("maxConcurrency", maxConcurrency);
-  }
-
-  public void setMaxNewConnections(final int maxNewConnections) {
-    this.maxNewConnections = this.requireMinMinusOne("maxNewConnections", maxNewConnections);
-  }
-
-  public void setMaxNewConnectionsResetTimeInMs(final long maxNewConnectionsResetTimeInMs) {
+    this.name = name;
+    this.maxConcurrency = maxConcurrency;
+    this.maxNewConnections = maxNewConnections;
     this.maxNewConnectionsResetTimeInMs = maxNewConnectionsResetTimeInMs;
-  }
-
-  public void setMaxNewConnectionsWaitTimeInMs(final long maxNewConnectionsWaitTimeInMs) {
     this.maxNewConnectionsWaitTimeInMs = maxNewConnectionsWaitTimeInMs;
   }
 
@@ -121,10 +101,9 @@ public class ThrottlingConfig {
     if (this == obj) {
       return true;
     }
-    if (!(obj instanceof ThrottlingConfig)) {
+    if (!(obj instanceof final ThrottlingConfig other)) {
       return false;
     }
-    final ThrottlingConfig other = (ThrottlingConfig) obj;
     return Objects.equals(this.name, other.name);
   }
 

--- a/osgp/platform/osgp-throttling-service/src/main/java/org/opensmartgridplatform/throttling/entities/ThrottlingConfig.java
+++ b/osgp/platform/osgp-throttling-service/src/main/java/org/opensmartgridplatform/throttling/entities/ThrottlingConfig.java
@@ -29,10 +29,13 @@ public class ThrottlingConfig {
   private int maxConcurrency;
 
   @Column(nullable = false)
-  private int maxNewConnectionRequests;
+  private int maxNewConnections;
 
   @Column(nullable = false)
-  private long maxNewConnectionResetTimeInMs;
+  private long maxNewConnectionsResetTimeInMs;
+
+  @Column(nullable = false)
+  private long maxNewConnectionsWaitTimeInMs;
 
   public ThrottlingConfig() {
     // no-arg constructor required by JPA specification
@@ -41,24 +44,33 @@ public class ThrottlingConfig {
   public ThrottlingConfig(
       final String name,
       final int maxConcurrency,
-      final int maxNewConnectionRequests,
-      final long maxNewConnectionResetTimeInMs) {
-    this(null, name, maxConcurrency, maxNewConnectionRequests, maxNewConnectionResetTimeInMs);
+      final int maxNewConnections,
+      final long maxNewConnectionsResetTimeInMs,
+      final long maxNewConnectionsWaitTimeInMs) {
+    this(
+        null,
+        name,
+        maxConcurrency,
+        maxNewConnections,
+        maxNewConnectionsResetTimeInMs,
+        maxNewConnectionsWaitTimeInMs);
   }
 
   public ThrottlingConfig(
       final Short id,
       final String name,
       final int maxConcurrency,
-      final int maxNewConnectionRequests,
-      final long maxNewConnectionResetTimeInMs) {
+      final int maxNewConnections,
+      final long maxNewConnectionsResetTimeInMs,
+      final long maxNewConnectionsWaitTimeInMs) {
     this.id = id;
     this.name = Objects.requireNonNull(name, "name must not be null");
     this.maxConcurrency = this.requireNonNegative("maxConcurrency", maxConcurrency);
-    this.maxNewConnectionRequests =
-        this.requireNonNegative("maxNewConnectionRequests", maxNewConnectionRequests);
-    this.maxNewConnectionResetTimeInMs =
-        this.requireNonNegative("maxNewConnectionResetTimeInMs", maxNewConnectionResetTimeInMs);
+    this.maxNewConnections = this.requireNonNegative("maxNewConnections", maxNewConnections);
+    this.maxNewConnectionsResetTimeInMs =
+        this.requireNonNegative("maxNewConnectionsResetTimeInMs", maxNewConnectionsResetTimeInMs);
+    this.maxNewConnectionsWaitTimeInMs =
+        this.requireNonNegative("maxNewConnectionsWaitTimeInMs", maxNewConnectionsWaitTimeInMs);
   }
 
   private int requireNonNegative(final String fieldName, final int value) {
@@ -79,25 +91,29 @@ public class ThrottlingConfig {
     this.maxConcurrency = this.requireNonNegative("maxConcurrency", maxConcurrency);
   }
 
-  public void setMaxNewConnectionRequests(final int maxNewConnectionRequests) {
-    this.maxNewConnectionRequests =
-        this.requireNonNegative("maxNewConnectionRequests", maxNewConnectionRequests);
+  public void setMaxNewConnections(final int maxNewConnections) {
+    this.maxNewConnections = this.requireNonNegative("maxNewConnections", maxNewConnections);
   }
 
-  public void setMaxNewConnectionResetTimeInMs(final long maxNewConnectionResetTimeInMs) {
-    this.maxNewConnectionResetTimeInMs = maxNewConnectionResetTimeInMs;
+  public void setMaxNewConnectionsResetTimeInMs(final long maxNewConnectionsResetTimeInMs) {
+    this.maxNewConnectionsResetTimeInMs = maxNewConnectionsResetTimeInMs;
+  }
+
+  public void setMaxNewConnectionsWaitTimeInMs(final long maxNewConnectionsWaitTimeInMs) {
+    this.maxNewConnectionsWaitTimeInMs = maxNewConnectionsWaitTimeInMs;
   }
 
   @Override
   public String toString() {
     return String.format(
-        "%s[id=%s, name=%s, maxConcurrency=%d, maxNewConnectionRequests=%d, maxNewConnectionResetTimeInMs=%s]",
+        "%s[id=%s, name=%s, maxConcurrency=%d, maxNewConnections=%d, maxNewConnectionsResetTimeInMs=%s, maxNewConnectionsWaitTimeInMs=%s]",
         ThrottlingConfig.class.getSimpleName(),
         this.id,
         this.name,
         this.maxConcurrency,
-        this.maxNewConnectionRequests,
-        this.maxNewConnectionResetTimeInMs);
+        this.maxNewConnections,
+        this.maxNewConnectionsResetTimeInMs,
+        this.maxNewConnectionsWaitTimeInMs);
   }
 
   @Override

--- a/osgp/platform/osgp-throttling-service/src/main/java/org/opensmartgridplatform/throttling/entities/ThrottlingConfig.java
+++ b/osgp/platform/osgp-throttling-service/src/main/java/org/opensmartgridplatform/throttling/entities/ThrottlingConfig.java
@@ -65,17 +65,17 @@ public class ThrottlingConfig {
       final long maxNewConnectionsWaitTimeInMs) {
     this.id = id;
     this.name = Objects.requireNonNull(name, "name must not be null");
-    this.maxConcurrency = this.requireNonNegative("maxConcurrency", maxConcurrency);
-    this.maxNewConnections = this.requireNonNegative("maxNewConnections", maxNewConnections);
+    this.maxConcurrency = this.requireMinMinusOne("maxConcurrency", maxConcurrency);
+    this.maxNewConnections = this.requireMinMinusOne("maxNewConnections", maxNewConnections);
     this.maxNewConnectionsResetTimeInMs =
         this.requireNonNegative("maxNewConnectionsResetTimeInMs", maxNewConnectionsResetTimeInMs);
     this.maxNewConnectionsWaitTimeInMs =
         this.requireNonNegative("maxNewConnectionsWaitTimeInMs", maxNewConnectionsWaitTimeInMs);
   }
 
-  private int requireNonNegative(final String fieldName, final int value) {
-    if (value < 0) {
-      throw new IllegalArgumentException(fieldName + " must be non-negative: " + value);
+  private int requireMinMinusOne(final String fieldName, final int value) {
+    if (value < -1) {
+      throw new IllegalArgumentException(fieldName + " must be minimal -1: " + value);
     }
     return value;
   }
@@ -88,11 +88,11 @@ public class ThrottlingConfig {
   }
 
   public void setMaxConcurrency(final int maxConcurrency) {
-    this.maxConcurrency = this.requireNonNegative("maxConcurrency", maxConcurrency);
+    this.maxConcurrency = this.requireMinMinusOne("maxConcurrency", maxConcurrency);
   }
 
   public void setMaxNewConnections(final int maxNewConnections) {
-    this.maxNewConnections = this.requireNonNegative("maxNewConnections", maxNewConnections);
+    this.maxNewConnections = this.requireMinMinusOne("maxNewConnections", maxNewConnections);
   }
 
   public void setMaxNewConnectionsResetTimeInMs(final long maxNewConnectionsResetTimeInMs) {

--- a/osgp/platform/osgp-throttling-service/src/main/java/org/opensmartgridplatform/throttling/mapping/ThrottlingMapper.java
+++ b/osgp/platform/osgp-throttling-service/src/main/java/org/opensmartgridplatform/throttling/mapping/ThrottlingMapper.java
@@ -14,6 +14,9 @@ public class ThrottlingMapper extends ConfigurableMapper {
   private static final String ID = "id";
   private static final String NAME = "name";
   private static final String MAX_CONCURRENCY = "maxConcurrency";
+  private static final String MAX_OPEN_CONNECTIONS = "maxOpenConnections";
+  private static final String MAX_NEW_CONNECTION_REQUESTS = "maxNewConnectionRequests";
+  private static final String MAX_NEW_CONNECTION_RESET_TIME_IN_MS = "maxNewConnectionResetTimeInMs";
 
   @Override
   protected void configure(final MapperFactory factory) {
@@ -26,8 +29,20 @@ public class ThrottlingMapper extends ConfigurableMapper {
             .classMap(
                 org.opensmartgridplatform.throttling.api.ThrottlingConfig.class,
                 org.opensmartgridplatform.throttling.entities.ThrottlingConfig.class)
-            .constructorA(ID, NAME, MAX_CONCURRENCY)
-            .constructorB(NAME, MAX_CONCURRENCY) // a new entity does not get its ID from the API
+            .constructorA(
+                ID,
+                NAME,
+                MAX_CONCURRENCY,
+                MAX_OPEN_CONNECTIONS,
+                MAX_NEW_CONNECTION_REQUESTS,
+                MAX_NEW_CONNECTION_RESET_TIME_IN_MS)
+            .constructorB(
+                NAME,
+                MAX_CONCURRENCY,
+                MAX_OPEN_CONNECTIONS,
+                MAX_NEW_CONNECTION_REQUESTS,
+                MAX_NEW_CONNECTION_RESET_TIME_IN_MS) // a new entity does not get its ID from the
+            // API
             .fieldBToA(ID, ID) // entity ID is not updated from the API
             .fieldBToA(NAME, NAME) // name is not updated from the API
             .byDefault()

--- a/osgp/platform/osgp-throttling-service/src/main/java/org/opensmartgridplatform/throttling/mapping/ThrottlingMapper.java
+++ b/osgp/platform/osgp-throttling-service/src/main/java/org/opensmartgridplatform/throttling/mapping/ThrottlingMapper.java
@@ -14,9 +14,10 @@ public class ThrottlingMapper extends ConfigurableMapper {
   private static final String ID = "id";
   private static final String NAME = "name";
   private static final String MAX_CONCURRENCY = "maxConcurrency";
-  private static final String MAX_OPEN_CONNECTIONS = "maxOpenConnections";
-  private static final String MAX_NEW_CONNECTION_REQUESTS = "maxNewConnectionRequests";
-  private static final String MAX_NEW_CONNECTION_RESET_TIME_IN_MS = "maxNewConnectionResetTimeInMs";
+  private static final String MAX_NEW_CONNECTIONS = "maxNewConnections";
+  private static final String MAX_NEW_CONNECTIONS_RESET_TIME_IN_MS =
+      "maxNewConnectionsResetTimeInMs";
+  private static final String MAX_NEW_CONNECTIONS_WAIT_TIME_IN_MS = "maxNewConnectionsWaitTimeInMs";
 
   @Override
   protected void configure(final MapperFactory factory) {
@@ -33,15 +34,15 @@ public class ThrottlingMapper extends ConfigurableMapper {
                 ID,
                 NAME,
                 MAX_CONCURRENCY,
-                MAX_OPEN_CONNECTIONS,
-                MAX_NEW_CONNECTION_REQUESTS,
-                MAX_NEW_CONNECTION_RESET_TIME_IN_MS)
+                MAX_NEW_CONNECTIONS,
+                MAX_NEW_CONNECTIONS_RESET_TIME_IN_MS,
+                MAX_NEW_CONNECTIONS_WAIT_TIME_IN_MS)
             .constructorB(
                 NAME,
                 MAX_CONCURRENCY,
-                MAX_OPEN_CONNECTIONS,
-                MAX_NEW_CONNECTION_REQUESTS,
-                MAX_NEW_CONNECTION_RESET_TIME_IN_MS) // a new entity does not get its ID from the
+                MAX_NEW_CONNECTIONS,
+                MAX_NEW_CONNECTIONS_RESET_TIME_IN_MS,
+                MAX_NEW_CONNECTIONS_WAIT_TIME_IN_MS) // a new entity does not get its ID from the
             // API
             .fieldBToA(ID, ID) // entity ID is not updated from the API
             .fieldBToA(NAME, NAME) // name is not updated from the API

--- a/osgp/platform/osgp-throttling-service/src/main/java/org/opensmartgridplatform/throttling/model/ThrottlingSettings.java
+++ b/osgp/platform/osgp-throttling-service/src/main/java/org/opensmartgridplatform/throttling/model/ThrottlingSettings.java
@@ -8,7 +8,9 @@ public interface ThrottlingSettings {
 
   int getMaxConcurrency();
 
-  int getMaxNewConnectionRequests();
+  int getMaxNewConnections();
 
-  long getMaxNewConnectionResetTimeInMs();
+  long getMaxNewConnectionsResetTimeInMs();
+
+  long getMaxNewConnectionsWaitTimeInMs();
 }

--- a/osgp/platform/osgp-throttling-service/src/main/java/org/opensmartgridplatform/throttling/model/ThrottlingSettings.java
+++ b/osgp/platform/osgp-throttling-service/src/main/java/org/opensmartgridplatform/throttling/model/ThrottlingSettings.java
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: Copyright Contributors to the GXF project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package org.opensmartgridplatform.throttling.model;
+
+public interface ThrottlingSettings {
+
+  int getMaxConcurrency();
+
+  int getMaxNewConnectionRequests();
+
+  long getMaxNewConnectionResetTimeInMs();
+}

--- a/osgp/platform/osgp-throttling-service/src/main/java/org/opensmartgridplatform/throttling/web/api/ThrottlingConfigController.java
+++ b/osgp/platform/osgp-throttling-service/src/main/java/org/opensmartgridplatform/throttling/web/api/ThrottlingConfigController.java
@@ -9,8 +9,8 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 import javax.validation.Valid;
-import org.opensmartgridplatform.throttling.MaxConcurrencyByThrottlingConfig;
 import org.opensmartgridplatform.throttling.PermitsByThrottlingConfig;
+import org.opensmartgridplatform.throttling.ThrottlingConfigCache;
 import org.opensmartgridplatform.throttling.api.ThrottlingConfig;
 import org.opensmartgridplatform.throttling.mapping.ThrottlingMapper;
 import org.opensmartgridplatform.throttling.repositories.ThrottlingConfigRepository;
@@ -42,18 +42,18 @@ public class ThrottlingConfigController {
 
   private final ThrottlingMapper throttlingMapper;
   private final ThrottlingConfigRepository throttlingConfigRepository;
-  private final MaxConcurrencyByThrottlingConfig maxConcurrencyByThrottlingConfig;
+  private final ThrottlingConfigCache throttlingConfigCache;
   private final PermitsByThrottlingConfig permitsByThrottlingConfig;
 
   public ThrottlingConfigController(
       final ThrottlingMapper throttlingMapper,
       final ThrottlingConfigRepository throttlingConfigRepository,
-      final MaxConcurrencyByThrottlingConfig maxConcurrencyByThrottlingConfig,
+      final ThrottlingConfigCache throttlingConfigCache,
       final PermitsByThrottlingConfig permitsByThrottlingConfig) {
 
     this.throttlingMapper = throttlingMapper;
     this.throttlingConfigRepository = throttlingConfigRepository;
-    this.maxConcurrencyByThrottlingConfig = maxConcurrencyByThrottlingConfig;
+    this.throttlingConfigCache = throttlingConfigCache;
     this.permitsByThrottlingConfig = permitsByThrottlingConfig;
   }
 
@@ -120,18 +120,18 @@ public class ThrottlingConfigController {
               throttlingConfig.getId());
         }
 
-        final int oldMaxConcurrency = throttlingConfigEntity.getMaxConcurrency();
+        final String oldThrottlingConfigValues = throttlingConfigEntity.toString();
         this.updateThrottlingConfig(throttlingConfigEntity, throttlingConfig);
         throttlingConfigEntity =
             this.throttlingConfigRepository.saveAndFlush(throttlingConfigEntity);
         LOGGER.info(
-            "Updated throttling configuration: {} (previous max concurrency: {})",
+            "Updated throttling configuration: {} (previous: {})",
             throttlingConfigEntity,
-            oldMaxConcurrency);
+            oldThrottlingConfigValues);
       }
 
-      this.maxConcurrencyByThrottlingConfig.setMaxConcurrency(
-          throttlingConfigEntity.getId(), throttlingConfigEntity.getMaxConcurrency());
+      this.throttlingConfigCache.setThrottlingConfig(
+          throttlingConfigEntity.getId(), throttlingConfigEntity);
 
     } finally {
       this.throttlingConfigLock.unlock();
@@ -143,7 +143,11 @@ public class ThrottlingConfigController {
   private boolean throttlingConfigNeedsUpdate(
       final org.opensmartgridplatform.throttling.entities.ThrottlingConfig throttlingConfigEntity,
       final ThrottlingConfig throttlingConfig) {
-    return throttlingConfigEntity.getMaxConcurrency() != throttlingConfig.getMaxConcurrency();
+    return throttlingConfigEntity.getMaxConcurrency() != throttlingConfig.getMaxConcurrency()
+        || throttlingConfigEntity.getMaxNewConnectionRequests()
+            != throttlingConfig.getMaxNewConnectionRequests()
+        || throttlingConfigEntity.getMaxNewConnectionResetTimeInMs()
+            != throttlingConfig.getMaxNewConnectionResetTimeInMs();
   }
 
   private void updateThrottlingConfig(

--- a/osgp/platform/osgp-throttling-service/src/main/java/org/opensmartgridplatform/throttling/web/api/ThrottlingConfigController.java
+++ b/osgp/platform/osgp-throttling-service/src/main/java/org/opensmartgridplatform/throttling/web/api/ThrottlingConfigController.java
@@ -144,10 +144,11 @@ public class ThrottlingConfigController {
       final org.opensmartgridplatform.throttling.entities.ThrottlingConfig throttlingConfigEntity,
       final ThrottlingConfig throttlingConfig) {
     return throttlingConfigEntity.getMaxConcurrency() != throttlingConfig.getMaxConcurrency()
-        || throttlingConfigEntity.getMaxNewConnectionRequests()
-            != throttlingConfig.getMaxNewConnectionRequests()
-        || throttlingConfigEntity.getMaxNewConnectionResetTimeInMs()
-            != throttlingConfig.getMaxNewConnectionResetTimeInMs();
+        || throttlingConfigEntity.getMaxNewConnections() != throttlingConfig.getMaxNewConnections()
+        || throttlingConfigEntity.getMaxNewConnectionsResetTimeInMs()
+            != throttlingConfig.getMaxNewConnectionsResetTimeInMs()
+        || throttlingConfigEntity.getMaxNewConnectionsWaitTimeInMs()
+            != throttlingConfig.getMaxNewConnectionsWaitTimeInMs();
   }
 
   private void updateThrottlingConfig(

--- a/osgp/platform/osgp-throttling-service/src/main/resources/db/migration/V20240219154738745__add_max_connections.sql
+++ b/osgp/platform/osgp-throttling-service/src/main/resources/db/migration/V20240219154738745__add_max_connections.sql
@@ -1,5 +1,7 @@
-ALTER TABLE throttling_config ADD COLUMN max_new_connection_requests integer NOT NULL;
-ALTER TABLE throttling_config ADD COLUMN max_new_connection_reset_time_in_ms bigint NOT NULL;
+ALTER TABLE throttling_config ADD COLUMN max_new_connections integer NOT NULL;
+ALTER TABLE throttling_config ADD COLUMN max_new_connections_reset_time_in_ms bigint NOT NULL;
+ALTER TABLE throttling_config ADD COLUMN max_new_connections_wait_time_in_ms bigint NOT NULL;
 
-ALTER TABLE throttling_config ADD CONSTRAINT throttling_config_max_new_connection_requests_non_negative CHECK (max_new_connection_requests > -1);
-ALTER TABLE throttling_config ADD CONSTRAINT throttling_config_max_new_connection_reset_time_in_ms_non_negative CHECK (max_new_connection_reset_time_in_ms > -1);
+ALTER TABLE throttling_config ADD CONSTRAINT throttling_config_max_new_connections_non_negative CHECK (max_new_connections > -1);
+ALTER TABLE throttling_config ADD CONSTRAINT throttling_config_max_new_connections_reset_time_in_ms_non_negative CHECK (max_new_connections_reset_time_in_ms > -1);
+ALTER TABLE throttling_config ADD CONSTRAINT throttling_config_max_new_connections_wait_time_in_ms_non_negative CHECK (max_new_connections_wait_time_in_ms > -1);

--- a/osgp/platform/osgp-throttling-service/src/main/resources/db/migration/V20240219154738745__add_max_connections.sql
+++ b/osgp/platform/osgp-throttling-service/src/main/resources/db/migration/V20240219154738745__add_max_connections.sql
@@ -1,7 +1,5 @@
-ALTER TABLE throttling_config ADD COLUMN max_open_connections integer NOT NULL;
 ALTER TABLE throttling_config ADD COLUMN max_new_connection_requests integer NOT NULL;
 ALTER TABLE throttling_config ADD COLUMN max_new_connection_reset_time_in_ms bigint NOT NULL;
 
-ALTER TABLE throttling_config ADD CONSTRAINT throttling_config_max_open_connections_non_negative CHECK (max_open_connections > -1);
 ALTER TABLE throttling_config ADD CONSTRAINT throttling_config_max_new_connection_requests_non_negative CHECK (max_new_connection_requests > -1);
 ALTER TABLE throttling_config ADD CONSTRAINT throttling_config_max_new_connection_reset_time_in_ms_non_negative CHECK (max_new_connection_reset_time_in_ms > -1);

--- a/osgp/platform/osgp-throttling-service/src/main/resources/db/migration/V20240219154738745__add_max_connections.sql
+++ b/osgp/platform/osgp-throttling-service/src/main/resources/db/migration/V20240219154738745__add_max_connections.sql
@@ -2,6 +2,9 @@ ALTER TABLE throttling_config ADD COLUMN max_new_connections integer NOT NULL;
 ALTER TABLE throttling_config ADD COLUMN max_new_connections_reset_time_in_ms bigint NOT NULL;
 ALTER TABLE throttling_config ADD COLUMN max_new_connections_wait_time_in_ms bigint NOT NULL;
 
-ALTER TABLE throttling_config ADD CONSTRAINT throttling_config_max_new_connections_non_negative CHECK (max_new_connections > -1);
+ALTER TABLE throttling_config DROP CONSTRAINT throttling_config_max_concurrency_non_negative;
+
+ALTER TABLE throttling_config ADD CONSTRAINT throttling_config_max_concurrency_check CHECK (max_concurrency >= -1);
+ALTER TABLE throttling_config ADD CONSTRAINT throttling_config_max_new_connections_check CHECK (max_new_connections >= -1);
 ALTER TABLE throttling_config ADD CONSTRAINT throttling_config_max_new_connections_reset_time_in_ms_non_negative CHECK (max_new_connections_reset_time_in_ms > -1);
 ALTER TABLE throttling_config ADD CONSTRAINT throttling_config_max_new_connections_wait_time_in_ms_non_negative CHECK (max_new_connections_wait_time_in_ms > -1);

--- a/osgp/platform/osgp-throttling-service/src/main/resources/db/migration/V20240219154738745__add_max_connections.sql
+++ b/osgp/platform/osgp-throttling-service/src/main/resources/db/migration/V20240219154738745__add_max_connections.sql
@@ -1,0 +1,7 @@
+ALTER TABLE throttling_config ADD COLUMN max_open_connections integer NOT NULL;
+ALTER TABLE throttling_config ADD COLUMN max_new_connection_requests integer NOT NULL;
+ALTER TABLE throttling_config ADD COLUMN max_new_connection_reset_time_in_ms bigint NOT NULL;
+
+ALTER TABLE throttling_config ADD CONSTRAINT throttling_config_max_open_connections_non_negative CHECK (max_open_connections > -1);
+ALTER TABLE throttling_config ADD CONSTRAINT throttling_config_max_new_connection_requests_non_negative CHECK (max_new_connection_requests > -1);
+ALTER TABLE throttling_config ADD CONSTRAINT throttling_config_max_new_connection_reset_time_in_ms_non_negative CHECK (max_new_connection_reset_time_in_ms > -1);

--- a/osgp/platform/osgp-throttling-service/src/main/resources/osgp-throttling-service.properties
+++ b/osgp/platform/osgp-throttling-service/src/main/resources/osgp-throttling-service.properties
@@ -33,6 +33,7 @@ cleanup.permits.batch.size=100
 
 wait.for.high.prio.enabled=true
 wait.for.high.prio.max.in.ms=10000
+wait.for.new.connection.request.max.in.ms=60000
 
 # The task to reset in memory counters with db state is executed by cron expression.
 scheduling.task.reinitialize.state.cron.expression=30 0/30 * * * ?

--- a/osgp/platform/osgp-throttling-service/src/main/resources/osgp-throttling-service.properties
+++ b/osgp/platform/osgp-throttling-service/src/main/resources/osgp-throttling-service.properties
@@ -33,7 +33,6 @@ cleanup.permits.batch.size=100
 
 wait.for.high.prio.enabled=true
 wait.for.high.prio.max.in.ms=10000
-wait.for.new.connection.request.max.in.ms=60000
 
 # The task to reset in memory counters with db state is executed by cron expression.
 scheduling.task.reinitialize.state.cron.expression=30 0/30 * * * ?

--- a/osgp/platform/osgp-throttling-service/src/test/java/org/opensmartgridplatform/throttling/NetworkUser.java
+++ b/osgp/platform/osgp-throttling-service/src/test/java/org/opensmartgridplatform/throttling/NetworkUser.java
@@ -21,7 +21,6 @@ public class NetworkUser {
   private final String throttlingIdentity;
 
   private final int initialMaxConcurrency;
-  private final int initialMaxOpenConnections;
   private final int initialMaxNewConnectionRequests;
   private final long initialMaxNewConnectionResetTimeInMs;
   private short throttlingConfigId = -1;
@@ -36,7 +35,6 @@ public class NetworkUser {
   public NetworkUser(
       final String throttlingIdentity,
       final int initialMaxConcurrency,
-      final int initialMaxOpenConnections,
       final int initialMaxNewConnectionRequests,
       final long initialMaxNewConnectionResetTimeInMs,
       final FakeConcurrencyRestrictedNetwork network,
@@ -45,7 +43,6 @@ public class NetworkUser {
 
     this.throttlingIdentity = throttlingIdentity;
     this.initialMaxConcurrency = initialMaxConcurrency;
-    this.initialMaxOpenConnections = initialMaxOpenConnections;
     this.initialMaxNewConnectionRequests = initialMaxNewConnectionRequests;
     this.initialMaxNewConnectionResetTimeInMs = initialMaxNewConnectionResetTimeInMs;
     this.network = network;

--- a/osgp/platform/osgp-throttling-service/src/test/java/org/opensmartgridplatform/throttling/NetworkUser.java
+++ b/osgp/platform/osgp-throttling-service/src/test/java/org/opensmartgridplatform/throttling/NetworkUser.java
@@ -21,8 +21,9 @@ public class NetworkUser {
   private final String throttlingIdentity;
 
   private final int initialMaxConcurrency;
-  private final int initialMaxNewConnectionRequests;
-  private final long initialMaxNewConnectionResetTimeInMs;
+  private final int initialMaxNewConnections;
+  private final long initialMaxNewConnectionsResetTimeInMs;
+  private final long initialMaxNewConnectionsWaitTimeInMs;
   private short throttlingConfigId = -1;
   private final String clientIdentity = "client-" + clientNumber.incrementAndGet();
   private int clientId = -1;
@@ -35,16 +36,18 @@ public class NetworkUser {
   public NetworkUser(
       final String throttlingIdentity,
       final int initialMaxConcurrency,
-      final int initialMaxNewConnectionRequests,
-      final long initialMaxNewConnectionResetTimeInMs,
+      final int initialMaxNewConnections,
+      final long initialMaxNewConnectionsResetTimeInMs,
+      final long initialMaxNewConnectionsWaitTimeInMs,
       final FakeConcurrencyRestrictedNetwork network,
       final RestTemplate restTemplate,
       final NetworkTaskQueue networkTaskQueue) {
 
     this.throttlingIdentity = throttlingIdentity;
     this.initialMaxConcurrency = initialMaxConcurrency;
-    this.initialMaxNewConnectionRequests = initialMaxNewConnectionRequests;
-    this.initialMaxNewConnectionResetTimeInMs = initialMaxNewConnectionResetTimeInMs;
+    this.initialMaxNewConnections = initialMaxNewConnections;
+    this.initialMaxNewConnectionsResetTimeInMs = initialMaxNewConnectionsResetTimeInMs;
+    this.initialMaxNewConnectionsWaitTimeInMs = initialMaxNewConnectionsWaitTimeInMs;
     this.network = network;
     this.restTemplate = restTemplate;
     this.networkTaskQueue = networkTaskQueue;
@@ -125,8 +128,9 @@ public class NetworkUser {
             new ThrottlingConfig(
                 this.throttlingIdentity,
                 this.initialMaxConcurrency,
-                this.initialMaxNewConnectionRequests,
-                this.initialMaxNewConnectionResetTimeInMs),
+                this.initialMaxNewConnections,
+                this.initialMaxNewConnectionsResetTimeInMs,
+                this.initialMaxNewConnectionsWaitTimeInMs),
             Short.class);
 
     if (throttlingConfigResponse.getStatusCode().series() != HttpStatus.Series.SUCCESSFUL

--- a/osgp/platform/osgp-throttling-service/src/test/java/org/opensmartgridplatform/throttling/NetworkUser.java
+++ b/osgp/platform/osgp-throttling-service/src/test/java/org/opensmartgridplatform/throttling/NetworkUser.java
@@ -21,6 +21,9 @@ public class NetworkUser {
   private final String throttlingIdentity;
 
   private final int initialMaxConcurrency;
+  private final int initialMaxOpenConnections;
+  private final int initialMaxNewConnectionRequests;
+  private final long initialMaxNewConnectionResetTimeInMs;
   private short throttlingConfigId = -1;
   private final String clientIdentity = "client-" + clientNumber.incrementAndGet();
   private int clientId = -1;
@@ -33,12 +36,18 @@ public class NetworkUser {
   public NetworkUser(
       final String throttlingIdentity,
       final int initialMaxConcurrency,
+      final int initialMaxOpenConnections,
+      final int initialMaxNewConnectionRequests,
+      final long initialMaxNewConnectionResetTimeInMs,
       final FakeConcurrencyRestrictedNetwork network,
       final RestTemplate restTemplate,
       final NetworkTaskQueue networkTaskQueue) {
 
     this.throttlingIdentity = throttlingIdentity;
     this.initialMaxConcurrency = initialMaxConcurrency;
+    this.initialMaxOpenConnections = initialMaxOpenConnections;
+    this.initialMaxNewConnectionRequests = initialMaxNewConnectionRequests;
+    this.initialMaxNewConnectionResetTimeInMs = initialMaxNewConnectionResetTimeInMs;
     this.network = network;
     this.restTemplate = restTemplate;
     this.networkTaskQueue = networkTaskQueue;
@@ -116,7 +125,11 @@ public class NetworkUser {
     final ResponseEntity<Short> throttlingConfigResponse =
         this.restTemplate.postForEntity(
             "/throttling-configs",
-            new ThrottlingConfig(this.throttlingIdentity, this.initialMaxConcurrency),
+            new ThrottlingConfig(
+                this.throttlingIdentity,
+                this.initialMaxConcurrency,
+                this.initialMaxNewConnectionRequests,
+                this.initialMaxNewConnectionResetTimeInMs),
             Short.class);
 
     if (throttlingConfigResponse.getStatusCode().series() != HttpStatus.Series.SUCCESSFUL

--- a/osgp/platform/osgp-throttling-service/src/test/java/org/opensmartgridplatform/throttling/NewConnectionRequestThrottlerTest.java
+++ b/osgp/platform/osgp-throttling-service/src/test/java/org/opensmartgridplatform/throttling/NewConnectionRequestThrottlerTest.java
@@ -1,0 +1,80 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Contributors to the GXF project
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensmartgridplatform.throttling;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
+
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+class NewConnectionRequestThrottlerTest {
+  private final int PRIORITY = 8;
+  private final int MAX_NEW_CONNECTION_REQUESTS = 1;
+  private final long RESET_TIME_IN_MS = 200;
+  private final long MAX_WAIT_FOR_NEW_CONNECTION_REQUEST_IN_MS = 100;
+
+  @Test
+  void isNewConnectionRequestAllowed() {
+    final NewConnectionRequestThrottler throttler =
+        new NewConnectionRequestThrottler(
+            this.MAX_NEW_CONNECTION_REQUESTS,
+            this.RESET_TIME_IN_MS,
+            this.MAX_WAIT_FOR_NEW_CONNECTION_REQUEST_IN_MS);
+
+    long startTime = System.currentTimeMillis();
+    // First success
+    assertThat(throttler.isNewConnectionRequestAllowed(this.PRIORITY)).isTrue();
+    assertThat(System.currentTimeMillis() - startTime)
+        .isLessThan(this.MAX_WAIT_FOR_NEW_CONNECTION_REQUEST_IN_MS);
+
+    // Second fail
+    startTime = System.currentTimeMillis();
+    assertThat(throttler.isNewConnectionRequestAllowed(this.PRIORITY)).isFalse();
+    assertThat(System.currentTimeMillis() - startTime)
+        .isGreaterThanOrEqualTo(this.MAX_WAIT_FOR_NEW_CONNECTION_REQUEST_IN_MS);
+  }
+
+  @Test
+  void newConnectionRequestAllowedAfterReset() {
+    final NewConnectionRequestThrottler throttler =
+        new NewConnectionRequestThrottler(
+            this.MAX_NEW_CONNECTION_REQUESTS,
+            this.RESET_TIME_IN_MS,
+            this.MAX_WAIT_FOR_NEW_CONNECTION_REQUEST_IN_MS);
+
+    final long startTime = System.currentTimeMillis();
+    // First success
+    assertThat(throttler.isNewConnectionRequestAllowed(this.PRIORITY)).isTrue();
+    assertThat(System.currentTimeMillis() - startTime)
+        .isLessThan(this.MAX_WAIT_FOR_NEW_CONNECTION_REQUEST_IN_MS);
+
+    // Second fail
+    assertThat(throttler.isNewConnectionRequestAllowed(this.PRIORITY)).isFalse();
+    assertThat(System.currentTimeMillis() - startTime).isLessThan(this.RESET_TIME_IN_MS);
+
+    // Third success after reset
+    await()
+        .atMost(this.RESET_TIME_IN_MS + 100, TimeUnit.MILLISECONDS)
+        .untilAsserted(
+            () -> assertThat(throttler.isNewConnectionRequestAllowed(this.PRIORITY)).isTrue());
+  }
+
+  @Test
+  void resetManyTimesAndFast() {
+    final NewConnectionRequestThrottler throttler = new NewConnectionRequestThrottler(1, 1, 10);
+
+    for (int i = 0; i < 1000; i++) {
+      final long startTime = System.currentTimeMillis();
+
+      assertThat(throttler.isNewConnectionRequestAllowed(this.PRIORITY)).isTrue();
+
+      assertThat(System.currentTimeMillis() - startTime)
+          .isLessThan(this.MAX_WAIT_FOR_NEW_CONNECTION_REQUEST_IN_MS);
+    }
+  }
+}

--- a/osgp/platform/osgp-throttling-service/src/test/java/org/opensmartgridplatform/throttling/NewConnectionRequestThrottlerTest.java
+++ b/osgp/platform/osgp-throttling-service/src/test/java/org/opensmartgridplatform/throttling/NewConnectionRequestThrottlerTest.java
@@ -66,7 +66,7 @@ class NewConnectionRequestThrottlerTest {
 
   @Test
   void resetManyTimesAndFast() {
-    final NewConnectionRequestThrottler throttler = new NewConnectionRequestThrottler(1, 1, 10);
+    final NewConnectionRequestThrottler throttler = new NewConnectionRequestThrottler(1, 1, 100);
 
     for (int i = 0; i < 1000; i++) {
       final long startTime = System.currentTimeMillis();

--- a/osgp/platform/osgp-throttling-service/src/test/java/org/opensmartgridplatform/throttling/PermitsByThrottlingConfigTest.java
+++ b/osgp/platform/osgp-throttling-service/src/test/java/org/opensmartgridplatform/throttling/PermitsByThrottlingConfigTest.java
@@ -59,9 +59,17 @@ class PermitsByThrottlingConfigTest {
     final short configId = Integer.valueOf(1).shortValue();
     final String name = "config1";
     final int maxConcurrency = 10;
+    final int maxNewConnectionRequests = 12;
+    final long maxNewConnectionResetTimeInMs = 1000;
 
     final List<ThrottlingConfig> throttlingConfigs =
-        List.of(new ThrottlingConfig(configId, name, maxConcurrency));
+        List.of(
+            new ThrottlingConfig(
+                configId,
+                name,
+                maxConcurrency,
+                maxNewConnectionRequests,
+                maxNewConnectionResetTimeInMs));
     when(this.throttlingConfigRepository.findAll()).thenReturn(throttlingConfigs);
     when(this.permitRepository.permitsByNetworkSegment(configId)).thenReturn(Lists.emptyList());
 
@@ -78,13 +86,22 @@ class PermitsByThrottlingConfigTest {
     final short configId = Integer.valueOf(1).shortValue();
     final String name = "config1";
     final int maxConcurrency = 10;
+    final int maxNewConnectionRequests = 12;
+    final long maxNewConnectionResetTimeInMs = 1000;
 
-    this.prepare(configId, name, maxConcurrency);
+    this.prepare(
+        configId, name, maxConcurrency, maxNewConnectionRequests, maxNewConnectionResetTimeInMs);
 
     final short newConfigId = Integer.valueOf(1).shortValue();
 
     final List<ThrottlingConfig> throttlingConfigs =
-        List.of(new ThrottlingConfig(newConfigId, name, maxConcurrency));
+        List.of(
+            new ThrottlingConfig(
+                newConfigId,
+                name,
+                maxConcurrency,
+                maxNewConnectionRequests,
+                maxNewConnectionResetTimeInMs));
     when(this.throttlingConfigRepository.findAll()).thenReturn(throttlingConfigs);
     when(this.permitRepository.permitsByNetworkSegment(newConfigId)).thenReturn(Lists.emptyList());
 
@@ -101,11 +118,20 @@ class PermitsByThrottlingConfigTest {
     final short configId = Integer.valueOf(1).shortValue();
     final String name = "config1";
     final int maxConcurrency = 10;
+    final int maxNewConnectionRequests = 12;
+    final long maxNewConnectionResetTimeInMs = 1000;
 
-    this.prepare(configId, name, maxConcurrency);
+    this.prepare(
+        configId, name, maxConcurrency, maxNewConnectionRequests, maxNewConnectionResetTimeInMs);
 
     final List<ThrottlingConfig> throttlingConfigs =
-        List.of(new ThrottlingConfig(configId, name, maxConcurrency));
+        List.of(
+            new ThrottlingConfig(
+                configId,
+                name,
+                maxConcurrency,
+                maxNewConnectionRequests,
+                maxNewConnectionResetTimeInMs));
     when(this.throttlingConfigRepository.findAll()).thenReturn(throttlingConfigs);
     when(this.permitRepository.permitsByNetworkSegment(configId)).thenReturn(Lists.emptyList());
 
@@ -122,8 +148,12 @@ class PermitsByThrottlingConfigTest {
     final short configId = Integer.valueOf(1).shortValue();
     final String name = "config1";
     final int maxConcurrency = 10;
+    final int maxOpenonnections = 11;
+    final int maxNewConnectionRequests = 12;
+    final long maxNewConnectionResetTimeInMs = 1000;
 
-    this.prepare(configId, name, maxConcurrency);
+    this.prepare(
+        configId, name, maxConcurrency, maxNewConnectionRequests, maxNewConnectionResetTimeInMs);
     reset(this.permitRepository);
 
     when(this.throttlingConfigRepository.findAll()).thenReturn(Lists.emptyList());
@@ -136,9 +166,20 @@ class PermitsByThrottlingConfigTest {
     assertThat(permitsPerNetworkSegmentByConfig).isEmpty();
   }
 
-  private void prepare(final short configId, final String name, final int maxConcurrency) {
+  private void prepare(
+      final short configId,
+      final String name,
+      final int maxConcurrency,
+      final int maxNewConnectionRequests,
+      final long maxNewConnectionResetTimeInMs) {
     final List<ThrottlingConfig> throttlingConfigs =
-        List.of(new ThrottlingConfig(configId, name, maxConcurrency));
+        List.of(
+            new ThrottlingConfig(
+                configId,
+                name,
+                maxConcurrency,
+                maxNewConnectionRequests,
+                maxNewConnectionResetTimeInMs));
     when(this.throttlingConfigRepository.findAll()).thenReturn(throttlingConfigs);
     when(this.permitRepository.permitsByNetworkSegment(configId)).thenReturn(Lists.emptyList());
 

--- a/osgp/platform/osgp-throttling-service/src/test/java/org/opensmartgridplatform/throttling/PermitsByThrottlingConfigTest.java
+++ b/osgp/platform/osgp-throttling-service/src/test/java/org/opensmartgridplatform/throttling/PermitsByThrottlingConfigTest.java
@@ -26,6 +26,7 @@ import org.opensmartgridplatform.throttling.service.PermitReleasedNotifier;
 class PermitsByThrottlingConfigTest {
   private static final boolean WAIT_FOR_HIGH_PRIO_ENABLED = true;
   private static final int MAX_WAIT_FOR_HIGH_PRIO = 1000;
+  private static final int MAX_WAIT_FOR_NEW_CONNECTION_REQUEST = 2000;
 
   @Mock private ThrottlingConfigRepository throttlingConfigRepository;
   @Mock private PermitRepository permitRepository;
@@ -40,7 +41,8 @@ class PermitsByThrottlingConfigTest {
             this.permitRepository,
             this.permitReleasedNotifier,
             WAIT_FOR_HIGH_PRIO_ENABLED,
-            this.MAX_WAIT_FOR_HIGH_PRIO);
+            this.MAX_WAIT_FOR_HIGH_PRIO,
+            this.MAX_WAIT_FOR_NEW_CONNECTION_REQUEST);
   }
 
   @Test

--- a/osgp/platform/osgp-throttling-service/src/test/java/org/opensmartgridplatform/throttling/PermitsByThrottlingConfigTest.java
+++ b/osgp/platform/osgp-throttling-service/src/test/java/org/opensmartgridplatform/throttling/PermitsByThrottlingConfigTest.java
@@ -26,7 +26,6 @@ import org.opensmartgridplatform.throttling.service.PermitReleasedNotifier;
 class PermitsByThrottlingConfigTest {
   private static final boolean WAIT_FOR_HIGH_PRIO_ENABLED = true;
   private static final int MAX_WAIT_FOR_HIGH_PRIO = 1000;
-  private static final int MAX_WAIT_FOR_NEW_CONNECTION_REQUEST = 2000;
 
   @Mock private ThrottlingConfigRepository throttlingConfigRepository;
   @Mock private PermitRepository permitRepository;
@@ -41,8 +40,7 @@ class PermitsByThrottlingConfigTest {
             this.permitRepository,
             this.permitReleasedNotifier,
             WAIT_FOR_HIGH_PRIO_ENABLED,
-            this.MAX_WAIT_FOR_HIGH_PRIO,
-            this.MAX_WAIT_FOR_NEW_CONNECTION_REQUEST);
+            this.MAX_WAIT_FOR_HIGH_PRIO);
   }
 
   @Test
@@ -61,8 +59,9 @@ class PermitsByThrottlingConfigTest {
     final short configId = Integer.valueOf(1).shortValue();
     final String name = "config1";
     final int maxConcurrency = 10;
-    final int maxNewConnectionRequests = 12;
-    final long maxNewConnectionResetTimeInMs = 1000;
+    final int maxNewConnections = 12;
+    final long maxNewConnectionsResetTimeInMs = 1000;
+    final long maxNewConnectionsWaitTimeInMs = 1000;
 
     final List<ThrottlingConfig> throttlingConfigs =
         List.of(
@@ -70,8 +69,9 @@ class PermitsByThrottlingConfigTest {
                 configId,
                 name,
                 maxConcurrency,
-                maxNewConnectionRequests,
-                maxNewConnectionResetTimeInMs));
+                maxNewConnections,
+                maxNewConnectionsResetTimeInMs,
+                maxNewConnectionsWaitTimeInMs));
     when(this.throttlingConfigRepository.findAll()).thenReturn(throttlingConfigs);
     when(this.permitRepository.permitsByNetworkSegment(configId)).thenReturn(Lists.emptyList());
 
@@ -88,11 +88,17 @@ class PermitsByThrottlingConfigTest {
     final short configId = Integer.valueOf(1).shortValue();
     final String name = "config1";
     final int maxConcurrency = 10;
-    final int maxNewConnectionRequests = 12;
-    final long maxNewConnectionResetTimeInMs = 1000;
+    final int maxNewConnections = 12;
+    final long maxNewConnectionsResetTimeInMs = 1000;
+    final long maxNewConnectionsWaitTimeInMs = 1000;
 
     this.prepare(
-        configId, name, maxConcurrency, maxNewConnectionRequests, maxNewConnectionResetTimeInMs);
+        configId,
+        name,
+        maxConcurrency,
+        maxNewConnections,
+        maxNewConnectionsResetTimeInMs,
+        maxNewConnectionsWaitTimeInMs);
 
     final short newConfigId = Integer.valueOf(1).shortValue();
 
@@ -102,8 +108,9 @@ class PermitsByThrottlingConfigTest {
                 newConfigId,
                 name,
                 maxConcurrency,
-                maxNewConnectionRequests,
-                maxNewConnectionResetTimeInMs));
+                maxNewConnections,
+                maxNewConnectionsResetTimeInMs,
+                maxNewConnectionsWaitTimeInMs));
     when(this.throttlingConfigRepository.findAll()).thenReturn(throttlingConfigs);
     when(this.permitRepository.permitsByNetworkSegment(newConfigId)).thenReturn(Lists.emptyList());
 
@@ -120,11 +127,17 @@ class PermitsByThrottlingConfigTest {
     final short configId = Integer.valueOf(1).shortValue();
     final String name = "config1";
     final int maxConcurrency = 10;
-    final int maxNewConnectionRequests = 12;
-    final long maxNewConnectionResetTimeInMs = 1000;
+    final int maxNewConnections = 12;
+    final long maxNewConnectionsResetTimeInMs = 1000;
+    final long maxNewConnectionsWaitTimeInMs = 1000;
 
     this.prepare(
-        configId, name, maxConcurrency, maxNewConnectionRequests, maxNewConnectionResetTimeInMs);
+        configId,
+        name,
+        maxConcurrency,
+        maxNewConnections,
+        maxNewConnectionsResetTimeInMs,
+        maxNewConnectionsWaitTimeInMs);
 
     final List<ThrottlingConfig> throttlingConfigs =
         List.of(
@@ -132,8 +145,9 @@ class PermitsByThrottlingConfigTest {
                 configId,
                 name,
                 maxConcurrency,
-                maxNewConnectionRequests,
-                maxNewConnectionResetTimeInMs));
+                maxNewConnections,
+                maxNewConnectionsResetTimeInMs,
+                maxNewConnectionsWaitTimeInMs));
     when(this.throttlingConfigRepository.findAll()).thenReturn(throttlingConfigs);
     when(this.permitRepository.permitsByNetworkSegment(configId)).thenReturn(Lists.emptyList());
 
@@ -150,12 +164,17 @@ class PermitsByThrottlingConfigTest {
     final short configId = Integer.valueOf(1).shortValue();
     final String name = "config1";
     final int maxConcurrency = 10;
-    final int maxOpenonnections = 11;
-    final int maxNewConnectionRequests = 12;
-    final long maxNewConnectionResetTimeInMs = 1000;
+    final int maxNewConnections = 12;
+    final long maxNewConnectionsResetTimeInMs = 1000;
+    final long maxNewConnectionsWaitTimeInMs = 1000;
 
     this.prepare(
-        configId, name, maxConcurrency, maxNewConnectionRequests, maxNewConnectionResetTimeInMs);
+        configId,
+        name,
+        maxConcurrency,
+        maxNewConnections,
+        maxNewConnectionsResetTimeInMs,
+        maxNewConnectionsWaitTimeInMs);
     reset(this.permitRepository);
 
     when(this.throttlingConfigRepository.findAll()).thenReturn(Lists.emptyList());
@@ -172,16 +191,18 @@ class PermitsByThrottlingConfigTest {
       final short configId,
       final String name,
       final int maxConcurrency,
-      final int maxNewConnectionRequests,
-      final long maxNewConnectionResetTimeInMs) {
+      final int maxNewConnections,
+      final long maxNewConnectionsResetTimeInMs,
+      final long maxNewConnectionsWaitTimeInMs) {
     final List<ThrottlingConfig> throttlingConfigs =
         List.of(
             new ThrottlingConfig(
                 configId,
                 name,
                 maxConcurrency,
-                maxNewConnectionRequests,
-                maxNewConnectionResetTimeInMs));
+                maxNewConnections,
+                maxNewConnectionsResetTimeInMs,
+                maxNewConnectionsWaitTimeInMs));
     when(this.throttlingConfigRepository.findAll()).thenReturn(throttlingConfigs);
     when(this.permitRepository.permitsByNetworkSegment(configId)).thenReturn(Lists.emptyList());
 

--- a/osgp/platform/osgp-throttling-service/src/test/java/org/opensmartgridplatform/throttling/PermitsPerNetworkSegmentTest.java
+++ b/osgp/platform/osgp-throttling-service/src/test/java/org/opensmartgridplatform/throttling/PermitsPerNetworkSegmentTest.java
@@ -251,6 +251,59 @@ class PermitsPerNetworkSegmentTest {
   }
 
   @Test
+  void testHighPrioPoolDisabled() {
+    this.permitsPerNetworkSegment =
+        new PermitsPerNetworkSegment(
+            this.permitRepository, this.permitReleasedNotifier, false, MAX_WAIT_FOR_HIGH_PRIO);
+
+    final int btsId = 1;
+    final int cellId = 2;
+    final int numberOfPermits = 1;
+    final short throttlingConfigId = Integer.valueOf(1).shortValue();
+    final int clientId = 4;
+    final int requestId = 5;
+    final int priority = 6;
+    final int maxConcurrency = 1;
+    final ThrottlingSettings throttlingSettings =
+        this.newThrottlingSettings(maxConcurrency, 1000, 1000, 1000);
+
+    this.preparePermits(btsId, cellId, numberOfPermits, throttlingConfigId);
+
+    final boolean permitGranted =
+        this.permitsPerNetworkSegment.requestPermit(
+            throttlingConfigId, clientId, btsId, cellId, requestId, priority, throttlingSettings);
+    assertThat(permitGranted).isFalse();
+  }
+
+  @Test
+  void testLowPrioPool() {
+    this.permitsPerNetworkSegment =
+        new PermitsPerNetworkSegment(
+            this.permitRepository,
+            this.permitReleasedNotifier,
+            WAIT_FOR_HIGH_PRIO_ENABLED,
+            MAX_WAIT_FOR_HIGH_PRIO);
+
+    final int btsId = 1;
+    final int cellId = 2;
+    final int numberOfPermits = 1;
+    final short throttlingConfigId = Integer.valueOf(1).shortValue();
+    final int clientId = 4;
+    final int requestId = 5;
+    final int priority = 1;
+    final int maxConcurrency = 1;
+    final ThrottlingSettings throttlingSettings =
+        this.newThrottlingSettings(maxConcurrency, 1000, 1000, 1000);
+
+    this.preparePermits(btsId, cellId, numberOfPermits, throttlingConfigId);
+
+    final boolean permitGranted =
+        this.permitsPerNetworkSegment.requestPermit(
+            throttlingConfigId, clientId, btsId, cellId, requestId, priority, throttlingSettings);
+    assertThat(permitGranted).isFalse();
+  }
+
+  @Test
   void testMaxNewRequestsClearedInTime() {
     final long start = System.currentTimeMillis();
 
@@ -300,6 +353,17 @@ class PermitsPerNetworkSegmentTest {
     this.assertDisabledFunctions(0, 10000, false);
 
     assertThat(this.permitsPerNetworkSegment.permitsPerNetworkSegment()).isEmpty();
+  }
+
+  @Test
+  void testToString() {
+    this.permitsPerNetworkSegment =
+        new PermitsPerNetworkSegment(
+            this.permitRepository,
+            this.permitReleasedNotifier,
+            WAIT_FOR_HIGH_PRIO_ENABLED,
+            MAX_WAIT_FOR_HIGH_PRIO);
+    assertThat(this.permitsPerNetworkSegment.toString()).isNotNull();
   }
 
   void assertDisabledFunctions(

--- a/osgp/platform/osgp-throttling-service/src/test/java/org/opensmartgridplatform/throttling/ThrottlingConfigCacheTest.java
+++ b/osgp/platform/osgp-throttling-service/src/test/java/org/opensmartgridplatform/throttling/ThrottlingConfigCacheTest.java
@@ -18,17 +18,20 @@ import org.opensmartgridplatform.throttling.entities.ThrottlingConfig;
 import org.opensmartgridplatform.throttling.repositories.ThrottlingConfigRepository;
 
 @ExtendWith(MockitoExtension.class)
-class MaxConcurrencyByThrottlingConfigTest {
-  @InjectMocks private MaxConcurrencyByThrottlingConfig throttlingConfig;
+class ThrottlingConfigCacheTest {
+  @InjectMocks private ThrottlingConfigCache throttlingConfig;
   @Mock private ThrottlingConfigRepository throttlingConfigRepository;
 
   @Test
   void shouldFetchFromCache() {
     final short existingConfigId = 3;
     final int maxConcurrency = 9;
-    this.throttlingConfig.setMaxConcurrency((short) 3, maxConcurrency);
+    final ThrottlingConfig throttlingConfig = new ThrottlingConfig();
+    throttlingConfig.setMaxConcurrency(maxConcurrency);
+    this.throttlingConfig.setThrottlingConfig((short) 3, throttlingConfig);
 
-    assertThat(this.throttlingConfig.getMaxConcurrency(existingConfigId)).isEqualTo(maxConcurrency);
+    assertThat(this.throttlingConfig.getThrottlingConfig(existingConfigId).getMaxConcurrency())
+        .isEqualTo(maxConcurrency);
   }
 
   @Test
@@ -37,21 +40,30 @@ class MaxConcurrencyByThrottlingConfigTest {
     final int cachedMaxConcurrency = 9;
     final short nonCachedConfigId = 4;
     final int nonCachedMaxConcurrency = 11;
+    final int nonCachedMaxNewConnectionRequests = 12;
+    final long nonCachedMaxNewConnectionResetTimeInMs = 1000;
 
-    this.throttlingConfig.setMaxConcurrency(cachedConfigId, cachedMaxConcurrency);
+    final ThrottlingConfig cachedThrottlingConfig = new ThrottlingConfig();
+    cachedThrottlingConfig.setMaxConcurrency(cachedMaxConcurrency);
+
+    this.throttlingConfig.setThrottlingConfig(cachedConfigId, cachedThrottlingConfig);
     when(this.throttlingConfigRepository.findById(nonCachedConfigId))
         .thenReturn(
             Optional.of(
                 new ThrottlingConfig(
-                    nonCachedConfigId, "config from db", nonCachedMaxConcurrency)));
+                    nonCachedConfigId,
+                    "config from db",
+                    nonCachedMaxConcurrency,
+                    nonCachedMaxNewConnectionRequests,
+                    nonCachedMaxNewConnectionResetTimeInMs)));
 
-    assertThat(this.throttlingConfig.getMaxConcurrency(nonCachedConfigId))
+    assertThat(this.throttlingConfig.getThrottlingConfig(nonCachedConfigId).getMaxConcurrency())
         .isEqualTo(nonCachedMaxConcurrency);
   }
 
   @Test
   void shouldFailWhenNonExistent() {
-    assertThatThrownBy(() -> this.throttlingConfig.getMaxConcurrency((short) 1))
+    assertThatThrownBy(() -> this.throttlingConfig.getThrottlingConfig((short) 1))
         .hasMessageContaining("unknown");
   }
 }

--- a/osgp/platform/osgp-throttling-service/src/test/java/org/opensmartgridplatform/throttling/ThrottlingConfigCacheTest.java
+++ b/osgp/platform/osgp-throttling-service/src/test/java/org/opensmartgridplatform/throttling/ThrottlingConfigCacheTest.java
@@ -40,8 +40,9 @@ class ThrottlingConfigCacheTest {
     final int cachedMaxConcurrency = 9;
     final short nonCachedConfigId = 4;
     final int nonCachedMaxConcurrency = 11;
-    final int nonCachedMaxNewConnectionRequests = 12;
-    final long nonCachedMaxNewConnectionResetTimeInMs = 1000;
+    final int nonCachedMaxNewConnections = 12;
+    final long nonCachedMaxNewConnectionsResetTimeInMs = 1000;
+    final long nonCachedMaxNewConnectionsWaitTimeInMs = 2000;
 
     final ThrottlingConfig cachedThrottlingConfig = new ThrottlingConfig();
     cachedThrottlingConfig.setMaxConcurrency(cachedMaxConcurrency);
@@ -54,8 +55,9 @@ class ThrottlingConfigCacheTest {
                     nonCachedConfigId,
                     "config from db",
                     nonCachedMaxConcurrency,
-                    nonCachedMaxNewConnectionRequests,
-                    nonCachedMaxNewConnectionResetTimeInMs)));
+                    nonCachedMaxNewConnections,
+                    nonCachedMaxNewConnectionsResetTimeInMs,
+                    nonCachedMaxNewConnectionsWaitTimeInMs)));
 
     assertThat(this.throttlingConfig.getThrottlingConfig(nonCachedConfigId).getMaxConcurrency())
         .isEqualTo(nonCachedMaxConcurrency);

--- a/osgp/platform/osgp-throttling-service/src/test/java/org/opensmartgridplatform/throttling/ThrottlingServiceApplicationIT.java
+++ b/osgp/platform/osgp-throttling-service/src/test/java/org/opensmartgridplatform/throttling/ThrottlingServiceApplicationIT.java
@@ -1126,7 +1126,6 @@ class ThrottlingServiceApplicationIT {
 
     final String throttlingIdentity = "shared-throttling-used-by-multiple-workers";
     final int maxConcurrency = 3;
-    final int maxOpenConnections = 4;
     final int maxNewConnectionRequests = 5;
     final Duration maxNewConnectionResetTime = Duration.of(1, ChronoUnit.SECONDS);
     final long maxNewConnectionResetTimeInMs = maxNewConnectionResetTime.toMillis();
@@ -1160,7 +1159,6 @@ class ThrottlingServiceApplicationIT {
           new NetworkUser(
               throttlingIdentity,
               maxConcurrency,
-              maxOpenConnections,
               maxNewConnectionRequests,
               maxNewConnectionResetTimeInMs,
               network,

--- a/osgp/platform/osgp-throttling-service/src/test/java/org/opensmartgridplatform/throttling/ThrottlingServiceApplicationIT.java
+++ b/osgp/platform/osgp-throttling-service/src/test/java/org/opensmartgridplatform/throttling/ThrottlingServiceApplicationIT.java
@@ -10,6 +10,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.security.SecureRandom;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -95,6 +97,9 @@ class ThrottlingServiceApplicationIT {
 
   private static final String EXISTING_THROTTLING_CONFIG_NAME = "pre-added-config";
   private static final int EXISTING_THROTTLING_CONFIG_INITIAL_MAX_CONCURRENCY = 8;
+  private static final int EXISTING_THROTTLING_CONFIG_INITIAL_MAX_NEW_CONNECTION_REQUESTS = 10;
+  private static final long EXISTING_THROTTLING_CONFIG_INITIAL_MAX_NEW_CONNECTION_RESET_TIME_IN_MS =
+      1000;
 
   private static final String PAGING_PARAMETERS = "?page={page}&size={size}";
   private static final String ID_PATH = "/{id}";
@@ -133,7 +138,7 @@ class ThrottlingServiceApplicationIT {
 
   @Autowired private PermitRepository permitRepository;
 
-  @Autowired private MaxConcurrencyByThrottlingConfig maxConcurrencyByThrottlingConfig;
+  @Autowired private ThrottlingConfigCache throttlingConfigCache;
   @Autowired private MaxConcurrencyByBtsCellConfig maxConcurrencyByBtsCellConfig;
 
   @Autowired private PermitsByThrottlingConfig permitsByThrottlingConfig;
@@ -148,7 +153,9 @@ class ThrottlingServiceApplicationIT {
             .save(
                 new org.opensmartgridplatform.throttling.entities.ThrottlingConfig(
                     EXISTING_THROTTLING_CONFIG_NAME,
-                    EXISTING_THROTTLING_CONFIG_INITIAL_MAX_CONCURRENCY))
+                    EXISTING_THROTTLING_CONFIG_INITIAL_MAX_CONCURRENCY,
+                    EXISTING_THROTTLING_CONFIG_INITIAL_MAX_NEW_CONNECTION_REQUESTS,
+                    EXISTING_THROTTLING_CONFIG_INITIAL_MAX_NEW_CONNECTION_RESET_TIME_IN_MS))
             .getId();
   }
 
@@ -163,14 +170,23 @@ class ThrottlingServiceApplicationIT {
   void registerNewConfiguration() {
     final String name = "register-config";
     final int maxConcurrency = 99;
+    final int maxNewConnectionRequests = 98;
+    final long maxNewConnectionResetTimeInMs = Duration.of(1, ChronoUnit.HOURS).toMillis();
 
-    final short id = this.idForNewThrottlingConfig(name, maxConcurrency);
+    final short id =
+        this.idForNewThrottlingConfig(
+            name, maxConcurrency, maxNewConnectionRequests, maxNewConnectionResetTimeInMs);
     this.assertThrottlingConfigEntityExistsWithValues(id, name, maxConcurrency);
   }
 
-  private short idForNewThrottlingConfig(final String name, final int maxConcurrency) {
+  private short idForNewThrottlingConfig(
+      final String name,
+      final int maxConcurrency,
+      final int maxNewConnectionRequests,
+      final long maxNewConnectionResetTimeInMs) {
     final ResponseEntity<Short> responseEntity =
-        this.registerThrottlingConfig(name, maxConcurrency);
+        this.registerThrottlingConfig(
+            name, maxConcurrency, maxNewConnectionRequests, maxNewConnectionResetTimeInMs);
     return this.validThrottlingConfigId(responseEntity);
   }
 
@@ -180,9 +196,17 @@ class ThrottlingServiceApplicationIT {
     final org.opensmartgridplatform.throttling.entities.ThrottlingConfig throttlingConfigEntity =
         this.findExistingThrottlingConfigByName(name);
     final int updatedMaxConcurrency = throttlingConfigEntity.getMaxConcurrency() + 3;
+    final int updatedMaxNewConnectionRequests =
+        throttlingConfigEntity.getMaxNewConnectionRequests() + 3;
+    final long updatedMaxNewConnectionResetTimeInMs =
+        throttlingConfigEntity.getMaxNewConnectionResetTimeInMs() + 1000;
 
     final ResponseEntity<Short> responseEntity =
-        this.registerThrottlingConfig(name, updatedMaxConcurrency);
+        this.registerThrottlingConfig(
+            name,
+            updatedMaxConcurrency,
+            updatedMaxNewConnectionRequests,
+            updatedMaxNewConnectionResetTimeInMs);
 
     final short id = this.validThrottlingConfigId(responseEntity);
     assertThat(id).isEqualTo(this.existingThrottlingConfigId);
@@ -195,7 +219,7 @@ class ThrottlingServiceApplicationIT {
     final int maxConcurrency = -29;
 
     final ResponseEntity<Short> responseEntity =
-        this.registerThrottlingConfig(name, maxConcurrency);
+        this.registerThrottlingConfig(name, maxConcurrency, 0, Duration.ZERO.toMillis());
 
     assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
     assertThat(this.throttlingConfigRepository.findOneByName(name)).isEmpty();
@@ -214,7 +238,11 @@ class ThrottlingServiceApplicationIT {
 
     for (int i = 0; i < numberOfThrottlingConfigs - 1; i++) {
       final ThrottlingConfig addedApiThrottlingConfig =
-          this.apiThrottlingConfig("additional-config-" + i, i + 2);
+          this.apiThrottlingConfig(
+              "additional-config-" + i,
+              i + 2,
+              i + 3,
+              Duration.of(i, ChronoUnit.SECONDS).toMillis());
       apiThrottlingConfigs.add(addedApiThrottlingConfig);
       final ResponseEntity<Short> response =
           this.registerThrottlingConfig(addedApiThrottlingConfig);
@@ -240,8 +268,13 @@ class ThrottlingServiceApplicationIT {
     }
   }
 
-  private ThrottlingConfig apiThrottlingConfig(final String name, final int maxConcurrency) {
-    return new ThrottlingConfig(name, maxConcurrency);
+  private ThrottlingConfig apiThrottlingConfig(
+      final String name,
+      final int maxConcurrency,
+      final int maxNewConnectionRequests,
+      final long maxNewConnectionResetTimeInMs) {
+    return new ThrottlingConfig(
+        name, maxConcurrency, maxNewConnectionRequests, maxNewConnectionResetTimeInMs);
   }
 
   private org.opensmartgridplatform.throttling.entities.ThrottlingConfig
@@ -254,9 +287,14 @@ class ThrottlingServiceApplicationIT {
   }
 
   private ResponseEntity<Short> registerThrottlingConfig(
-      final String name, final int maxConcurrency) {
+      final String name,
+      final int maxConcurrency,
+      final int maxNewConnectionRequests,
+      final long maxNewConnectionResetTimeInMs) {
 
-    return this.registerThrottlingConfig(this.apiThrottlingConfig(name, maxConcurrency));
+    return this.registerThrottlingConfig(
+        this.apiThrottlingConfig(
+            name, maxConcurrency, maxNewConnectionRequests, maxNewConnectionResetTimeInMs));
   }
 
   private ResponseEntity<Short> registerThrottlingConfig(final ThrottlingConfig throttlingConfig) {
@@ -661,7 +699,8 @@ class ThrottlingServiceApplicationIT {
 
     final int maxConcurrency = 2;
     final short throttlingConfigId =
-        this.idForNewThrottlingConfig("at-most-2-concurrent-permits", maxConcurrency);
+        this.idForNewThrottlingConfig(
+            "at-most-2-concurrent-permits", maxConcurrency, 0, Duration.ZERO.toMillis());
     final int clientId = this.registeredClientId;
 
     final int baseTransceiverStationId = 45910;
@@ -976,21 +1015,32 @@ class ThrottlingServiceApplicationIT {
   @Test
   @Sql(scripts = "/max-concurrency-by-throttling-config-initializes-from-database.sql")
   void initializesMaxConcurrencyByThrottlingConfigFromDatabase() {
-    this.maxConcurrencyByThrottlingConfig.reset();
+    this.throttlingConfigCache.reset();
 
-    final Map<Short, Integer> expected = new TreeMap<>();
+    final Map<Short, org.opensmartgridplatform.throttling.entities.ThrottlingConfig> expected =
+        new TreeMap<>();
     // values added by the SQL script
-    expected.put((short) 1, 3);
-    expected.put((short) 2, 7123);
-    expected.put((short) 3, 2);
-    expected.put((short) 4, 3);
-    expected.put((short) 5, 383);
-    // value added before each test
-    expected.put((short) 6, EXISTING_THROTTLING_CONFIG_INITIAL_MAX_CONCURRENCY);
+    expected.put((short) 1, this.newThrottlingConfig(3));
+    expected.put((short) 2, this.newThrottlingConfig(7123));
+    expected.put((short) 3, this.newThrottlingConfig(2));
+    expected.put((short) 4, this.newThrottlingConfig(3));
+    expected.put((short) 5, this.newThrottlingConfig(383));
+    expected.put(
+        (short) 6, this.newThrottlingConfig(EXISTING_THROTTLING_CONFIG_INITIAL_MAX_CONCURRENCY));
 
-    final Map<Short, Integer> actualMaxConcurrencyByConfigId =
-        this.maxConcurrencyByThrottlingConfig.maxConcurrencyByConfigId();
-    assertThat(actualMaxConcurrencyByConfigId).containsExactlyEntriesOf(expected);
+    final Map<Short, org.opensmartgridplatform.throttling.entities.ThrottlingConfig>
+        actualThrottlingConfigByConfigId = this.throttlingConfigCache.throttlingConfigByConfigId();
+    assertThat(actualThrottlingConfigByConfigId).containsExactlyEntriesOf(expected);
+  }
+
+  private org.opensmartgridplatform.throttling.entities.ThrottlingConfig newThrottlingConfig(
+      final int startValue) {
+    final org.opensmartgridplatform.throttling.entities.ThrottlingConfig throttlingConfig =
+        new org.opensmartgridplatform.throttling.entities.ThrottlingConfig();
+    throttlingConfig.setMaxConcurrency(startValue);
+    throttlingConfig.setMaxNewConnectionRequests(startValue + 1);
+    throttlingConfig.setMaxNewConnectionResetTimeInMs(startValue + 2);
+    return throttlingConfig;
   }
 
   @Test
@@ -1076,6 +1126,11 @@ class ThrottlingServiceApplicationIT {
 
     final String throttlingIdentity = "shared-throttling-used-by-multiple-workers";
     final int maxConcurrency = 3;
+    final int maxOpenConnections = 4;
+    final int maxNewConnectionRequests = 5;
+    final Duration maxNewConnectionResetTime = Duration.of(1, ChronoUnit.SECONDS);
+    final long maxNewConnectionResetTimeInMs = maxNewConnectionResetTime.toMillis();
+
     final int numberOfWorkers = 50;
     final int numberOfNetworkTasks = 2000;
     final int maxTaskDurationMillis = 20;
@@ -1105,6 +1160,9 @@ class ThrottlingServiceApplicationIT {
           new NetworkUser(
               throttlingIdentity,
               maxConcurrency,
+              maxOpenConnections,
+              maxNewConnectionRequests,
+              maxNewConnectionResetTimeInMs,
               network,
               this.testRestTemplate.getRestTemplate(),
               networkTaskQueue);

--- a/osgp/platform/osgp-throttling-service/src/test/java/org/opensmartgridplatform/throttling/ThrottlingServiceApplicationIT.java
+++ b/osgp/platform/osgp-throttling-service/src/test/java/org/opensmartgridplatform/throttling/ThrottlingServiceApplicationIT.java
@@ -97,9 +97,11 @@ class ThrottlingServiceApplicationIT {
 
   private static final String EXISTING_THROTTLING_CONFIG_NAME = "pre-added-config";
   private static final int EXISTING_THROTTLING_CONFIG_INITIAL_MAX_CONCURRENCY = 8;
-  private static final int EXISTING_THROTTLING_CONFIG_INITIAL_MAX_NEW_CONNECTION_REQUESTS = 10;
-  private static final long EXISTING_THROTTLING_CONFIG_INITIAL_MAX_NEW_CONNECTION_RESET_TIME_IN_MS =
-      1000;
+  private static final int EXISTING_THROTTLING_CONFIG_INITIAL_MAX_NEW_CONNECTIONS = 10;
+  private static final long
+      EXISTING_THROTTLING_CONFIG_INITIAL_MAX_NEW_CONNECTIONS_RESET_TIME_IN_MS = 500;
+  private static final long EXISTING_THROTTLING_CONFIG_INITIAL_MAX_NEW_CONNECTIONS_WAIT_TIME_IN_MS =
+      800;
 
   private static final String PAGING_PARAMETERS = "?page={page}&size={size}";
   private static final String ID_PATH = "/{id}";
@@ -154,8 +156,9 @@ class ThrottlingServiceApplicationIT {
                 new org.opensmartgridplatform.throttling.entities.ThrottlingConfig(
                     EXISTING_THROTTLING_CONFIG_NAME,
                     EXISTING_THROTTLING_CONFIG_INITIAL_MAX_CONCURRENCY,
-                    EXISTING_THROTTLING_CONFIG_INITIAL_MAX_NEW_CONNECTION_REQUESTS,
-                    EXISTING_THROTTLING_CONFIG_INITIAL_MAX_NEW_CONNECTION_RESET_TIME_IN_MS))
+                    EXISTING_THROTTLING_CONFIG_INITIAL_MAX_NEW_CONNECTIONS,
+                    EXISTING_THROTTLING_CONFIG_INITIAL_MAX_NEW_CONNECTIONS_RESET_TIME_IN_MS,
+                    EXISTING_THROTTLING_CONFIG_INITIAL_MAX_NEW_CONNECTIONS_WAIT_TIME_IN_MS))
             .getId();
   }
 
@@ -170,23 +173,33 @@ class ThrottlingServiceApplicationIT {
   void registerNewConfiguration() {
     final String name = "register-config";
     final int maxConcurrency = 99;
-    final int maxNewConnectionRequests = 98;
-    final long maxNewConnectionResetTimeInMs = Duration.of(1, ChronoUnit.HOURS).toMillis();
+    final int maxNewConnections = 98;
+    final long maxNewConnectionsResetTimeInMs = Duration.of(1, ChronoUnit.HOURS).toMillis();
+    final long maxNewConnectionsWaitTimeInMs = Duration.of(2, ChronoUnit.HOURS).toMillis();
 
     final short id =
         this.idForNewThrottlingConfig(
-            name, maxConcurrency, maxNewConnectionRequests, maxNewConnectionResetTimeInMs);
+            name,
+            maxConcurrency,
+            maxNewConnections,
+            maxNewConnectionsResetTimeInMs,
+            maxNewConnectionsWaitTimeInMs);
     this.assertThrottlingConfigEntityExistsWithValues(id, name, maxConcurrency);
   }
 
   private short idForNewThrottlingConfig(
       final String name,
       final int maxConcurrency,
-      final int maxNewConnectionRequests,
-      final long maxNewConnectionResetTimeInMs) {
+      final int maxNewConnections,
+      final long maxNewConnectionsResetTimeInMs,
+      final long maxNewConnectionsWaitTimeInMs) {
     final ResponseEntity<Short> responseEntity =
         this.registerThrottlingConfig(
-            name, maxConcurrency, maxNewConnectionRequests, maxNewConnectionResetTimeInMs);
+            name,
+            maxConcurrency,
+            maxNewConnections,
+            maxNewConnectionsResetTimeInMs,
+            maxNewConnectionsWaitTimeInMs);
     return this.validThrottlingConfigId(responseEntity);
   }
 
@@ -196,17 +209,19 @@ class ThrottlingServiceApplicationIT {
     final org.opensmartgridplatform.throttling.entities.ThrottlingConfig throttlingConfigEntity =
         this.findExistingThrottlingConfigByName(name);
     final int updatedMaxConcurrency = throttlingConfigEntity.getMaxConcurrency() + 3;
-    final int updatedMaxNewConnectionRequests =
-        throttlingConfigEntity.getMaxNewConnectionRequests() + 3;
-    final long updatedMaxNewConnectionResetTimeInMs =
-        throttlingConfigEntity.getMaxNewConnectionResetTimeInMs() + 1000;
+    final int updatedMaxNewConnections = throttlingConfigEntity.getMaxNewConnections() + 3;
+    final long updatedMaxNewConnectionsResetTimeInMs =
+        throttlingConfigEntity.getMaxNewConnectionsResetTimeInMs() + 1000;
+    final long updatedMaxNewConnectionsWaitTimeInMs =
+        throttlingConfigEntity.getMaxNewConnectionsWaitTimeInMs() + 1500;
 
     final ResponseEntity<Short> responseEntity =
         this.registerThrottlingConfig(
             name,
             updatedMaxConcurrency,
-            updatedMaxNewConnectionRequests,
-            updatedMaxNewConnectionResetTimeInMs);
+            updatedMaxNewConnections,
+            updatedMaxNewConnectionsResetTimeInMs,
+            updatedMaxNewConnectionsWaitTimeInMs);
 
     final short id = this.validThrottlingConfigId(responseEntity);
     assertThat(id).isEqualTo(this.existingThrottlingConfigId);
@@ -219,7 +234,7 @@ class ThrottlingServiceApplicationIT {
     final int maxConcurrency = -29;
 
     final ResponseEntity<Short> responseEntity =
-        this.registerThrottlingConfig(name, maxConcurrency, 0, Duration.ZERO.toMillis());
+        this.registerThrottlingConfig(name, maxConcurrency, 0, 0, 0);
 
     assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
     assertThat(this.throttlingConfigRepository.findOneByName(name)).isEmpty();
@@ -238,11 +253,7 @@ class ThrottlingServiceApplicationIT {
 
     for (int i = 0; i < numberOfThrottlingConfigs - 1; i++) {
       final ThrottlingConfig addedApiThrottlingConfig =
-          this.apiThrottlingConfig(
-              "additional-config-" + i,
-              i + 2,
-              i + 3,
-              Duration.of(i, ChronoUnit.SECONDS).toMillis());
+          this.apiThrottlingConfig("additional-config-" + i, i + 2, i + 3, i + 3, i + 4);
       apiThrottlingConfigs.add(addedApiThrottlingConfig);
       final ResponseEntity<Short> response =
           this.registerThrottlingConfig(addedApiThrottlingConfig);
@@ -271,10 +282,15 @@ class ThrottlingServiceApplicationIT {
   private ThrottlingConfig apiThrottlingConfig(
       final String name,
       final int maxConcurrency,
-      final int maxNewConnectionRequests,
-      final long maxNewConnectionResetTimeInMs) {
+      final int maxNewConnections,
+      final long maxNewConnectionsResetTimeInMs,
+      final long maxNewConnectionsWaitTimeInMs) {
     return new ThrottlingConfig(
-        name, maxConcurrency, maxNewConnectionRequests, maxNewConnectionResetTimeInMs);
+        name,
+        maxConcurrency,
+        maxNewConnections,
+        maxNewConnectionsResetTimeInMs,
+        maxNewConnectionsWaitTimeInMs);
   }
 
   private org.opensmartgridplatform.throttling.entities.ThrottlingConfig
@@ -289,12 +305,17 @@ class ThrottlingServiceApplicationIT {
   private ResponseEntity<Short> registerThrottlingConfig(
       final String name,
       final int maxConcurrency,
-      final int maxNewConnectionRequests,
-      final long maxNewConnectionResetTimeInMs) {
+      final int maxNewConnections,
+      final long maxNewConnectionsResetTimeInMs,
+      final long maxNewConnectionsWaitTimeInMs) {
 
     return this.registerThrottlingConfig(
         this.apiThrottlingConfig(
-            name, maxConcurrency, maxNewConnectionRequests, maxNewConnectionResetTimeInMs));
+            name,
+            maxConcurrency,
+            maxNewConnections,
+            maxNewConnectionsResetTimeInMs,
+            maxNewConnectionsWaitTimeInMs));
   }
 
   private ResponseEntity<Short> registerThrottlingConfig(final ThrottlingConfig throttlingConfig) {
@@ -699,8 +720,7 @@ class ThrottlingServiceApplicationIT {
 
     final int maxConcurrency = 2;
     final short throttlingConfigId =
-        this.idForNewThrottlingConfig(
-            "at-most-2-concurrent-permits", maxConcurrency, 0, Duration.ZERO.toMillis());
+        this.idForNewThrottlingConfig("at-most-2-concurrent-permits", maxConcurrency, 0, 0, 0);
     final int clientId = this.registeredClientId;
 
     final int baseTransceiverStationId = 45910;
@@ -1038,8 +1058,9 @@ class ThrottlingServiceApplicationIT {
     final org.opensmartgridplatform.throttling.entities.ThrottlingConfig throttlingConfig =
         new org.opensmartgridplatform.throttling.entities.ThrottlingConfig();
     throttlingConfig.setMaxConcurrency(startValue);
-    throttlingConfig.setMaxNewConnectionRequests(startValue + 1);
-    throttlingConfig.setMaxNewConnectionResetTimeInMs(startValue + 2);
+    throttlingConfig.setMaxNewConnections(startValue + 1);
+    throttlingConfig.setMaxNewConnectionsResetTimeInMs(startValue + 2);
+    throttlingConfig.setMaxNewConnectionsWaitTimeInMs(startValue + 3);
     return throttlingConfig;
   }
 
@@ -1126,9 +1147,10 @@ class ThrottlingServiceApplicationIT {
 
     final String throttlingIdentity = "shared-throttling-used-by-multiple-workers";
     final int maxConcurrency = 3;
-    final int maxNewConnectionRequests = 5;
-    final Duration maxNewConnectionResetTime = Duration.of(1, ChronoUnit.SECONDS);
-    final long maxNewConnectionResetTimeInMs = maxNewConnectionResetTime.toMillis();
+    final int maxNewConnections = 5;
+    final Duration maxNewConnectionsResetTime = Duration.of(1, ChronoUnit.SECONDS);
+    final long maxNewConnectionsResetTimeInMs = maxNewConnectionsResetTime.toMillis();
+    final long maxNewConnectionsWaitTimeInMs = maxNewConnectionsResetTimeInMs + 500;
 
     final int numberOfWorkers = 50;
     final int numberOfNetworkTasks = 2000;
@@ -1159,8 +1181,9 @@ class ThrottlingServiceApplicationIT {
           new NetworkUser(
               throttlingIdentity,
               maxConcurrency,
-              maxNewConnectionRequests,
-              maxNewConnectionResetTimeInMs,
+              maxNewConnections,
+              maxNewConnectionsResetTimeInMs,
+              maxNewConnectionsWaitTimeInMs,
               network,
               this.testRestTemplate.getRestTemplate(),
               networkTaskQueue);

--- a/osgp/platform/osgp-throttling-service/src/test/java/org/opensmartgridplatform/throttling/mapping/ThrottlingMapperTest.java
+++ b/osgp/platform/osgp-throttling-service/src/test/java/org/opensmartgridplatform/throttling/mapping/ThrottlingMapperTest.java
@@ -19,15 +19,26 @@ class ThrottlingMapperTest {
     final Short id = null;
     final String name = "test-config-new-entity";
     final int maxConcurrency = 91;
-    final int maxNewConnectionRequests = 351;
-    final long maxNewConnectionResetTimeInMs = 3000;
+    final int maxNewConnections = 351;
+    final long maxNewConnectionsResetTimeInMs = 3000;
+    final long maxNewConnectionsWaitTimeInMs = 4000;
 
     final org.opensmartgridplatform.throttling.entities.ThrottlingConfig expected =
         this.throttlingConfigEntity(
-            id, name, maxConcurrency, maxNewConnectionRequests, maxNewConnectionResetTimeInMs);
+            id,
+            name,
+            maxConcurrency,
+            maxNewConnections,
+            maxNewConnectionsResetTimeInMs,
+            maxNewConnectionsWaitTimeInMs);
     final ThrottlingConfig source =
         this.throttlingConfigApi(
-            id, name, maxConcurrency, maxNewConnectionRequests, maxNewConnectionResetTimeInMs);
+            id,
+            name,
+            maxConcurrency,
+            maxNewConnections,
+            maxNewConnectionsResetTimeInMs,
+            maxNewConnectionsWaitTimeInMs);
 
     final org.opensmartgridplatform.throttling.entities.ThrottlingConfig actual =
         this.throttlingMapper.map(
@@ -43,19 +54,26 @@ class ThrottlingMapperTest {
     final Short idEntity = null;
     final String name = "test-config-no-id-on-new";
     final int maxConcurrency = 3;
-    final int maxNewConnectionRequests = 351;
-    final long maxNewConnectionResetTimeInMs = 3000;
+    final int maxNewConnections = 351;
+    final long maxNewConnectionsResetTimeInMs = 3000;
+    final long maxNewConnectionsWaitTimeInMs = 2000;
 
     final org.opensmartgridplatform.throttling.entities.ThrottlingConfig expected =
         this.throttlingConfigEntity(
             idEntity,
             name,
             maxConcurrency,
-            maxNewConnectionRequests,
-            maxNewConnectionResetTimeInMs);
+            maxNewConnections,
+            maxNewConnectionsResetTimeInMs,
+            maxNewConnectionsWaitTimeInMs);
     final ThrottlingConfig source =
         this.throttlingConfigApi(
-            idApi, name, maxConcurrency, maxNewConnectionRequests, maxNewConnectionResetTimeInMs);
+            idApi,
+            name,
+            maxConcurrency,
+            maxNewConnections,
+            maxNewConnectionsResetTimeInMs,
+            maxNewConnectionsWaitTimeInMs);
 
     final org.opensmartgridplatform.throttling.entities.ThrottlingConfig actual =
         this.throttlingMapper.map(
@@ -70,15 +88,26 @@ class ThrottlingMapperTest {
     final Short id = 489;
     final String name = "test-config-entity-to-api";
     final int maxConcurrency = 349;
-    final int maxNewConnectionRequests = 351;
-    final long maxNewConnectionResetTimeInMs = 3000;
+    final int maxNewConnections = 351;
+    final long maxNewConnectionsResetTimeInMs = 3000;
+    final long maxNewConnectionsWaitTimeInMs = 2000;
 
     final ThrottlingConfig expected =
         this.throttlingConfigApi(
-            id, name, maxConcurrency, maxNewConnectionRequests, maxNewConnectionResetTimeInMs);
+            id,
+            name,
+            maxConcurrency,
+            maxNewConnections,
+            maxNewConnectionsResetTimeInMs,
+            maxNewConnectionsWaitTimeInMs);
     final org.opensmartgridplatform.throttling.entities.ThrottlingConfig source =
         this.throttlingConfigEntity(
-            id, name, maxConcurrency, maxNewConnectionRequests, maxNewConnectionResetTimeInMs);
+            id,
+            name,
+            maxConcurrency,
+            maxNewConnections,
+            maxNewConnectionsResetTimeInMs,
+            maxNewConnectionsWaitTimeInMs);
 
     final ThrottlingConfig actual = this.throttlingMapper.map(source, ThrottlingConfig.class);
 
@@ -92,34 +121,39 @@ class ThrottlingMapperTest {
     final Short idEntity = 3479;
     final String name = "test-config-update-entity";
     final int maxConcurrencyApi = 10;
-    final int maxNewConnectionRequestsApi = 12;
-    final long maxNewConnectionResetTimeInMsApi = 1000;
+    final int maxNewConnectionsApi = 12;
+    final long maxNewConnectionsResetTimeInMsApi = 1000;
+    final long maxNewConnectionsWaitTimeInMsApi = 1200;
 
     final int maxConcurrencyEntity = 15;
-    final int maxNewConnectionRequestsEntity = 8;
-    final long maxNewConnectionResetTimeInMsEntity = 2000;
+    final int maxNewConnectionsEntity = 8;
+    final long maxNewConnectionsResetTimeInMsEntity = 2000;
+    final long maxNewConnectionsWaitTimeInMsEntity = 2200;
 
     final org.opensmartgridplatform.throttling.entities.ThrottlingConfig destination =
         this.throttlingConfigEntity(
             idEntity,
             name,
             maxConcurrencyEntity,
-            maxNewConnectionRequestsEntity,
-            maxNewConnectionResetTimeInMsEntity);
+            maxNewConnectionsEntity,
+            maxNewConnectionsResetTimeInMsEntity,
+            maxNewConnectionsWaitTimeInMsEntity);
     final org.opensmartgridplatform.throttling.entities.ThrottlingConfig expected =
         this.throttlingConfigEntity(
             idEntity,
             name,
             maxConcurrencyApi,
-            maxNewConnectionRequestsApi,
-            maxNewConnectionResetTimeInMsApi);
+            maxNewConnectionsApi,
+            maxNewConnectionsResetTimeInMsApi,
+            maxNewConnectionsWaitTimeInMsApi);
     final ThrottlingConfig source =
         this.throttlingConfigApi(
             idApi,
             name,
             maxConcurrencyApi,
-            maxNewConnectionRequestsApi,
-            maxNewConnectionResetTimeInMsApi);
+            maxNewConnectionsApi,
+            maxNewConnectionsResetTimeInMsApi,
+            maxNewConnectionsWaitTimeInMsApi);
 
     this.throttlingMapper.map(source, destination);
 
@@ -134,34 +168,39 @@ class ThrottlingMapperTest {
     final String nameApi = "test-config-update-entity-ignore-id-api";
     final String nameEntity = "test-config-update-entity-ignore-id";
     final int maxConcurrencyApi = 5;
-    final int maxNewConnectionRequestsApi = 12;
-    final long maxNewConnectionResetTimeInMsApi = 1000;
+    final int maxNewConnectionsApi = 12;
+    final long maxNewConnectionsResetTimeInMsApi = 1000;
+    final long maxNewConnectionsWaitTimeInMsApi = 1200;
 
     final int maxConcurrencyEntity = 3;
-    final int maxNewConnectionRequestsEntity = 8;
-    final long maxNewConnectionResetTimeInMsEntity = 2000;
+    final int maxNewConnectionsEntity = 8;
+    final long maxNewConnectionsResetTimeInMsEntity = 2000;
+    final long maxNewConnectionsWaitTimeInMsEntity = 2200;
 
     final org.opensmartgridplatform.throttling.entities.ThrottlingConfig destination =
         this.throttlingConfigEntity(
             idEntity,
             nameEntity,
             maxConcurrencyEntity,
-            maxNewConnectionRequestsEntity,
-            maxNewConnectionResetTimeInMsEntity);
+            maxNewConnectionsEntity,
+            maxNewConnectionsResetTimeInMsEntity,
+            maxNewConnectionsWaitTimeInMsEntity);
     final org.opensmartgridplatform.throttling.entities.ThrottlingConfig expected =
         this.throttlingConfigEntity(
             idEntity,
             nameEntity,
             maxConcurrencyApi,
-            maxNewConnectionRequestsApi,
-            maxNewConnectionResetTimeInMsApi);
+            maxNewConnectionsApi,
+            maxNewConnectionsResetTimeInMsApi,
+            maxNewConnectionsWaitTimeInMsApi);
     final ThrottlingConfig source =
         this.throttlingConfigApi(
             idApi,
             nameApi,
             maxConcurrencyApi,
-            maxNewConnectionRequestsApi,
-            maxNewConnectionResetTimeInMsApi);
+            maxNewConnectionsApi,
+            maxNewConnectionsResetTimeInMsApi,
+            maxNewConnectionsWaitTimeInMsApi);
 
     this.throttlingMapper.map(source, destination);
 
@@ -172,21 +211,33 @@ class ThrottlingMapperTest {
       final Short id,
       final String name,
       final int maxConcurrency,
-      final int maxNewConnectionRequests,
-      final long maxNewConnectionResetTimeInMs) {
+      final int maxNewConnections,
+      final long maxNewConnectionsResetTimeInMs,
+      final long maxNewConnectionsWaitTimeInMs) {
 
     return new ThrottlingConfig(
-        id, name, maxConcurrency, maxNewConnectionRequests, maxNewConnectionResetTimeInMs);
+        id,
+        name,
+        maxConcurrency,
+        maxNewConnections,
+        maxNewConnectionsResetTimeInMs,
+        maxNewConnectionsWaitTimeInMs);
   }
 
   private org.opensmartgridplatform.throttling.entities.ThrottlingConfig throttlingConfigEntity(
       final Short id,
       final String name,
       final int maxConcurrency,
-      final int maxNewConnectionRequests,
-      final long maxNewConnectionResetTimeInMs) {
+      final int maxNewConnections,
+      final long maxNewConnectionsResetTimeInMs,
+      final long maxNewConnectionsWaitTimeInMs) {
 
     return new org.opensmartgridplatform.throttling.entities.ThrottlingConfig(
-        id, name, maxConcurrency, maxNewConnectionRequests, maxNewConnectionResetTimeInMs);
+        id,
+        name,
+        maxConcurrency,
+        maxNewConnections,
+        maxNewConnectionsResetTimeInMs,
+        maxNewConnectionsWaitTimeInMs);
   }
 }

--- a/osgp/platform/osgp-throttling-service/src/test/java/org/opensmartgridplatform/throttling/mapping/ThrottlingMapperTest.java
+++ b/osgp/platform/osgp-throttling-service/src/test/java/org/opensmartgridplatform/throttling/mapping/ThrottlingMapperTest.java
@@ -19,10 +19,15 @@ class ThrottlingMapperTest {
     final Short id = null;
     final String name = "test-config-new-entity";
     final int maxConcurrency = 91;
+    final int maxNewConnectionRequests = 351;
+    final long maxNewConnectionResetTimeInMs = 3000;
 
     final org.opensmartgridplatform.throttling.entities.ThrottlingConfig expected =
-        this.throttlingConfigEntity(id, name, maxConcurrency);
-    final ThrottlingConfig source = this.throttlingConfigApi(id, name, maxConcurrency);
+        this.throttlingConfigEntity(
+            id, name, maxConcurrency, maxNewConnectionRequests, maxNewConnectionResetTimeInMs);
+    final ThrottlingConfig source =
+        this.throttlingConfigApi(
+            id, name, maxConcurrency, maxNewConnectionRequests, maxNewConnectionResetTimeInMs);
 
     final org.opensmartgridplatform.throttling.entities.ThrottlingConfig actual =
         this.throttlingMapper.map(
@@ -38,10 +43,19 @@ class ThrottlingMapperTest {
     final Short idEntity = null;
     final String name = "test-config-no-id-on-new";
     final int maxConcurrency = 3;
+    final int maxNewConnectionRequests = 351;
+    final long maxNewConnectionResetTimeInMs = 3000;
 
     final org.opensmartgridplatform.throttling.entities.ThrottlingConfig expected =
-        this.throttlingConfigEntity(idEntity, name, maxConcurrency);
-    final ThrottlingConfig source = this.throttlingConfigApi(idApi, name, maxConcurrency);
+        this.throttlingConfigEntity(
+            idEntity,
+            name,
+            maxConcurrency,
+            maxNewConnectionRequests,
+            maxNewConnectionResetTimeInMs);
+    final ThrottlingConfig source =
+        this.throttlingConfigApi(
+            idApi, name, maxConcurrency, maxNewConnectionRequests, maxNewConnectionResetTimeInMs);
 
     final org.opensmartgridplatform.throttling.entities.ThrottlingConfig actual =
         this.throttlingMapper.map(
@@ -56,10 +70,15 @@ class ThrottlingMapperTest {
     final Short id = 489;
     final String name = "test-config-entity-to-api";
     final int maxConcurrency = 349;
+    final int maxNewConnectionRequests = 351;
+    final long maxNewConnectionResetTimeInMs = 3000;
 
-    final ThrottlingConfig expected = this.throttlingConfigApi(id, name, maxConcurrency);
+    final ThrottlingConfig expected =
+        this.throttlingConfigApi(
+            id, name, maxConcurrency, maxNewConnectionRequests, maxNewConnectionResetTimeInMs);
     final org.opensmartgridplatform.throttling.entities.ThrottlingConfig source =
-        this.throttlingConfigEntity(id, name, maxConcurrency);
+        this.throttlingConfigEntity(
+            id, name, maxConcurrency, maxNewConnectionRequests, maxNewConnectionResetTimeInMs);
 
     final ThrottlingConfig actual = this.throttlingMapper.map(source, ThrottlingConfig.class);
 
@@ -73,13 +92,34 @@ class ThrottlingMapperTest {
     final Short idEntity = 3479;
     final String name = "test-config-update-entity";
     final int maxConcurrencyApi = 10;
+    final int maxNewConnectionRequestsApi = 12;
+    final long maxNewConnectionResetTimeInMsApi = 1000;
+
     final int maxConcurrencyEntity = 15;
+    final int maxNewConnectionRequestsEntity = 8;
+    final long maxNewConnectionResetTimeInMsEntity = 2000;
 
     final org.opensmartgridplatform.throttling.entities.ThrottlingConfig destination =
-        this.throttlingConfigEntity(idEntity, name, maxConcurrencyEntity);
+        this.throttlingConfigEntity(
+            idEntity,
+            name,
+            maxConcurrencyEntity,
+            maxNewConnectionRequestsEntity,
+            maxNewConnectionResetTimeInMsEntity);
     final org.opensmartgridplatform.throttling.entities.ThrottlingConfig expected =
-        this.throttlingConfigEntity(idEntity, name, maxConcurrencyApi);
-    final ThrottlingConfig source = this.throttlingConfigApi(idApi, name, maxConcurrencyApi);
+        this.throttlingConfigEntity(
+            idEntity,
+            name,
+            maxConcurrencyApi,
+            maxNewConnectionRequestsApi,
+            maxNewConnectionResetTimeInMsApi);
+    final ThrottlingConfig source =
+        this.throttlingConfigApi(
+            idApi,
+            name,
+            maxConcurrencyApi,
+            maxNewConnectionRequestsApi,
+            maxNewConnectionResetTimeInMsApi);
 
     this.throttlingMapper.map(source, destination);
 
@@ -94,13 +134,34 @@ class ThrottlingMapperTest {
     final String nameApi = "test-config-update-entity-ignore-id-api";
     final String nameEntity = "test-config-update-entity-ignore-id";
     final int maxConcurrencyApi = 5;
+    final int maxNewConnectionRequestsApi = 12;
+    final long maxNewConnectionResetTimeInMsApi = 1000;
+
     final int maxConcurrencyEntity = 3;
+    final int maxNewConnectionRequestsEntity = 8;
+    final long maxNewConnectionResetTimeInMsEntity = 2000;
 
     final org.opensmartgridplatform.throttling.entities.ThrottlingConfig destination =
-        this.throttlingConfigEntity(idEntity, nameEntity, maxConcurrencyEntity);
+        this.throttlingConfigEntity(
+            idEntity,
+            nameEntity,
+            maxConcurrencyEntity,
+            maxNewConnectionRequestsEntity,
+            maxNewConnectionResetTimeInMsEntity);
     final org.opensmartgridplatform.throttling.entities.ThrottlingConfig expected =
-        this.throttlingConfigEntity(idEntity, nameEntity, maxConcurrencyApi);
-    final ThrottlingConfig source = this.throttlingConfigApi(idApi, nameApi, maxConcurrencyApi);
+        this.throttlingConfigEntity(
+            idEntity,
+            nameEntity,
+            maxConcurrencyApi,
+            maxNewConnectionRequestsApi,
+            maxNewConnectionResetTimeInMsApi);
+    final ThrottlingConfig source =
+        this.throttlingConfigApi(
+            idApi,
+            nameApi,
+            maxConcurrencyApi,
+            maxNewConnectionRequestsApi,
+            maxNewConnectionResetTimeInMsApi);
 
     this.throttlingMapper.map(source, destination);
 
@@ -108,15 +169,24 @@ class ThrottlingMapperTest {
   }
 
   private ThrottlingConfig throttlingConfigApi(
-      final Short id, final String name, final int maxConcurrency) {
+      final Short id,
+      final String name,
+      final int maxConcurrency,
+      final int maxNewConnectionRequests,
+      final long maxNewConnectionResetTimeInMs) {
 
-    return new ThrottlingConfig(id, name, maxConcurrency);
+    return new ThrottlingConfig(
+        id, name, maxConcurrency, maxNewConnectionRequests, maxNewConnectionResetTimeInMs);
   }
 
   private org.opensmartgridplatform.throttling.entities.ThrottlingConfig throttlingConfigEntity(
-      final Short id, final String name, final int maxConcurrency) {
+      final Short id,
+      final String name,
+      final int maxConcurrency,
+      final int maxNewConnectionRequests,
+      final long maxNewConnectionResetTimeInMs) {
 
     return new org.opensmartgridplatform.throttling.entities.ThrottlingConfig(
-        id, name, maxConcurrency);
+        id, name, maxConcurrency, maxNewConnectionRequests, maxNewConnectionResetTimeInMs);
   }
 }

--- a/osgp/platform/osgp-throttling-service/src/test/java/org/opensmartgridplatform/throttling/repositories/ThrottlingConfigRepositoryIT.java
+++ b/osgp/platform/osgp-throttling-service/src/test/java/org/opensmartgridplatform/throttling/repositories/ThrottlingConfigRepositoryIT.java
@@ -1,0 +1,158 @@
+// SPDX-FileCopyrightText: Copyright Contributors to the GXF project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package org.opensmartgridplatform.throttling.repositories;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import java.util.Collections;
+import javax.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.ClassRule;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.opensmartgridplatform.throttling.ThrottlingServiceApplication;
+import org.opensmartgridplatform.throttling.entities.ThrottlingConfig;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+@Slf4j
+@SpringBootTest(
+    classes = ThrottlingServiceApplication.class,
+    webEnvironment = WebEnvironment.RANDOM_PORT)
+@ContextConfiguration(initializers = ThrottlingConfigRepositoryIT.Initializer.class)
+class ThrottlingConfigRepositoryIT {
+
+  private static final int MAX_WAIT_FOR_HIGH_PRIO = 1000;
+
+  @ClassRule
+  private static final PostgreSQLContainer<?> postgreSQLContainer =
+      new PostgreSQLContainer<>("postgres:12.4")
+          .withDatabaseName("throttling_integration_test_db")
+          .withUsername("osp_admin")
+          .withPassword("1234")
+          .withTmpFs(Collections.singletonMap("/var/lib/postgresql/data", "rw"));
+
+  public static final String NULL = "NULL";
+
+  static class Initializer
+      implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+    @Override
+    public void initialize(final ConfigurableApplicationContext configurableApplicationContext) {
+      TestPropertyValues.of(
+              "spring.datasource.driver-class-name=" + postgreSQLContainer.getDriverClassName(),
+              "spring.datasource.url=" + postgreSQLContainer.getJdbcUrl(),
+              "spring.datasource.username=" + postgreSQLContainer.getUsername(),
+              "spring.datasource.password=" + postgreSQLContainer.getPassword(),
+              "spring.jpa.show-sql=false",
+              "max.wait.for.high.prio.in.ms=" + MAX_WAIT_FOR_HIGH_PRIO)
+          .applyTo(configurableApplicationContext.getEnvironment());
+    }
+  }
+
+  @Autowired private ThrottlingConfigRepository throttlingConfigRepository;
+
+  @BeforeAll
+  static void beforeAll() {
+    postgreSQLContainer.start();
+  }
+
+  @AfterAll
+  static void afterAll() {
+    postgreSQLContainer.stop();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {NULL, "name", ""})
+  void testValidationName(final String name) {
+    final ThrottlingConfig throttlingConfig = this.newThrottlingConfig(name);
+
+    if (NULL.equals(name)) {
+      assertThatThrownBy(() -> this.throttlingConfigRepository.save(throttlingConfig))
+          .isInstanceOf(ConstraintViolationException.class);
+    } else {
+      final ThrottlingConfig saved = this.throttlingConfigRepository.save(throttlingConfig);
+      assertThat(saved.getId()).isNotNull();
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {-2, -1, 0, 1})
+  void testValidationMaxConcurrency(final int maxConcurrency) {
+    final ThrottlingConfig throttlingConfig =
+        this.newThrottlingConfig("maxConcurrency_" + maxConcurrency);
+    throttlingConfig.setMaxConcurrency(maxConcurrency);
+
+    if (maxConcurrency < -1) {
+      assertThatThrownBy(() -> this.throttlingConfigRepository.save(throttlingConfig))
+          .isInstanceOf(ConstraintViolationException.class);
+    } else {
+      final ThrottlingConfig saved = this.throttlingConfigRepository.save(throttlingConfig);
+      assertThat(saved.getId()).isNotNull();
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {-2, -1, 0, 1})
+  void testValidationMaxNewConnections(final int maxNewConnections) {
+    final ThrottlingConfig throttlingConfig =
+        this.newThrottlingConfig("maxNewConnections_" + maxNewConnections);
+    throttlingConfig.setMaxNewConnections(maxNewConnections);
+
+    if (maxNewConnections < -1) {
+      assertThatThrownBy(() -> this.throttlingConfigRepository.save(throttlingConfig))
+          .isInstanceOf(ConstraintViolationException.class);
+    } else {
+      final ThrottlingConfig saved = this.throttlingConfigRepository.save(throttlingConfig);
+      assertThat(saved.getId()).isNotNull();
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(longs = {-2, -1, 0, 1})
+  void testValidationMaxMaxNewConnectionsResetTimeInMs(final long maxNewConnectionsResetTimeInMs) {
+    final ThrottlingConfig throttlingConfig =
+        this.newThrottlingConfig(
+            "maxNewConnectionsResetTimeInMs_" + maxNewConnectionsResetTimeInMs);
+    throttlingConfig.setMaxNewConnectionsResetTimeInMs(maxNewConnectionsResetTimeInMs);
+
+    if (maxNewConnectionsResetTimeInMs < 0) {
+      assertThatThrownBy(() -> this.throttlingConfigRepository.save(throttlingConfig))
+          .isInstanceOf(ConstraintViolationException.class);
+    } else {
+      final ThrottlingConfig saved = this.throttlingConfigRepository.save(throttlingConfig);
+      assertThat(saved.getId()).isNotNull();
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(longs = {-2, -1, 0, 1})
+  void testValidationMaxNewConnectionsWaitTimeInMs(final long maxNewConnectionsWaitTimeInMs) {
+    final ThrottlingConfig throttlingConfig =
+        this.newThrottlingConfig("maxNewConnectionsWaitTimeInMs_" + maxNewConnectionsWaitTimeInMs);
+    throttlingConfig.setMaxNewConnectionsWaitTimeInMs(maxNewConnectionsWaitTimeInMs);
+
+    if (maxNewConnectionsWaitTimeInMs < 0) {
+      assertThatThrownBy(() -> this.throttlingConfigRepository.save(throttlingConfig))
+          .isInstanceOf(ConstraintViolationException.class);
+    } else {
+      final ThrottlingConfig saved = this.throttlingConfigRepository.save(throttlingConfig);
+      assertThat(saved.getId()).isNotNull();
+    }
+  }
+
+  private ThrottlingConfig newThrottlingConfig(final String name) {
+    return new ThrottlingConfig(name, 0, 0, 0, 0);
+  }
+}

--- a/osgp/platform/osgp-throttling-service/src/test/resources/max-concurrency-by-throttling-config-initializes-from-database.sql
+++ b/osgp/platform/osgp-throttling-service/src/test/resources/max-concurrency-by-throttling-config-initializes-from-database.sql
@@ -1,9 +1,9 @@
 -- Insert database content expected to be present executing test methods annotated with
 -- @Sql(scripts = "/max-concurrency-by-throttling-config-initializes-from-database.sql")
-INSERT INTO throttling_config (id, name, max_concurrency) VALUES
-  (1, 'one', 3),
-  (2, 'two', 7123),
-  (3, 'three', 2),
-  (4, 'four', 3),
-  (5, 'five', 383);
+INSERT INTO throttling_config (id, name, max_concurrency, max_open_connections, max_new_connection_requests, max_new_connection_reset_time_in_ms) VALUES
+  (1, 'one', 3, 4, 5, 6),
+  (2, 'two', 7123, 7124, 7125, 7126),
+  (3, 'three', 2, 3, 4, 5),
+  (4, 'four', 3, 4, 5, 6),
+  (5, 'five', 383, 384, 385, 386);
 ALTER SEQUENCE throttling_config_id_seq RESTART WITH 6;

--- a/osgp/platform/osgp-throttling-service/src/test/resources/max-concurrency-by-throttling-config-initializes-from-database.sql
+++ b/osgp/platform/osgp-throttling-service/src/test/resources/max-concurrency-by-throttling-config-initializes-from-database.sql
@@ -1,9 +1,9 @@
 -- Insert database content expected to be present executing test methods annotated with
 -- @Sql(scripts = "/max-concurrency-by-throttling-config-initializes-from-database.sql")
-INSERT INTO throttling_config (id, name, max_concurrency, max_open_connections, max_new_connection_requests, max_new_connection_reset_time_in_ms) VALUES
-  (1, 'one', 3, 4, 5, 6),
-  (2, 'two', 7123, 7124, 7125, 7126),
-  (3, 'three', 2, 3, 4, 5),
-  (4, 'four', 3, 4, 5, 6),
-  (5, 'five', 383, 384, 385, 386);
+INSERT INTO throttling_config (id, name, max_concurrency, max_new_connection_requests, max_new_connection_reset_time_in_ms) VALUES
+  (1, 'one', 3, 4, 5),
+  (2, 'two', 7123, 7124, 7125),
+  (3, 'three', 2, 3, 4),
+  (4, 'four', 3, 4, 5),
+  (5, 'five', 383, 384, 385);
 ALTER SEQUENCE throttling_config_id_seq RESTART WITH 6;

--- a/osgp/platform/osgp-throttling-service/src/test/resources/max-concurrency-by-throttling-config-initializes-from-database.sql
+++ b/osgp/platform/osgp-throttling-service/src/test/resources/max-concurrency-by-throttling-config-initializes-from-database.sql
@@ -1,9 +1,9 @@
 -- Insert database content expected to be present executing test methods annotated with
 -- @Sql(scripts = "/max-concurrency-by-throttling-config-initializes-from-database.sql")
-INSERT INTO throttling_config (id, name, max_concurrency, max_new_connection_requests, max_new_connection_reset_time_in_ms) VALUES
-  (1, 'one', 3, 4, 5),
-  (2, 'two', 7123, 7124, 7125),
-  (3, 'three', 2, 3, 4),
-  (4, 'four', 3, 4, 5),
-  (5, 'five', 383, 384, 385);
+INSERT INTO throttling_config (id, name, max_concurrency, max_new_connections, max_new_connections_reset_time_in_ms, max_new_connections_wait_time_in_ms) VALUES
+  (1, 'one', 3, 4, 5, 6),
+  (2, 'two', 7123, 7124, 7125, 7126),
+  (3, 'three', 2, 3, 4, 5),
+  (4, 'four', 3, 4, 5, 6),
+  (5, 'five', 383, 384, 385, 386);
 ALTER SEQUENCE throttling_config_id_seq RESTART WITH 6;

--- a/osgp/platform/osgp-throttling-service/src/test/resources/permits-by-throttling-config-initializes-from-database.sql
+++ b/osgp/platform/osgp-throttling-service/src/test/resources/permits-by-throttling-config-initializes-from-database.sql
@@ -1,10 +1,10 @@
 -- Insert database content expected to be present executing test methods annotated with
 -- @Sql(scripts = "/permits-by-throttling-config-initializes-from-database.sql")
-INSERT INTO throttling_config (id, name, max_concurrency) VALUES
-  (1, 'config-one', 10),
-  (2, 'config-two', 15),
-  (3, 'config-three', 2),
-  (4, 'config-four', 1);
+INSERT INTO throttling_config (id, name, max_concurrency, max_open_connections, max_new_connection_requests, max_new_connection_reset_time_in_ms) VALUES
+  (1, 'config-one', 10, 11, 12, 13),
+  (2, 'config-two', 15, 16, 17, 18),
+  (3, 'config-three', 2, 3, 4, 5),
+  (4, 'config-four', 1, 2, 3, 4);
 ALTER SEQUENCE throttling_config_id_seq RESTART WITH 5;
 
 INSERT INTO permit (id, throttling_config_id, client_id, bts_id, cell_id, request_id, created_at) VALUES

--- a/osgp/platform/osgp-throttling-service/src/test/resources/permits-by-throttling-config-initializes-from-database.sql
+++ b/osgp/platform/osgp-throttling-service/src/test/resources/permits-by-throttling-config-initializes-from-database.sql
@@ -1,10 +1,10 @@
 -- Insert database content expected to be present executing test methods annotated with
 -- @Sql(scripts = "/permits-by-throttling-config-initializes-from-database.sql")
-INSERT INTO throttling_config (id, name, max_concurrency, max_new_connection_requests, max_new_connection_reset_time_in_ms) VALUES
-  (1, 'config-one', 10, 11, 12),
-  (2, 'config-two', 15, 16, 17),
-  (3, 'config-three', 2, 3, 4),
-  (4, 'config-four', 1, 2, 3);
+INSERT INTO throttling_config (id, name, max_concurrency, max_new_connections, max_new_connections_reset_time_in_ms, max_new_connections_wait_time_in_ms) VALUES
+  (1, 'config-one', 10, 11, 12, 13),
+  (2, 'config-two', 15, 16, 17, 18),
+  (3, 'config-three', 2, 3, 4, 5),
+  (4, 'config-four', 1, 2, 3, 4);
 ALTER SEQUENCE throttling_config_id_seq RESTART WITH 5;
 
 INSERT INTO permit (id, throttling_config_id, client_id, bts_id, cell_id, request_id, created_at) VALUES

--- a/osgp/platform/osgp-throttling-service/src/test/resources/permits-by-throttling-config-initializes-from-database.sql
+++ b/osgp/platform/osgp-throttling-service/src/test/resources/permits-by-throttling-config-initializes-from-database.sql
@@ -1,10 +1,10 @@
 -- Insert database content expected to be present executing test methods annotated with
 -- @Sql(scripts = "/permits-by-throttling-config-initializes-from-database.sql")
-INSERT INTO throttling_config (id, name, max_concurrency, max_open_connections, max_new_connection_requests, max_new_connection_reset_time_in_ms) VALUES
-  (1, 'config-one', 10, 11, 12, 13),
-  (2, 'config-two', 15, 16, 17, 18),
-  (3, 'config-three', 2, 3, 4, 5),
-  (4, 'config-four', 1, 2, 3, 4);
+INSERT INTO throttling_config (id, name, max_concurrency, max_new_connection_requests, max_new_connection_reset_time_in_ms) VALUES
+  (1, 'config-one', 10, 11, 12),
+  (2, 'config-two', 15, 16, 17),
+  (3, 'config-three', 2, 3, 4),
+  (4, 'config-four', 1, 2, 3);
 ALTER SEQUENCE throttling_config_id_seq RESTART WITH 5;
 
 INSERT INTO permit (id, throttling_config_id, client_id, bts_id, cell_id, request_id, created_at) VALUES

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/config/ThrottlingClientConfig.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/config/ThrottlingClientConfig.java
@@ -25,9 +25,6 @@ public class ThrottlingClientConfig {
   @Value("${throttling.configuration.max.concurrency:1000}")
   private int configurationMaxConcurrency;
 
-  @Value("${throttling.configuration.max.open.connections:1000}")
-  private int configurationMaxOpenConnections;
-
   @Value("${throttling.configuration.max.new.connection.requests:30}")
   private int configurationMaxNewConnectionRequests;
 
@@ -61,7 +58,6 @@ public class ThrottlingClientConfig {
         new ThrottlingConfig(
             this.configurationName,
             this.configurationMaxConcurrency,
-            this.configurationMaxOpenConnections,
             this.configurationMaxNewConnectionRequests,
             this.configurationMaxNewConnectionResetTimeInMs),
         this.throttlingServiceUrl,

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/config/ThrottlingClientConfig.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/config/ThrottlingClientConfig.java
@@ -25,7 +25,7 @@ public class ThrottlingClientConfig {
   @Value("${throttling.configuration.max.concurrency:1000}")
   private int configurationMaxConcurrency;
 
-  @Value("${throttling.configuration.max.new.connections:30}")
+  @Value("${throttling.configuration.max.new.connections:-1}")
   private int configurationMaxNewConnections;
 
   @Value("${throttling.configuration.max.new.connections.reset.time.in.ms:1000}")

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/config/ThrottlingClientConfig.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/config/ThrottlingClientConfig.java
@@ -25,6 +25,15 @@ public class ThrottlingClientConfig {
   @Value("${throttling.configuration.max.concurrency:1000}")
   private int configurationMaxConcurrency;
 
+  @Value("${throttling.configuration.max.open.connections:1000}")
+  private int configurationMaxOpenConnections;
+
+  @Value("${throttling.configuration.max.new.connection.requests:30}")
+  private int configurationMaxNewConnectionRequests;
+
+  @Value("${throttling.configuration.max.new.connection.reset.time.in.ms:1000}")
+  private long configurationMaxNewConnectionResetTimeInMs;
+
   @Value("${throttling.service.url:http://localhost:9090}")
   private String throttlingServiceUrl;
 
@@ -49,7 +58,12 @@ public class ThrottlingClientConfig {
   @Conditional(SharedThrottlingServiceCondition.class)
   public ThrottlingClient throttlingClient() {
     return new ThrottlingClient(
-        new ThrottlingConfig(this.configurationName, this.configurationMaxConcurrency),
+        new ThrottlingConfig(
+            this.configurationName,
+            this.configurationMaxConcurrency,
+            this.configurationMaxOpenConnections,
+            this.configurationMaxNewConnectionRequests,
+            this.configurationMaxNewConnectionResetTimeInMs),
         this.throttlingServiceUrl,
         this.timeout,
         this.maxConnPerRoute,

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/config/ThrottlingClientConfig.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/config/ThrottlingClientConfig.java
@@ -19,19 +19,22 @@ public class ThrottlingClientConfig {
   @Value("${throttling.client.enabled:false}")
   private boolean clientEnabled;
 
-  @Value("${throttling.configuration.name:'CDMA'}")
+  @Value("${throttling.configuration.name:CDMA}")
   private String configurationName;
 
   @Value("${throttling.configuration.max.concurrency:1000}")
   private int configurationMaxConcurrency;
 
-  @Value("${throttling.configuration.max.new.connection.requests:30}")
-  private int configurationMaxNewConnectionRequests;
+  @Value("${throttling.configuration.max.new.connections:30}")
+  private int configurationMaxNewConnections;
 
-  @Value("${throttling.configuration.max.new.connection.reset.time.in.ms:1000}")
-  private long configurationMaxNewConnectionResetTimeInMs;
+  @Value("${throttling.configuration.max.new.connections.reset.time.in.ms:1000}")
+  private long configurationMaxNewConnectionsResetTimeInMs;
 
-  @Value("${throttling.service.url:http://localhost:9090}")
+  @Value("${throttling.configuration.max.new.connections.wait.time.in.ms:1000}")
+  private long configurationMaxNewConnectionsWaitTimeInMs;
+
+  @Value("${throttling.service.url}")
   private String throttlingServiceUrl;
 
   @Value("${throttling.client.max-conn-per-route:20}")
@@ -58,8 +61,9 @@ public class ThrottlingClientConfig {
         new ThrottlingConfig(
             this.configurationName,
             this.configurationMaxConcurrency,
-            this.configurationMaxNewConnectionRequests,
-            this.configurationMaxNewConnectionResetTimeInMs),
+            this.configurationMaxNewConnections,
+            this.configurationMaxNewConnectionsResetTimeInMs,
+            this.configurationMaxNewConnectionsWaitTimeInMs),
         this.throttlingServiceUrl,
         this.timeout,
         this.maxConnPerRoute,

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/resources/osgp-adapter-protocol-dlms.properties
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/resources/osgp-adapter-protocol-dlms.properties
@@ -188,8 +188,9 @@ throttling.client.max-conn-total=100
 # Configuration for the throttling client for max concurrency on the CDMA network
 throttling.configuration.name=CDMA
 throttling.configuration.max.concurrency=1000
-throttling.configuration.max.new.connection.requests=1000
-throttling.configuration.max.new.connection.reset.time.in.ms=1000
+throttling.configuration.max.new.connections=1000
+throttling.configuration.max.new.connections.reset.time.in.ms=1000
+throttling.configuration.max.new.connections.wait.time.in.ms=60000
 
 throttling.service.url=http://localhost:9090
 throttling.service.timeout=PT30S

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/resources/osgp-adapter-protocol-dlms.properties
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/resources/osgp-adapter-protocol-dlms.properties
@@ -188,6 +188,10 @@ throttling.client.max-conn-total=100
 # Configuration for the throttling client for max concurrency on the CDMA network
 throttling.configuration.name=CDMA
 throttling.configuration.max.concurrency=1000
+throttling.configuration.max.open.connections=1000
+throttling.configuration.max.new.connection.requests=30
+throttling.configuration.max.new.connection.reset.time.in.ms=1000
+
 throttling.service.url=http://localhost:9090
 throttling.service.timeout=PT30S
 throttling.rejected.min.delay=PT50S

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/resources/osgp-adapter-protocol-dlms.properties
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/resources/osgp-adapter-protocol-dlms.properties
@@ -188,8 +188,7 @@ throttling.client.max-conn-total=100
 # Configuration for the throttling client for max concurrency on the CDMA network
 throttling.configuration.name=CDMA
 throttling.configuration.max.concurrency=1000
-throttling.configuration.max.open.connections=1000
-throttling.configuration.max.new.connection.requests=30
+throttling.configuration.max.new.connection.requests=1000
 throttling.configuration.max.new.connection.reset.time.in.ms=1000
 
 throttling.service.url=http://localhost:9090

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/resources/osgp-adapter-protocol-dlms.properties
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/resources/osgp-adapter-protocol-dlms.properties
@@ -187,8 +187,10 @@ throttling.client.max-conn-per-route=20
 throttling.client.max-conn-total=100
 # Configuration for the throttling client for max concurrency on the CDMA network
 throttling.configuration.name=CDMA
+# -1 means no throttling on max concurrency
 throttling.configuration.max.concurrency=1000
-throttling.configuration.max.new.connections=1000
+# -1 means no throttling on new connections
+throttling.configuration.max.new.connections=-1
 throttling.configuration.max.new.connections.reset.time.in.ms=1000
 throttling.configuration.max.new.connections.wait.time.in.ms=60000
 

--- a/osgp/shared/osgp-throttling-api/src/main/java/org/opensmartgridplatform/throttling/api/ThrottlingConfig.java
+++ b/osgp/shared/osgp-throttling-api/src/main/java/org/opensmartgridplatform/throttling/api/ThrottlingConfig.java
@@ -22,32 +22,42 @@ public class ThrottlingConfig {
   @NotBlank private String name;
 
   @NotNull @PositiveOrZero private Integer maxConcurrency;
-  @NotNull @PositiveOrZero private int maxNewConnectionRequests;
-  @NotNull private long maxNewConnectionResetTimeInMs;
+  @NotNull @PositiveOrZero private int maxNewConnections;
+  @NotNull @PositiveOrZero private long maxNewConnectionsResetTimeInMs;
+  @NotNull @PositiveOrZero private long maxNewConnectionsWaitTimeInMs;
 
   public ThrottlingConfig() {
-    this(UUID.randomUUID().toString(), 0, 0, 0);
+    this(UUID.randomUUID().toString(), 0, 0, 0, 0);
   }
 
   public ThrottlingConfig(
       final String name,
       final int maxConcurrency,
-      final int maxNewConnectionRequests,
-      final long maxNewConnectionResetTimeInMs) {
-    this(null, name, maxConcurrency, maxNewConnectionRequests, maxNewConnectionResetTimeInMs);
+      final int maxNewConnections,
+      final long maxNewConnectionsResetTimeInMs,
+      final long maxNewConnectionsWaitTimeInMs) {
+    this(
+        null,
+        name,
+        maxConcurrency,
+        maxNewConnections,
+        maxNewConnectionsResetTimeInMs,
+        maxNewConnectionsWaitTimeInMs);
   }
 
   public ThrottlingConfig(
       final Short id,
       final String name,
       final int maxConcurrency,
-      final int maxNewConnectionRequests,
-      final long maxNewConnectionResetTimeInMs) {
+      final int maxNewConnections,
+      final long maxNewConnectionsResetTimeInMs,
+      final long maxNewConnectionsWaitTimeInMs) {
     this.id = id;
     this.name = name;
     this.maxConcurrency = maxConcurrency;
-    this.maxNewConnectionRequests = maxNewConnectionRequests;
-    this.maxNewConnectionResetTimeInMs = maxNewConnectionResetTimeInMs;
+    this.maxNewConnections = maxNewConnections;
+    this.maxNewConnectionsResetTimeInMs = maxNewConnectionsResetTimeInMs;
+    this.maxNewConnectionsWaitTimeInMs = maxNewConnectionsWaitTimeInMs;
   }
 
   public Short getId() {
@@ -74,31 +84,40 @@ public class ThrottlingConfig {
     this.maxConcurrency = maxConcurrency;
   }
 
-  public int getMaxNewConnectionRequests() {
-    return this.maxNewConnectionRequests;
+  public int getMaxNewConnections() {
+    return this.maxNewConnections;
   }
 
-  public void setMaxNewConnectionRequests(final int maxNewConnectionRequests) {
-    this.maxNewConnectionRequests = maxNewConnectionRequests;
+  public void setMaxNewConnections(final int maxNewConnections) {
+    this.maxNewConnections = maxNewConnections;
   }
 
-  public long getMaxNewConnectionResetTimeInMs() {
-    return this.maxNewConnectionResetTimeInMs;
+  public long getMaxNewConnectionsResetTimeInMs() {
+    return this.maxNewConnectionsResetTimeInMs;
   }
 
-  public void setMaxNewConnectionResetTimeInMs(final long maxNewConnectionResetTimeInMs) {
-    this.maxNewConnectionResetTimeInMs = maxNewConnectionResetTimeInMs;
+  public void setMaxNewConnectionsResetTimeInMs(final long maxNewConnectionsResetTimeInMs) {
+    this.maxNewConnectionsResetTimeInMs = maxNewConnectionsResetTimeInMs;
+  }
+
+  public long getMaxNewConnectionsWaitTimeInMs() {
+    return this.maxNewConnectionsWaitTimeInMs;
+  }
+
+  public void setMaxNewConnectionsWaitTimeInMs(final long maxNewConnectionsWaitTimeInMs) {
+    this.maxNewConnectionsWaitTimeInMs = maxNewConnectionsWaitTimeInMs;
   }
 
   @Override
   public String toString() {
     return String.format(
-        "%s[id=%s, name=%s, maxConcurrency=%s, maxNewConnectionRequests=%s, maxNewConnectionResetTime=%s]",
+        "%s[id=%s, name=%s, maxConcurrency=%s, maxNewConnections=%s, maxNewConnectionsResetTime=%s, maxNewConnectionsWaitTime=%s]",
         ThrottlingConfig.class.getSimpleName(),
         this.id,
         this.name,
         this.maxConcurrency,
-        this.maxNewConnectionRequests,
-        this.maxNewConnectionResetTimeInMs);
+        this.maxNewConnections,
+        this.maxNewConnectionsResetTimeInMs,
+        this.maxNewConnectionsWaitTimeInMs);
   }
 }

--- a/osgp/shared/osgp-throttling-api/src/main/java/org/opensmartgridplatform/throttling/api/ThrottlingConfig.java
+++ b/osgp/shared/osgp-throttling-api/src/main/java/org/opensmartgridplatform/throttling/api/ThrottlingConfig.java
@@ -22,19 +22,32 @@ public class ThrottlingConfig {
   @NotBlank private String name;
 
   @NotNull @PositiveOrZero private Integer maxConcurrency;
+  @NotNull @PositiveOrZero private int maxNewConnectionRequests;
+  @NotNull private long maxNewConnectionResetTimeInMs;
 
   public ThrottlingConfig() {
-    this(UUID.randomUUID().toString(), 0);
+    this(UUID.randomUUID().toString(), 0, 0, 0);
   }
 
-  public ThrottlingConfig(final String name, final int maxConcurrency) {
-    this(null, name, maxConcurrency);
+  public ThrottlingConfig(
+      final String name,
+      final int maxConcurrency,
+      final int maxNewConnectionRequests,
+      final long maxNewConnectionResetTimeInMs) {
+    this(null, name, maxConcurrency, maxNewConnectionRequests, maxNewConnectionResetTimeInMs);
   }
 
-  public ThrottlingConfig(final Short id, final String name, final int maxConcurrency) {
+  public ThrottlingConfig(
+      final Short id,
+      final String name,
+      final int maxConcurrency,
+      final int maxNewConnectionRequests,
+      final long maxNewConnectionResetTimeInMs) {
     this.id = id;
     this.name = name;
     this.maxConcurrency = maxConcurrency;
+    this.maxNewConnectionRequests = maxNewConnectionRequests;
+    this.maxNewConnectionResetTimeInMs = maxNewConnectionResetTimeInMs;
   }
 
   public Short getId() {
@@ -61,10 +74,31 @@ public class ThrottlingConfig {
     this.maxConcurrency = maxConcurrency;
   }
 
+  public int getMaxNewConnectionRequests() {
+    return this.maxNewConnectionRequests;
+  }
+
+  public void setMaxNewConnectionRequests(final int maxNewConnectionRequests) {
+    this.maxNewConnectionRequests = maxNewConnectionRequests;
+  }
+
+  public long getMaxNewConnectionResetTimeInMs() {
+    return this.maxNewConnectionResetTimeInMs;
+  }
+
+  public void setMaxNewConnectionResetTimeInMs(final long maxNewConnectionResetTimeInMs) {
+    this.maxNewConnectionResetTimeInMs = maxNewConnectionResetTimeInMs;
+  }
+
   @Override
   public String toString() {
     return String.format(
-        "%s[id=%s, name=%s, maxConcurrency=%s]",
-        ThrottlingConfig.class.getSimpleName(), this.id, this.name, this.maxConcurrency);
+        "%s[id=%s, name=%s, maxConcurrency=%s, maxNewConnectionRequests=%s, maxNewConnectionResetTime=%s]",
+        ThrottlingConfig.class.getSimpleName(),
+        this.id,
+        this.name,
+        this.maxConcurrency,
+        this.maxNewConnectionRequests,
+        this.maxNewConnectionResetTimeInMs);
   }
 }

--- a/osgp/shared/osgp-throttling-api/src/main/java/org/opensmartgridplatform/throttling/api/ThrottlingConfig.java
+++ b/osgp/shared/osgp-throttling-api/src/main/java/org/opensmartgridplatform/throttling/api/ThrottlingConfig.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import java.util.UUID;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
@@ -21,8 +22,14 @@ public class ThrottlingConfig {
 
   @NotBlank private String name;
 
-  @NotNull @PositiveOrZero private Integer maxConcurrency;
-  @NotNull @PositiveOrZero private int maxNewConnections;
+  @NotNull
+  @Min(value = -1)
+  private Integer maxConcurrency;
+
+  @NotNull
+  @Min(value = -1)
+  private int maxNewConnections;
+
   @NotNull @PositiveOrZero private long maxNewConnectionsResetTimeInMs;
   @NotNull @PositiveOrZero private long maxNewConnectionsWaitTimeInMs;
 

--- a/osgp/shared/osgp-throttling-client/src/test/java/org/opensmartgridplatform/throttling/ThrottlingClientTest.java
+++ b/osgp/shared/osgp-throttling-client/src/test/java/org/opensmartgridplatform/throttling/ThrottlingClientTest.java
@@ -37,7 +37,7 @@ class ThrottlingClientTest {
   @BeforeEach
   void beforeEach() {
     this.mockWebServer = new MockWebServer();
-    this.throttlingConfig = new ThrottlingConfig("throttling-client-test", 2);
+    this.throttlingConfig = new ThrottlingConfig("throttling-client-test", 2, 3, 4);
     this.throttlingClient =
         new ThrottlingClient(
             this.throttlingConfig,
@@ -84,7 +84,7 @@ class ThrottlingClientTest {
 
   private boolean isThrottlingConfigRegister(final RecordedRequest request) {
     return "/throttling-configs".equals(request.getPath())
-        && "{\"name\":\"throttling-client-test\",\"maxConcurrency\":2}"
+        && "{\"name\":\"throttling-client-test\",\"maxConcurrency\":2,\"maxNewConnectionRequests\":3,\"maxNewConnectionResetTimeInMs\":4}"
             .equals(request.getBody().readUtf8())
         && "POST".equals(request.getMethod());
   }

--- a/osgp/shared/osgp-throttling-client/src/test/java/org/opensmartgridplatform/throttling/ThrottlingClientTest.java
+++ b/osgp/shared/osgp-throttling-client/src/test/java/org/opensmartgridplatform/throttling/ThrottlingClientTest.java
@@ -37,7 +37,7 @@ class ThrottlingClientTest {
   @BeforeEach
   void beforeEach() {
     this.mockWebServer = new MockWebServer();
-    this.throttlingConfig = new ThrottlingConfig("throttling-client-test", 2, 3, 4);
+    this.throttlingConfig = new ThrottlingConfig("throttling-client-test", 2, 3, 4, 5);
     this.throttlingClient =
         new ThrottlingClient(
             this.throttlingConfig,
@@ -84,7 +84,7 @@ class ThrottlingClientTest {
 
   private boolean isThrottlingConfigRegister(final RecordedRequest request) {
     return "/throttling-configs".equals(request.getPath())
-        && "{\"name\":\"throttling-client-test\",\"maxConcurrency\":2,\"maxNewConnectionRequests\":3,\"maxNewConnectionResetTimeInMs\":4}"
+        && "{\"name\":\"throttling-client-test\",\"maxConcurrency\":2,\"maxNewConnections\":3,\"maxNewConnectionsResetTimeInMs\":4,\"maxNewConnectionsWaitTimeInMs\":5}"
             .equals(request.getBody().readUtf8())
         && "POST".equals(request.getMethod());
   }


### PR DESCRIPTION
Throttling can now also be done requests be based by time-unit.
The throttling-client (protocol-adapter) registers the client at the throttling-service:

`# -1 means no throttling on max concurrency`
`throttling.configuration.max.concurrency=1000`
`# -1 means no throttling on new connections`
`throttling.configuration.max.new.connections=1000`
`throttling.configuration.max.new.connections.reset.time.in.ms=1000`
`throttling.configuration.max.new.connections.wait.time.in.ms=60000`

The throttling service with these parameters the number of connections