### PR TITLE
SMHE-749: Device without manufacturer ID warning

### DIFF
--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/factories/Hls5Connector.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/factories/Hls5Connector.java
@@ -11,7 +11,6 @@ import java.io.IOException;
 import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.Map;
-import org.apache.commons.lang3.StringUtils;
 import org.openmuc.jdlms.AuthenticationMechanism;
 import org.openmuc.jdlms.DlmsConnection;
 import org.openmuc.jdlms.SecuritySuite;

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/factories/Hls5Connector.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/factories/Hls5Connector.java
@@ -170,18 +170,7 @@ public class Hls5Connector extends SecureDlmsConnector {
      * builder the library is enabled to meet the IV requirements of DLMS
      * HLS5 communication.
      */
-    final String manufacturerId;
-    if (StringUtils.isEmpty(device.getManufacturerId())) {
-      LOGGER.debug(
-          "Device {} does not have its manufacturer ID stored in the database. "
-              + "Using a default value which makes the system title (part of the IV in HLS 5) less "
-              + "unique.",
-          device.getDeviceIdentification());
-      manufacturerId = "   ";
-    } else {
-      manufacturerId = device.getManufacturerId();
-    }
-    tcpConnectionBuilder.setSystemTitle(manufacturerId, device.getDeviceId());
+    tcpConnectionBuilder.setSystemTitle("   ", device.getDeviceId());
 
     final long frameCounter = device.getInvocationCounter();
 


### PR DESCRIPTION
Removed the check for a manufacturerId in a DlmsDevice. The manufacturerId was used to create a unique "system title" per device. However, it only needs to be unique per client. The DLMS green book, section 4.3.4, edition 9, states:
_The system title Sys-T shall uniquely identify each DLMS/COSEM entity that may be server, a client or a third party that can access servers via clients_
By replacing the manufacturerId with three spaces we still adhere to the DLMS green book.
