### PR TITLE
Feature/scheduled task performance

### DIFF
--- a/osgp/platform/osgp-core/pom.xml
+++ b/osgp/platform/osgp-core/pom.xml
@@ -224,7 +224,7 @@ SPDX-License-Identifier: Apache-2.0
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
+      <artifactId>mockito-inline</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/application/config/ScheduledTaskExecutorJobConfig.java
+++ b/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/application/config/ScheduledTaskExecutorJobConfig.java
@@ -29,6 +29,9 @@ public class ScheduledTaskExecutorJobConfig {
   @Value("${scheduling.task.pending.duration.max.seconds:3600}")
   private int scheduledTaskPendingDurationMaxSeconds;
 
+  @Value("${scheduling.task.thread.pool.size:10}")
+  private int scheduledTaskThreadPoolSize;
+
   @Autowired private OsgpScheduler osgpScheduler;
 
   @Bean
@@ -45,5 +48,9 @@ public class ScheduledTaskExecutorJobConfig {
   private void initializeScheduledJob() throws SchedulerException {
     this.osgpScheduler.createAndScheduleJob(
         ScheduledTaskExecutorJob.class, this.cronExpressionScheduledTaskExecution);
+  }
+
+  public int getScheduledTaskThreadPoolSize() {
+    return this.scheduledTaskThreadPoolSize;
   }
 }

--- a/osgp/platform/osgp-core/src/main/resources/osgp-core.properties
+++ b/osgp/platform/osgp-core/src/main/resources/osgp-core.properties
@@ -219,7 +219,9 @@ quartz.scheduler.thread.count=1
 
 scheduling.scheduled.tasks.cron.expression=0 */1 * * * ?
 
-scheduling.task.page.size=100
+scheduling.task.page.size=1000
+scheduling.task.thread.pool.size=10
+scheduling.task.pending.duration.max.seconds=28800
 
 # Max count to retry the failed response
 max.retry.count=3

--- a/osgp/platform/osgp-domain-core/src/main/java/org/opensmartgridplatform/domain/core/repositories/ScheduledTaskRepository.java
+++ b/osgp/platform/osgp-domain-core/src/main/java/org/opensmartgridplatform/domain/core/repositories/ScheduledTaskRepository.java
@@ -10,7 +10,11 @@ import org.opensmartgridplatform.domain.core.entities.ScheduledTask;
 import org.opensmartgridplatform.domain.core.valueobjects.ScheduledTaskStatusType;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface ScheduledTaskRepository extends JpaRepository<ScheduledTask, Long> {
@@ -18,4 +22,14 @@ public interface ScheduledTaskRepository extends JpaRepository<ScheduledTask, Lo
       ScheduledTaskStatusType status, Timestamp currentTimestamp, Pageable pageable);
 
   ScheduledTask findByCorrelationUid(String correlationUid);
+
+  @Transactional
+  @Modifying
+  @Query(
+      value =
+          "UPDATE ScheduledTask st SET st.status = :scheduledTaskStatus, st.modificationTime = CURRENT_TIMESTAMP()"
+              + " WHERE st.id = :scheduledTaskId")
+  int updateStatus(
+      @Param("scheduledTaskId") Long id,
+      @Param("scheduledTaskStatus") ScheduledTaskStatusType scheduledTaskStatusType);
 }


### PR DESCRIPTION
Make processing scheduled tasks faster.
Process multi-threaded, and improve update queries

`scheduling.task.page.size=1000`
`scheduling.task.thread.pool.size=10`
`scheduling.task.pending.duration.max.seconds=28800`