### PR TITLE
feature/fix-stacktraceutilstest-for-windows

### DIFF
--- a/osgp/shared/shared/src/test/java/org/opensmartgridplatform/shared/utils/StacktraceUtilsTest.java
+++ b/osgp/shared/shared/src/test/java/org/opensmartgridplatform/shared/utils/StacktraceUtilsTest.java
@@ -33,6 +33,6 @@ class StacktraceUtilsTest {
             Caused by org.opensmartgridplatform.shared.utils.StacktraceUtilsTest: This is the original error""";
 
     final var actual = messageAndCauses(exception).replaceAll("\r\n", "\n");
-    assertThat(actual).isEqualTo(expected);
+    assertThat(actual).isEqualToIgnoringNewLines(expected);
   }
 }


### PR DESCRIPTION
In Windows environment string comparison fails due to newlines in stacktrace