### PR TITLE
SMHE-2048: Add Flonidan SMR5.5 gas meters to config lookup

### DIFF
--- a/osgp/protocol-adapter-dlms/osgp-dlms/src/main/resources/dlmsprofiles/configlookup.json
+++ b/osgp/protocol-adapter-dlms/osgp-dlms/src/main/resources/dlmsprofiles/configlookup.json
@@ -20,7 +20,9 @@
       {
         "type": "value in meter is not like in specification",
         "match": [
-          "G4SRT 1.2L"
+          "G4SRT 1.2L",
+          "G10-16SRT_SMR55",
+          "G25SRT_SMR55"
         ]
       },      {
       "type": "unknown gas meter type",


### PR DESCRIPTION
Flonidan 5.5 meters G10 and bigger have a different scaler_unit than specified. For these meters the scaler_unit should be read from the meter.