### PR TITLE
Bump org.postgresql:postgresql from 42.6.0 to 42.7.2

### DIFF
--- a/super/pom.xml
+++ b/super/pom.xml
@@ -133,7 +133,7 @@ SPDX-License-Identifier: Apache-2.0
     <cucumber.version>5.7.0</cucumber.version>
     <testcontainers.version>1.16.2</testcontainers.version>
     <sun.httpserver.version>20070405</sun.httpserver.version>
-    <postgresql.version>42.6.0</postgresql.version>
+    <postgresql.version>42.7.2</postgresql.version>
     <jakarta.xml.soap-api.version>3.0.1</jakarta.xml.soap-api.version>
     <!-- to avoid conflicts with spring-kafka-test the older kafka version 2.4.1 is used-->
     <kafka.version>3.6.1</kafka.version>


### PR DESCRIPTION
Resolves https://github.com/OSGP/open-smart-grid-platform/security/dependabot/119