### PR TITLE
Bump org.springframework.security:spring-security-core from 6.2.0 to 6.2.2

### DIFF
--- a/super/pom.xml
+++ b/super/pom.xml
@@ -51,7 +51,7 @@ SPDX-License-Identifier: Apache-2.0
     <spring.version>6.1.4</spring.version>
     <spring.data.version>3.2.0</spring.data.version>
     <spring.data.commons.version>3.2.0</spring.data.commons.version>
-    <spring.security.version>6.2.0</spring.security.version>
+    <spring.security.version>6.2.2</spring.security.version>
     <spring.ws.version>4.0.10</spring.ws.version>
     <reactor.version>2023.0.3</reactor.version>
     <assertj.version>3.16.1</assertj.version>


### PR DESCRIPTION
Resolves:
https://github.com/OSGP/open-smart-grid-platform/security/dependabot/124
https://github.com/OSGP/open-smart-grid-platform/security/dependabot/127