### PR TITLE
SMHE-1972: PQ readings for DSMR2.2 should fail

### DIFF
--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringbundle/BundledGetPowerQualityProfileDataSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringbundle/BundledGetPowerQualityProfileDataSteps.java
@@ -9,10 +9,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
-import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -32,7 +30,6 @@ import org.opensmartgridplatform.adapter.ws.schema.smartmetering.monitoring.Powe
 import org.opensmartgridplatform.cucumber.core.ScenarioContext;
 import org.opensmartgridplatform.cucumber.platform.smartmetering.builders.GetPowerQualityProfileRequestBuilder;
 import org.opensmartgridplatform.domain.core.valueobjects.smartmetering.SignalQualityType;
-import org.opensmartgridplatform.shared.exceptionhandling.WebServiceSecurityException;
 
 @Slf4j
 public class BundledGetPowerQualityProfileDataSteps extends BaseBundleSteps {
@@ -84,21 +81,6 @@ public class BundledGetPowerQualityProfileDataSteps extends BaseBundleSteps {
 
     this.theBundleResponseShouldContainAGetPowerQualityProfileResponse(
         nrOfValues, profileLogicalName, response, valuesDataTable);
-  }
-
-  @Then("^the bundle response should contain an empty power quality profile response$")
-  public void theBundleResponseShouldContainAnEmptyGetPowerQualityProfileResponse()
-      throws GeneralSecurityException, IOException, WebServiceSecurityException {
-
-    final Response response = this.getNextBundleResponse();
-    ScenarioContext.current().put(LAST_RESPONSE, response);
-
-    assertThat(response).isInstanceOf(GetPowerQualityProfileResponse.class);
-
-    final GetPowerQualityProfileResponse getPowerQualityProfileResponse =
-        (GetPowerQualityProfileResponse) response;
-
-    assertThat(getPowerQualityProfileResponse.getPowerQualityProfileDatas()).isEmpty();
   }
 
   public void theBundleResponseShouldContainAGetPowerQualityProfileResponse(

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/bundle/BundledGetPowerQualityProfile.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/bundle/BundledGetPowerQualityProfile.feature
@@ -383,7 +383,8 @@ Feature: SmartMetering Bundle - GetPowerQualityProfile
       | BeginDate            | 2015-01-01 00:00:00 |
       | EndDate              | 2017-01-10 00:00:00 |
     When the bundle request is received
-    Then the bundle response should contain an empty power quality profile response
+    Then the bundle response should be a FaultResponse with message containing
+      | Message | No PQ profile found in profile DSMR version 2.2 |
 
     Examples:
       | deviceIdentification | port | polyphase | profileType |

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/monitoring/AbstractGetPowerQualityProfileHandler.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/monitoring/AbstractGetPowerQualityProfileHandler.java
@@ -184,7 +184,7 @@ public abstract class AbstractGetPowerQualityProfileHandler {
     this.addToMapIfNeeded(POWER_QUALITY_PROFILE_2, privateOrPublic, device, profilesWithObjects);
 
     if (profilesWithObjects.isEmpty()) {
-      throw new IllegalArgumentException(
+      throw new ProtocolAdapterException(
           String.format(
               "No PQ profile found in profile %s version %s",
               device.getProtocolName(), device.getProtocolVersion()));

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/monitoring/AbstractGetPowerQualityProfileHandler.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/monitoring/AbstractGetPowerQualityProfileHandler.java
@@ -183,6 +183,13 @@ public abstract class AbstractGetPowerQualityProfileHandler {
     this.addToMapIfNeeded(POWER_QUALITY_PROFILE_1, privateOrPublic, device, profilesWithObjects);
     this.addToMapIfNeeded(POWER_QUALITY_PROFILE_2, privateOrPublic, device, profilesWithObjects);
 
+    if (profilesWithObjects.isEmpty()) {
+      throw new IllegalArgumentException(
+          String.format(
+              "No PQ profile found in profile %s version %s",
+              device.getProtocolName(), device.getProtocolVersion()));
+    }
+
     return profilesWithObjects;
   }
 

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/monitoring/GetPowerQualityProfileNoSelectiveAccessHandlerTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/monitoring/GetPowerQualityProfileNoSelectiveAccessHandlerTest.java
@@ -252,7 +252,7 @@ class GetPowerQualityProfileNoSelectiveAccessHandlerTest extends GetPowerQuality
             this.dlmsHelper, this.objectConfigService);
 
     assertThrows(
-        IllegalArgumentException.class,
+        ProtocolAdapterException.class,
         () -> handler.handle(this.conn, this.dlmsDevice, requestDto));
   }
 

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/monitoring/GetPowerQualityProfileNoSelectiveAccessHandlerTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/monitoring/GetPowerQualityProfileNoSelectiveAccessHandlerTest.java
@@ -230,7 +230,7 @@ class GetPowerQualityProfileNoSelectiveAccessHandlerTest extends GetPowerQuality
   @ParameterizedTest
   @EnumSource(PowerQualityProfile.class)
   void testSkipIfProfileDoesNotContainObject(final PowerQualityProfile profile)
-      throws ObjectConfigException, ProtocolAdapterException {
+      throws ObjectConfigException {
     final GetPowerQualityProfileRequestDataDto requestDto =
         new GetPowerQualityProfileRequestDataDto(
             profile.name(),
@@ -251,9 +251,9 @@ class GetPowerQualityProfileNoSelectiveAccessHandlerTest extends GetPowerQuality
         new GetPowerQualityProfileNoSelectiveAccessHandler(
             this.dlmsHelper, this.objectConfigService);
 
-    final GetPowerQualityProfileResponseDto responseDto =
-        handler.handle(this.conn, this.dlmsDevice, requestDto);
-    assertThat(responseDto.getPowerQualityProfileResponseDatas()).hasSize(0);
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> handler.handle(this.conn, this.dlmsDevice, requestDto));
   }
 
   private List<GetResult> createInvalidCaptureObjects() {

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/monitoring/GetPowerQualityProfileSelectiveAccessHandlerTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/monitoring/GetPowerQualityProfileSelectiveAccessHandlerTest.java
@@ -157,7 +157,7 @@ class GetPowerQualityProfileSelectiveAccessHandlerTest extends GetPowerQualityPr
         new GetPowerQualityProfileSelectiveAccessHandler(this.dlmsHelper, this.objectConfigService);
 
     assertThrows(
-        IllegalArgumentException.class,
+        ProtocolAdapterException.class,
         () -> handler.handle(this.conn, this.dlmsDevice, requestDto));
   }
 }

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/monitoring/GetPowerQualityProfileSelectiveAccessHandlerTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/monitoring/GetPowerQualityProfileSelectiveAccessHandlerTest.java
@@ -5,6 +5,7 @@
 package org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.monitoring;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -135,7 +136,7 @@ class GetPowerQualityProfileSelectiveAccessHandlerTest extends GetPowerQualityPr
   @ParameterizedTest
   @EnumSource(PowerQualityProfile.class)
   void testSkipIfProfileDoesNotContainObject(final PowerQualityProfile profile)
-      throws ObjectConfigException, ProtocolAdapterException {
+      throws ObjectConfigException {
     final GetPowerQualityProfileRequestDataDto requestDto =
         new GetPowerQualityProfileRequestDataDto(
             profile.name(),
@@ -155,8 +156,8 @@ class GetPowerQualityProfileSelectiveAccessHandlerTest extends GetPowerQualityPr
     final GetPowerQualityProfileSelectiveAccessHandler handler =
         new GetPowerQualityProfileSelectiveAccessHandler(this.dlmsHelper, this.objectConfigService);
 
-    final GetPowerQualityProfileResponseDto responseDto =
-        handler.handle(this.conn, this.dlmsDevice, requestDto);
-    assertThat(responseDto.getPowerQualityProfileResponseDatas()).hasSize(0);
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> handler.handle(this.conn, this.dlmsDevice, requestDto));
   }
 }


### PR DESCRIPTION
When a PQ readings request is sent to a DSMR2.2 meter, a fault response should be returned, because a DSMR2.2 meter doesn't have any PQ profiles.