### PR TITLE
Fix Flaky throttling test

### DIFF
--- a/osgp/platform/osgp-throttling-service/src/test/java/org/opensmartgridplatform/throttling/PermitsPerNetworkSegmentTest.java
+++ b/osgp/platform/osgp-throttling-service/src/test/java/org/opensmartgridplatform/throttling/PermitsPerNetworkSegmentTest.java
@@ -217,12 +217,13 @@ class PermitsPerNetworkSegmentTest {
 
     final long start = System.currentTimeMillis();
 
+    when(this.permitReleasedNotifier.waitForAvailablePermit(btsId, cellId, 1000))
+        .thenReturn(false)
+        .thenReturn(true);
+
     final ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(2);
     executor.schedule(
         () -> {
-          when(this.permitReleasedNotifier.waitForAvailablePermit(btsId, cellId, 1000))
-              .thenReturn(false)
-              .thenReturn(true);
           this.permitsPerNetworkSegment.releasePermit(
               throttlingConfigId, clientId, btsId, cellId, requestId);
 


### PR DESCRIPTION
Move then when then outside the multithreaded execution. This could reduce weird behavior in the mockito mocking storage