### PR TITLE
SMHE-1981 Framecounter verlagen na een geslaagde key change

### DIFF
--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/database/device/DlmsDeviceSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/database/device/DlmsDeviceSteps.java
@@ -367,6 +367,23 @@ public class DlmsDeviceSteps {
         .isNull();
   }
 
+  @Then("the dlms device with identification {string} has invocationcounter with value {string}")
+  public void theInvocationCounterShouldBeReset(
+      final String deviceIdentification, final String invocationDounter) {
+
+    final DlmsDevice dlmsDevice =
+        this.dlmsDeviceRepository.findByDeviceIdentification(deviceIdentification);
+    assertThat(dlmsDevice)
+        .as("DLMS device with identification " + deviceIdentification + " in protocol database")
+        .isNotNull();
+    assertThat(dlmsDevice.getInvocationCounter())
+        .as(
+            "Invocation counter of DLMS device with identification "
+                + deviceIdentification
+                + " is not reset")
+        .isEqualTo(Long.parseLong(invocationDounter));
+  }
+
   @Then(
       "^the newly generated keys are stored in the secret management database encrypted_secret table$")
   public void theNewlyGeneratedKeysAreStoredInTheSecretManagementDatabaseEncryptedSecretTable() {

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/configuration/GenerateAndReplaceKeys.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/configuration/GenerateAndReplaceKeys.feature
@@ -8,11 +8,12 @@ Feature: SmartMetering Configuration - Generate And Replace Keys
   I want to be able to generate and replace the keys on a device
   So I can ensure secure device communication according to requirements
 
-  @ResetKeysOnDevice 
+  @ResetKeysOnDevice
   Scenario: Generate and Replace keys on a device
     Given a dlms device
       | DeviceIdentification | TEST1024000000001 |
       | DeviceType           | SMART_METER_E     |
+      | InvocationCounter    | 7500              |
     When the generate and replace keys request is received
       | DeviceIdentification | TEST1024000000001 |
     Then the generate and replace keys response should be returned
@@ -24,12 +25,14 @@ Feature: SmartMetering Configuration - Generate And Replace Keys
     And the encrypted_secret table in the secret management database should contain "Encryption_key" keys for device "TEST1024000000001"
       | SECURITY_KEY_E | EXPIRED |
     And the keyprocessing lock should be removed from off dlms device with identification "TEST1024000000001"
+    And the dlms device with identification "TEST1024000000001" has invocationcounter with value "250"
 
   @ResetKeysOnDevice
   Scenario: Generate and Replace keys on a device while NEW key already present in SecretManagement
     Given a dlms device
       | DeviceIdentification | TEST1024000000001 |
       | DeviceType           | SMART_METER_E     |
+      | InvocationCounter    | 7500              |
     And new keys are registered in the secret management database 1440 minutes ago
       | DeviceIdentification | TEST1024000000001 |
       | Encryption_key       | SECURITY_KEY_1    |
@@ -47,12 +50,14 @@ Feature: SmartMetering Configuration - Generate And Replace Keys
       | SECURITY_KEY_E | EXPIRED   |
       | SECURITY_KEY_1 | WITHDRAWN |
     And the keyprocessing lock should be removed from off dlms device with identification "TEST1024000000001"
+    And the dlms device with identification "TEST1024000000001" has invocationcounter with value "250"
 
   @ResetKeysOnDevice 
   Scenario: Generate and Replace keys on a device while multiple NEW keys already present in SecretManagement
     Given a dlms device
       | DeviceIdentification | TEST1024000000001 |
       | DeviceType           | SMART_METER_E     |
+      | InvocationCounter    | 7500              |
     And new keys are registered in the secret management database 1440 minutes ago
       | DeviceIdentification | TEST1024000000001 |
       | Encryption_key       | SECURITY_KEY_1    |
@@ -76,6 +81,7 @@ Feature: SmartMetering Configuration - Generate And Replace Keys
       | SECURITY_KEY_1 | WITHDRAWN |
       | SECURITY_KEY_3 | WITHDRAWN |
     And the keyprocessing lock should be removed from off dlms device with identification "TEST1024000000001"
+    And the dlms device with identification "TEST1024000000001" has invocationcounter with value "250"
 
   @ResetKeysOnDevice
   Scenario: Generate and Replace keys on a device (multiple concurrent single requests are executed after one other)
@@ -85,6 +91,7 @@ Feature: SmartMetering Configuration - Generate And Replace Keys
       | Master_key           | SECURITY_KEY_M    |
       | Encryption_key       | SECURITY_KEY_E    |
       | Authentication_key   | SECURITY_KEY_A    |
+      | InvocationCounter    | 7500              |
     When multiple generate and replace keys requests are received
       | DeviceIdentification | TEST1024000000001,TEST1024000000001,TEST1024000000001 |
     Then multiple generate and replace keys responses should be returned
@@ -98,6 +105,7 @@ Feature: SmartMetering Configuration - Generate And Replace Keys
       | Authentication_key | 3 |
       | Encryption_key     | 3 |
     And the keyprocessing lock should be removed from off dlms device with identification "TEST1024000000001"
+    And the dlms device with identification "TEST1024000000001" has invocationcounter with value "250"
 
   @ResetKeysOnDevice
   Scenario: Generate and Replace keys on a device (multiple requests in one bundle are executed after one other)
@@ -107,6 +115,7 @@ Feature: SmartMetering Configuration - Generate And Replace Keys
       | Master_key           | SECURITY_KEY_M    |
       | Encryption_key       | SECURITY_KEY_E    |
       | Authentication_key   | SECURITY_KEY_A    |
+      | InvocationCounter    | 7500              |
     Given a bundle request
       | DeviceIdentification | TEST1024000000001 |
     And the bundle request contains a generate and replace keys action
@@ -124,3 +133,4 @@ Feature: SmartMetering Configuration - Generate And Replace Keys
       | Authentication_key | 3 |
       | Encryption_key     | 3 |
     And the keyprocessing lock should be removed from off dlms device with identification "TEST1024000000001"
+    And the dlms device with identification "TEST1024000000001" has invocationcounter with value "250"

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/configuration/ReplaceKeys.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/configuration/ReplaceKeys.feature
@@ -16,6 +16,7 @@ Feature: SmartMetering Configuration - Replace Keys
       | Master_key           | SECURITY_KEY_M    |
       | Encryption_key       | SECURITY_KEY_E    |
       | Authentication_key   | SECURITY_KEY_A    |
+      | InvocationCounter    | 7500              |
     When the replace keys request is received
       | DeviceIdentification | TEST1024000000001 |
       | Encryption_key       | SECURITY_KEY_1    |
@@ -32,12 +33,14 @@ Feature: SmartMetering Configuration - Replace Keys
       | SECURITY_KEY_E | EXPIRED |
       | SECURITY_KEY_1 | ACTIVE  |
     And the keyprocessing lock should be removed from off dlms device with identification "TEST1024000000001"
+    And the dlms device with identification "TEST1024000000001" has invocationcounter with value "250"
 
   @ResetKeysOnDevice
   Scenario: Replace keys on a device while NEW key already present in SecretManagement
     Given a dlms device
       | DeviceIdentification | TEST1024000000001 |
       | DeviceType           | SMART_METER_E     |
+      | InvocationCounter    | 7500              |
     And new keys are registered in the secret management database 1440 minutes ago
       | DeviceIdentification | TEST1024000000001 |
       | Encryption_key       | SECURITY_KEY_1    |
@@ -66,6 +69,7 @@ Feature: SmartMetering Configuration - Replace Keys
     Given a dlms device
       | DeviceIdentification | TEST1024000000001 |
       | DeviceType           | SMART_METER_E     |
+      | InvocationCounter    | 7500              |
     And new keys are registered in the secret management database 1440 minutes ago
       | DeviceIdentification | TEST1024000000001 |
       | Encryption_key       | SECURITY_KEY_1    |
@@ -94,6 +98,7 @@ Feature: SmartMetering Configuration - Replace Keys
       | SECURITY_KEY_3 | WITHDRAWN |
       | SECURITY_KEY_1 | WITHDRAWN |
     And the keyprocessing lock should be removed from off dlms device with identification "TEST1024000000001"
+    And the dlms device with identification "TEST1024000000001" has invocationcounter with value "250"
 
   @ResetKeysOnDevice
   Scenario: Replace keys on a device (multiple concurrent single requests are executed after one other)
@@ -103,6 +108,7 @@ Feature: SmartMetering Configuration - Replace Keys
       | Master_key           | SECURITY_KEY_M    |
       | Encryption_key       | SECURITY_KEY_E    |
       | Authentication_key   | SECURITY_KEY_A    |
+      | InvocationCounter    | 7500              |
     When multiple replace keys requests are received
       | DeviceIdentification | TEST1024000000001,TEST1024000000001 |
       | Encryption_key       | SECURITY_KEY_1,SECURITY_KEY_3       |
@@ -118,6 +124,7 @@ Feature: SmartMetering Configuration - Replace Keys
       | Authentication_key | SECURITY_KEY_2,SECURITY_KEY_4 |
       | Encryption_key     | SECURITY_KEY_1,SECURITY_KEY_3 |
     And the keyprocessing lock should be removed from off dlms device with identification "TEST1024000000001"
+    And the dlms device with identification "TEST1024000000001" has invocationcounter with value "250"
 
   @ResetKeysOnDevice
   Scenario: Replace keys on a device (multiple requests in one bundle are executed after one other)
@@ -127,6 +134,7 @@ Feature: SmartMetering Configuration - Replace Keys
       | Master_key           | SECURITY_KEY_M    |
       | Encryption_key       | SECURITY_KEY_E    |
       | Authentication_key   | SECURITY_KEY_A    |
+      | InvocationCounter    | 7500              |
     Given a bundle request
       | DeviceIdentification | TEST1024000000001 |
     And the bundle request contains a replace keys action
@@ -150,3 +158,4 @@ Feature: SmartMetering Configuration - Replace Keys
       | Authentication_key | SECURITY_KEY_2,SECURITY_KEY_4,SECURITY_KEY_6 |
       | Encryption_key     | SECURITY_KEY_1,SECURITY_KEY_3,SECURITY_KEY_5 |
     And the keyprocessing lock should be removed from off dlms device with identification "TEST1024000000001"
+    And the dlms device with identification "TEST1024000000001" has invocationcounter with value "250"

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/security/AbstractReplaceKeyCommandExecutor.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/security/AbstractReplaceKeyCommandExecutor.java
@@ -16,6 +16,7 @@ import org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.utils.Jdl
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.entities.DlmsDevice;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.entities.SecurityKeyType;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.factories.DlmsConnectionManager;
+import org.opensmartgridplatform.adapter.protocol.dlms.domain.repositories.DlmsDeviceRepository;
 import org.opensmartgridplatform.adapter.protocol.dlms.exceptions.ConnectionException;
 import org.opensmartgridplatform.adapter.protocol.dlms.exceptions.ProtocolAdapterException;
 import org.opensmartgridplatform.dto.valueobjects.smartmetering.ActionRequestDto;
@@ -39,9 +40,13 @@ public abstract class AbstractReplaceKeyCommandExecutor<T>
 
   @Autowired private SecretManagementService secretManagementService;
 
+  @Autowired private DlmsDeviceRepository dlmsDeviceRepository;
+
   @Autowired
   @Qualifier("decrypterForGxfSmartMetering")
   private RsaEncrypter decrypterForGxfSmartMetering;
+
+  private static final Long INVOCATION_COUNTER_AFTER_KEY_CHANGE = 250L;
 
   /**
    * Constructor for CommandExecutors that need to be executed in the context of bundle actions.
@@ -91,6 +96,9 @@ public abstract class AbstractReplaceKeyCommandExecutor<T>
         messageMetadata);
 
     log.info("Encryption key successfully set on device :{}", device.getDeviceIdentification());
+
+    this.dlmsDeviceRepository.updateInvocationCounter(
+        devicePostSave.getDeviceIdentification(), INVOCATION_COUNTER_AFTER_KEY_CHANGE);
 
     return new ActionResponseDto(
         String.format(

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/security/GenerateAndReplaceKeyCommandExecutorTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/security/GenerateAndReplaceKeyCommandExecutorTest.java
@@ -1,0 +1,122 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Contributors to the GXF project
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.security;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.openmuc.jdlms.AttributeAddress;
+import org.openmuc.jdlms.DlmsConnection;
+import org.openmuc.jdlms.GetResult;
+import org.openmuc.jdlms.MethodParameter;
+import org.openmuc.jdlms.MethodResult;
+import org.openmuc.jdlms.MethodResultCode;
+import org.openmuc.jdlms.SetParameter;
+import org.opensmartgridplatform.adapter.protocol.dlms.application.services.DeviceKeyProcessingService;
+import org.opensmartgridplatform.adapter.protocol.dlms.application.services.SecretManagementService;
+import org.opensmartgridplatform.adapter.protocol.dlms.domain.entities.DlmsDevice;
+import org.opensmartgridplatform.adapter.protocol.dlms.domain.entities.SecurityKeyType;
+import org.opensmartgridplatform.adapter.protocol.dlms.domain.factories.DlmsConnectionManager;
+import org.opensmartgridplatform.adapter.protocol.dlms.domain.repositories.DlmsDeviceRepository;
+import org.opensmartgridplatform.adapter.protocol.dlms.infra.messaging.DlmsMessageListener;
+import org.opensmartgridplatform.dto.valueobjects.smartmetering.ActionResponseDto;
+import org.opensmartgridplatform.dto.valueobjects.smartmetering.ClearMBusStatusOnAllChannelsRequestDto;
+import org.opensmartgridplatform.dto.valueobjects.smartmetering.GenerateAndReplaceKeysRequestDataDto;
+import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
+
+@ExtendWith(MockitoExtension.class)
+class GenerateAndReplaceKeyCommandExecutorTest {
+
+  @Mock private SecretManagementService secretManagementService;
+
+  @Mock private DeviceKeyProcessingService deviceKeyProcessingService;
+  @Mock private DlmsDeviceRepository dlmsDeviceRepository;
+  @Mock private DlmsConnectionManager connectionManager;
+
+  @Mock private DlmsConnection dlmsConnection;
+
+  private DlmsMessageListener dlmsMessageListener;
+
+  @Mock private ClearMBusStatusOnAllChannelsRequestDto dto;
+
+  @Mock private MessageMetadata messageMetadata;
+
+  @Mock private GetResult getResult;
+
+  @Mock private MethodResult methodResult;
+
+  @Captor private ArgumentCaptor<AttributeAddress> attributeAddressArgumentCaptor;
+
+  @Captor private ArgumentCaptor<SetParameter> setParameterArgumentCaptor;
+
+  @Captor private ArgumentCaptor<MethodParameter> methodParameterArgumentCaptor;
+  @InjectMocks private GenerateAndReplaceKeyCommandExecutor commandExecutor;
+
+  @BeforeEach
+  public void setup() {
+    this.dlmsMessageListener = Mockito.mock(DlmsMessageListener.class);
+  }
+
+  @Test
+  void testExecute() throws Exception {
+    final DlmsDevice device = Mockito.mock(DlmsDevice.class);
+    final GenerateAndReplaceKeysRequestDataDto actionRequestDto =
+        Mockito.mock(GenerateAndReplaceKeysRequestDataDto.class);
+    final MessageMetadata messageMetadata = Mockito.mock(MessageMetadata.class);
+
+    when(this.connectionManager.getDlmsMessageListener()).thenReturn(this.dlmsMessageListener);
+    when(this.connectionManager.getConnection()).thenReturn(this.dlmsConnection);
+    when(this.methodResult.getResultCode()).thenReturn(MethodResultCode.SUCCESS);
+    when(this.dlmsConnection.action(this.methodParameterArgumentCaptor.capture()))
+        .thenReturn(this.methodResult);
+    when(device.getDeviceIdentification()).thenReturn("device1");
+    when(messageMetadata.getDeviceIdentification()).thenReturn("device1");
+    when(device.getDeviceIdentification()).thenReturn("device1");
+    when(messageMetadata.getDeviceIdentification()).thenReturn("device1");
+
+    final byte[] decryptedMasterKey = new byte[16];
+    when(this.secretManagementService.getKey(any(), any(), any())).thenReturn(decryptedMasterKey);
+    final Map<SecurityKeyType, byte[]> generatedKeys =
+        Map.of(
+            SecurityKeyType.E_METER_AUTHENTICATION,
+            new byte[16],
+            SecurityKeyType.E_METER_ENCRYPTION,
+            new byte[16]);
+    when(this.secretManagementService.generate128BitsKeysAndStoreAsNewKeys(any(), any(), any()))
+        .thenReturn(generatedKeys);
+
+    final ActionResponseDto result =
+        this.commandExecutor.execute(
+            this.connectionManager, device, actionRequestDto, messageMetadata);
+
+    assertThat("Replace keys for device device1 was successful")
+        .isEqualTo(result.getResultString());
+
+    verify(this.secretManagementService, times(1))
+        .generate128BitsKeysAndStoreAsNewKeys(Mockito.any(), Mockito.any(), Mockito.any());
+    verify(this.secretManagementService, times(2))
+        .getKey(Mockito.any(), Mockito.any(), Mockito.any());
+    verify(this.secretManagementService, times(2))
+        .activateNewKey(Mockito.any(), Mockito.any(), Mockito.any());
+
+    verify(this.dlmsDeviceRepository, times(1))
+        .updateInvocationCounter(Mockito.any(), Mockito.any());
+  }
+}

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/security/GenerateAndReplaceKeyCommandExecutorTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/security/GenerateAndReplaceKeyCommandExecutorTest.java
@@ -110,13 +110,10 @@ class GenerateAndReplaceKeyCommandExecutorTest {
         .isEqualTo(result.getResultString());
 
     verify(this.secretManagementService, times(1))
-        .generate128BitsKeysAndStoreAsNewKeys(Mockito.any(), Mockito.any(), Mockito.any());
-    verify(this.secretManagementService, times(2))
-        .getKey(Mockito.any(), Mockito.any(), Mockito.any());
-    verify(this.secretManagementService, times(2))
-        .activateNewKey(Mockito.any(), Mockito.any(), Mockito.any());
+        .generate128BitsKeysAndStoreAsNewKeys(any(), any(), any());
+    verify(this.secretManagementService, times(2)).getKey(any(), any(), any());
+    verify(this.secretManagementService, times(2)).activateNewKey(any(), any(), any());
 
-    verify(this.dlmsDeviceRepository, times(1))
-        .updateInvocationCounter(Mockito.any(), Mockito.any());
+    verify(this.dlmsDeviceRepository, times(1)).updateInvocationCounter(any(), any());
   }
 }


### PR DESCRIPTION
-Zowel na een ReplaceKeys als een GenerateAndReplaceKeys moeten de framecounter worden terug gezet.
-Zet de Framecounter niet op 0, maar op 250

https://jenkins.fdp.osgp.cloud/view/SMHE-cucumber/job/gxf-smhe-cucumber-build/221/