### PR TITLE
Feature/smhe 1672 identification number int overflow

### DIFF
--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/firmware/UpdateFirmwareCommandExecutor.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/firmware/UpdateFirmwareCommandExecutor.java
@@ -13,6 +13,7 @@ import org.bouncycastle.util.encoders.Hex;
 import org.opensmartgridplatform.adapter.protocol.dlms.application.services.MacGenerationService;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.AbstractCommandExecutor;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.firmware.firmwarefile.FirmwareFile;
+import org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.mbus.IdentificationNumber;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.entities.DlmsDevice;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.factories.DlmsConnectionManager;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.repositories.DlmsDeviceRepository;
@@ -213,11 +214,11 @@ public class UpdateFirmwareCommandExecutor
           String.format(EXCEPTION_MSG_DEVICE_NOT_AVAILABLE_IN_DATABASE, deviceIdentification));
     }
 
-    final String identificationNumber = this.getIdentificationNumber(mbusDevice);
+    final IdentificationNumber identificationNumber = this.getIdentificationNumber(mbusDevice);
 
     log.debug("Original Firmware file header: {}", firmwareFile.getHeader());
-
-    log.debug("Setting M-Bus Identification number: {}", identificationNumber);
+    log.debug(
+        "Setting M-Bus Identification number: {}", identificationNumber.getTextualRepresentation());
     firmwareFile.setMbusDeviceIdentificationNumber(identificationNumber);
 
     final int mbusVersion = 80;
@@ -237,7 +238,7 @@ public class UpdateFirmwareCommandExecutor
     return firmwareFile;
   }
 
-  private String getIdentificationNumber(final DlmsDevice mbusDevice)
+  private IdentificationNumber getIdentificationNumber(final DlmsDevice mbusDevice)
       throws ProtocolAdapterException {
     final String mbusIdentificationNumberTextualRepresentation =
         mbusDevice.getMbusIdentificationNumberTextualRepresentation();
@@ -247,7 +248,8 @@ public class UpdateFirmwareCommandExecutor
               EXCEPTION_MSG_DEVICE_HAS_NO_MBUS_IDENTIFICATION_NUMBER,
               mbusDevice.getDeviceIdentification()));
     }
-    return mbusIdentificationNumberTextualRepresentation;
+    return IdentificationNumber.fromTextualRepresentation(
+        mbusIdentificationNumberTextualRepresentation);
   }
 
   private byte[] getImageIdentifier(

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/firmware/firmwarefile/FirmwareFile.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/firmware/firmwarefile/FirmwareFile.java
@@ -13,6 +13,7 @@ import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
 import org.bouncycastle.util.encoders.Hex;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.firmware.firmwarefile.enums.AddressType;
+import org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.mbus.IdentificationNumber;
 import org.opensmartgridplatform.adapter.protocol.dlms.exceptions.ProtocolAdapterException;
 
 /**
@@ -106,13 +107,13 @@ public class FirmwareFile {
             .array();
   }
 
-  public void setMbusDeviceIdentificationNumber(final String mbusDeviceIdentificationNumber)
-      throws ProtocolAdapterException {
+  public void setMbusDeviceIdentificationNumber(
+      final IdentificationNumber mbusDeviceIdentificationNumber) throws ProtocolAdapterException {
 
     final byte[] mbusDeviceIdentificationNumberByteArray =
         ByteBuffer.allocate(4)
             .order(ByteOrder.LITTLE_ENDIAN)
-            .putInt(Integer.parseInt(mbusDeviceIdentificationNumber, 16))
+            .putInt(mbusDeviceIdentificationNumber.getIntRepresentation())
             .array();
 
     this.checkWildcard(mbusDeviceIdentificationNumber);
@@ -135,16 +136,17 @@ public class FirmwareFile {
    * The Identification number can be wildcarded, a firmware file can be made available for a range
    * or all individual meters. The wildcard character is hex-value: 'F'.
    */
-  private void checkWildcard(final String mbusDeviceIdentificationNumber)
+  private void checkWildcard(final IdentificationNumber mbusDeviceIdentificationNumber)
       throws ProtocolAdapterException {
     final String lsbFirstPattern = this.getHeader().getMbusDeviceIdentificationNumber();
     final String msbFirstPattern = this.reverseHexString(lsbFirstPattern);
     if (!Pattern.matches(
-        msbFirstPattern.replaceAll("[fF]", "[0-9]"), mbusDeviceIdentificationNumber)) {
+        msbFirstPattern.replaceAll("[fF]", "[0-9]"),
+        mbusDeviceIdentificationNumber.getTextualRepresentation())) {
       throw new ProtocolAdapterException(
           String.format(
               "M-Bus Device Identification Number (%s) does not fit the range of Identification Numbers supported by this Firmware File (%s)",
-              mbusDeviceIdentificationNumber, msbFirstPattern));
+              mbusDeviceIdentificationNumber.getTextualRepresentation(), msbFirstPattern));
     }
   }
 

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/mbus/IdentificationNumber.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/mbus/IdentificationNumber.java
@@ -4,8 +4,6 @@
 
 package org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.mbus;
 
-import java.nio.ByteBuffer;
-import java.util.Arrays;
 import org.apache.commons.lang3.StringUtils;
 import org.openmuc.jdlms.datatypes.DataObject;
 import org.opensmartgridplatform.adapter.protocol.dlms.exceptions.ProtocolAdapterException;
@@ -115,7 +113,7 @@ public class IdentificationNumber {
     if (StringUtils.isBlank(this.textualRepresentation)) {
       return DataObject.newNullData();
     }
-    return DataObject.newUInteger32Data(this.getLongRepresentation());
+    return DataObject.newUInteger32Data(Long.parseLong(this.getTextualRepresentation()));
   }
 
   public Long getIdentificationNumberInBcdRepresentationAsLong() {
@@ -126,26 +124,14 @@ public class IdentificationNumber {
     return this.textualRepresentation;
   }
 
-  public Long getLongRepresentation() {
-    return Long.parseLong(this.getTextualRepresentation());
-  }
-
+  /**
+   * In the firmware file header 4 bytes are reserved for the device identification. Therefor the
+   * textual (hex) representation of the device identification is parsed to an integer ignoring the
+   * four least significant of the long (eight bytes). There first four bytes are assumed to be
+   * empty (zero). Since textual representation is always checked on length and digits this is
+   * always the case
+   */
   public Integer getIntRepresentation() throws ProtocolAdapterException {
-    // Convert textual representation of deviceIdentificationNumber to long (eight bytes)
-    final ByteBuffer longBytesBuffer = ByteBuffer.allocate(Long.BYTES);
-    longBytesBuffer.putLong(0, Long.parseLong(this.textualRepresentation, 16));
-    // First four bytes should be empty (zero)
-    byte[] intBytes = Arrays.copyOfRange(longBytesBuffer.array(), 0, 4);
-    ByteBuffer buffer = ByteBuffer.allocate(Integer.BYTES);
-    if (buffer.put(intBytes).flip().getInt() != 0) {
-      throw new ProtocolAdapterException(
-          String.format(
-              "IdentificationNumber %s cannot be represented as integer.",
-              this.textualRepresentation));
-    }
-    // Convert the last four bytes to integer
-    intBytes = Arrays.copyOfRange(longBytesBuffer.array(), 4, 8);
-    buffer = ByteBuffer.allocate(Integer.BYTES);
-    return buffer.put(intBytes).flip().getInt();
+    return (int) Long.parseLong(this.textualRepresentation, 16);
   }
 }

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/mbus/IdentificationNumber.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/mbus/IdentificationNumber.java
@@ -6,7 +6,6 @@ package org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.mbus;
 
 import org.apache.commons.lang3.StringUtils;
 import org.openmuc.jdlms.datatypes.DataObject;
-import org.opensmartgridplatform.adapter.protocol.dlms.exceptions.ProtocolAdapterException;
 import org.opensmartgridplatform.dlms.interfaceclass.attribute.MbusClientAttribute;
 
 /**
@@ -131,7 +130,7 @@ public class IdentificationNumber {
    * empty (zero). Since textual representation is always checked on length and digits this is
    * always the case
    */
-  public Integer getIntRepresentation() throws ProtocolAdapterException {
+  public Integer getIntRepresentation() {
     return (int) Long.parseLong(this.textualRepresentation, 16);
   }
 }

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/mbus/IdentificationNumber.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/mbus/IdentificationNumber.java
@@ -4,8 +4,11 @@
 
 package org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.mbus;
 
+import java.nio.ByteBuffer;
+import java.util.Arrays;
 import org.apache.commons.lang3.StringUtils;
 import org.openmuc.jdlms.datatypes.DataObject;
+import org.opensmartgridplatform.adapter.protocol.dlms.exceptions.ProtocolAdapterException;
 import org.opensmartgridplatform.dlms.interfaceclass.attribute.MbusClientAttribute;
 
 /**
@@ -112,7 +115,7 @@ public class IdentificationNumber {
     if (StringUtils.isBlank(this.textualRepresentation)) {
       return DataObject.newNullData();
     }
-    return DataObject.newUInteger32Data(this.getNumericalRepresentation());
+    return DataObject.newUInteger32Data(this.getLongRepresentation());
   }
 
   public Long getIdentificationNumberInBcdRepresentationAsLong() {
@@ -123,7 +126,26 @@ public class IdentificationNumber {
     return this.textualRepresentation;
   }
 
-  public Long getNumericalRepresentation() {
+  public Long getLongRepresentation() {
     return Long.parseLong(this.getTextualRepresentation());
+  }
+
+  public Integer getIntRepresentation() throws ProtocolAdapterException {
+    // Convert textual representation of deviceIdentificationNumber to long (eight bytes)
+    final ByteBuffer longBytesBuffer = ByteBuffer.allocate(Long.BYTES);
+    longBytesBuffer.putLong(0, Long.parseLong(this.textualRepresentation, 16));
+    // First four bytes should be empty (zero)
+    byte[] intBytes = Arrays.copyOfRange(longBytesBuffer.array(), 0, 4);
+    ByteBuffer buffer = ByteBuffer.allocate(Integer.BYTES);
+    if (buffer.put(intBytes).flip().getInt() != 0) {
+      throw new ProtocolAdapterException(
+          String.format(
+              "IdentificationNumber %s cannot be represented as integer.",
+              this.textualRepresentation));
+    }
+    // Convert the last four bytes to integer
+    intBytes = Arrays.copyOfRange(longBytesBuffer.array(), 4, 8);
+    buffer = ByteBuffer.allocate(Integer.BYTES);
+    return buffer.put(intBytes).flip().getInt();
   }
 }

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/application/services/MacGenerationServiceTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/application/services/MacGenerationServiceTest.java
@@ -118,12 +118,12 @@ public class MacGenerationServiceTest {
   }
 
   @Test
-  public void testIV1() throws ProtocolAdapterException {
+  void testIV1() throws ProtocolAdapterException {
     this.testIV(byteArray1, this.expectedIv1, getIdentificationNumber(this.deviceIdentification1));
   }
 
   @Test
-  public void testIV2() throws ProtocolAdapterException {
+  void testIV2() throws ProtocolAdapterException {
     this.testIV(byteArray2, this.expectedIv1, getIdentificationNumber(this.deviceIdentification1));
   }
 
@@ -152,7 +152,7 @@ public class MacGenerationServiceTest {
   }
 
   @Test
-  public void testInvalidFirmwareImageMagicNumber() throws ProtocolAdapterException {
+  void testInvalidFirmwareImageMagicNumber() throws ProtocolAdapterException {
 
     final byte[] clonedByteArray = byteArray1.clone();
     clonedByteArray[0] = (byte) 0;
@@ -164,7 +164,7 @@ public class MacGenerationServiceTest {
   }
 
   @Test
-  public void testInvalidHeaderLength() throws ProtocolAdapterException {
+  void testInvalidHeaderLength() throws ProtocolAdapterException {
 
     final byte[] clonedByteArray = byteArray1.clone();
     clonedByteArray[5] = (byte) 0;
@@ -176,7 +176,7 @@ public class MacGenerationServiceTest {
   }
 
   @Test
-  public void testInvalidAddressLength() throws ProtocolAdapterException {
+  void testInvalidAddressLength() throws ProtocolAdapterException {
 
     final byte[] clonedByteArray = byteArray1.clone();
     clonedByteArray[18] = (byte) 0;
@@ -188,7 +188,7 @@ public class MacGenerationServiceTest {
   }
 
   @Test
-  public void testInvalidAddressType() throws ProtocolAdapterException {
+  void testInvalidAddressType() throws ProtocolAdapterException {
 
     final byte[] clonedByteArray = byteArray1.clone();
     clonedByteArray[19] = (byte) 0;
@@ -200,7 +200,7 @@ public class MacGenerationServiceTest {
   }
 
   @Test
-  public void testNonExistingSecurityType() throws ProtocolAdapterException {
+  void testNonExistingSecurityType() throws ProtocolAdapterException {
 
     final byte[] clonedByteArray = byteArray1.clone();
     clonedByteArray[17] = (byte) 6;
@@ -212,7 +212,7 @@ public class MacGenerationServiceTest {
   }
 
   @Test
-  public void testNotExpectedSecurityType() throws ProtocolAdapterException {
+  void testNotExpectedSecurityType() throws ProtocolAdapterException {
 
     final byte[] clonedByteArray = byteArray1.clone();
     clonedByteArray[17] = (byte) 0;
@@ -224,7 +224,7 @@ public class MacGenerationServiceTest {
   }
 
   @Test
-  public void testInvalidSecurityLength() throws ProtocolAdapterException {
+  void testInvalidSecurityLength() throws ProtocolAdapterException {
 
     final byte[] clonedByteArray = byteArray1.clone();
     clonedByteArray[15] = (byte) 0;
@@ -236,7 +236,7 @@ public class MacGenerationServiceTest {
   }
 
   @Test
-  public void testNotExpectedActivationType() throws ProtocolAdapterException {
+  void testNotExpectedActivationType() throws ProtocolAdapterException {
 
     final byte[] clonedByteArray = byteArray1.clone();
     clonedByteArray[28] = (byte) 1;
@@ -248,7 +248,7 @@ public class MacGenerationServiceTest {
   }
 
   @Test
-  public void testNonExistingActivationType() throws ProtocolAdapterException {
+  void testNonExistingActivationType() throws ProtocolAdapterException {
 
     final byte[] clonedByteArray = byteArray1.clone();
     clonedByteArray[28] = (byte) 0;
@@ -260,7 +260,7 @@ public class MacGenerationServiceTest {
   }
 
   @Test
-  public void testNonExistingDeviceType() throws ProtocolAdapterException {
+  void testNonExistingDeviceType() throws ProtocolAdapterException {
 
     final byte[] clonedByteArray = byteArray1.clone();
     clonedByteArray[27] = (byte) 0;

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/firmware/firmwarefile/FirmwareFileTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/firmware/firmwarefile/FirmwareFileTest.java
@@ -67,8 +67,8 @@ public class FirmwareFileTest {
 
     final FirmwareFile firmwareFile = this.createPartialWildcardFirmwareFile("FFFF0000");
 
-    final String fittingMbusDeviceIdentificationNumber =
-        IdentificationNumber.fromTextualRepresentation("00009999").getTextualRepresentation();
+    final IdentificationNumber fittingMbusDeviceIdentificationNumber =
+        IdentificationNumber.fromTextualRepresentation("00009999");
     assertDoesNotThrow(
         () ->
             firmwareFile.setMbusDeviceIdentificationNumber(fittingMbusDeviceIdentificationNumber));
@@ -80,8 +80,8 @@ public class FirmwareFileTest {
 
     final FirmwareFile firmwareFile = this.createPartialWildcardFirmwareFile("FFFFFFFF");
 
-    final String fittingMbusDeviceIdentificationNumber =
-        IdentificationNumber.fromTextualRepresentation("16019864").getTextualRepresentation();
+    final IdentificationNumber fittingMbusDeviceIdentificationNumber =
+        IdentificationNumber.fromTextualRepresentation("16019864");
 
     assertDoesNotThrow(
         () ->
@@ -95,9 +95,8 @@ public class FirmwareFileTest {
     final String reversedWildcard = "0000FFFF";
     final String identificationNumber = "00010000";
 
-    final String misfittingMbusDeviceIdentificationNumber =
-        IdentificationNumber.fromTextualRepresentation(identificationNumber)
-            .getTextualRepresentation();
+    final IdentificationNumber misfittingMbusDeviceIdentificationNumber =
+        IdentificationNumber.fromTextualRepresentation(identificationNumber);
 
     final Exception exception =
         assertThrows(
@@ -116,8 +115,8 @@ public class FirmwareFileTest {
   void acceptIdentificationNumberThatDoesNotMatchLessRegularPattern() {
     final FirmwareFile firmwareFile1 = this.createPartialWildcardFirmwareFile("FFFF0116");
 
-    final String fittingMbusIdentificationNumber =
-        IdentificationNumber.fromTextualRepresentation("16019864").getTextualRepresentation();
+    final IdentificationNumber fittingMbusIdentificationNumber =
+        IdentificationNumber.fromTextualRepresentation("16019864");
 
     assertDoesNotThrow(
         () -> firmwareFile1.setMbusDeviceIdentificationNumber(fittingMbusIdentificationNumber));
@@ -130,9 +129,8 @@ public class FirmwareFileTest {
 
     final String identificationNumber = "16019864";
 
-    final String misfittingMbusIdentificationNumber =
-        IdentificationNumber.fromTextualRepresentation(identificationNumber)
-            .getTextualRepresentation();
+    final IdentificationNumber misfittingMbusIdentificationNumber =
+        IdentificationNumber.fromTextualRepresentation(identificationNumber);
 
     final Exception exception =
         assertThrows(
@@ -160,11 +158,12 @@ public class FirmwareFileTest {
   @Test
   public void testMbusDeviceIdentificationNumber() throws IOException, ProtocolAdapterException {
     final String id = "10000540";
-    final String mbusDeviceIdentificationNumberInput = id;
+    final IdentificationNumber mbusDeviceIdentificationNumberInput =
+        IdentificationNumber.fromTextualRepresentation(id);
     final byte[] mbusDeviceIdentificationNumberByteArrayOutput =
         ByteBuffer.allocate(4)
             .order(ByteOrder.LITTLE_ENDIAN)
-            .putInt(Integer.parseInt(String.valueOf(mbusDeviceIdentificationNumberInput), 16))
+            .putInt(mbusDeviceIdentificationNumberInput.getIntRepresentation())
             .array();
 
     final FirmwareFile firmwareFile = new FirmwareFile(byteArray);
@@ -182,7 +181,7 @@ public class FirmwareFileTest {
   public void testImageIdentifierForMbusDevice() throws ProtocolAdapterException {
     final FirmwareFile firmwareFile = new FirmwareFile(byteArray);
     firmwareFile.setMbusDeviceIdentificationNumber(
-        IdentificationNumber.fromTextualRepresentation("16019864").getTextualRepresentation());
+        IdentificationNumber.fromTextualRepresentation("16019864"));
 
     assertThat(firmwareFile.createImageIdentifierForMbusDevice())
         .isEqualTo(

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/mbus/IdentificationNumberTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/mbus/IdentificationNumberTest.java
@@ -8,12 +8,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import org.junit.jupiter.api.Test;
+import org.opensmartgridplatform.adapter.protocol.dlms.exceptions.ProtocolAdapterException;
 
 class IdentificationNumberTest {
 
   private final String IDENTIFICATION_NUMBER_AS_STRING = "12049260";
   private final Long IDENTIFICATION_NUMBER_AS_NUMBER = 12049260L;
   private final Long IDENTIFICATION_NUMBER_IN_BCD_AS_LONG = 302289504L;
+
+  private final String IDENTIFICATION_NUMBER_AS_STRING_LARGE = "99999999";
+  private final int IDENTIFICATION_NUMBER_AS_INT = -1717986919;
+  private final Long IDENTIFICATION_NUMBER_AS_LONG = 99999999L;
 
   @Test
   void testFromBcdRepresentation() {
@@ -33,6 +38,18 @@ class IdentificationNumberTest {
 
     assertThat(identificationNumber.getIdentificationNumberInBcdRepresentationAsLong())
         .isEqualTo(this.IDENTIFICATION_NUMBER_IN_BCD_AS_LONG);
+  }
+
+  @Test
+  void testFromTextualRepresentationIntOverflow() throws ProtocolAdapterException {
+
+    final IdentificationNumber identificationNumber =
+        IdentificationNumber.fromTextualRepresentation(this.IDENTIFICATION_NUMBER_AS_STRING_LARGE);
+
+    assertThat(identificationNumber.getIntRepresentation())
+        .isEqualTo(this.IDENTIFICATION_NUMBER_AS_INT);
+    assertThat(identificationNumber.getLongRepresentation())
+        .isEqualTo(this.IDENTIFICATION_NUMBER_AS_LONG);
   }
 
   @Test

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/mbus/IdentificationNumberTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/mbus/IdentificationNumberTest.java
@@ -16,9 +16,8 @@ class IdentificationNumberTest {
   private final Long IDENTIFICATION_NUMBER_AS_NUMBER = 12049260L;
   private final Long IDENTIFICATION_NUMBER_IN_BCD_AS_LONG = 302289504L;
 
-  private final String IDENTIFICATION_NUMBER_AS_STRING_LARGE = "99999999";
-  private final int IDENTIFICATION_NUMBER_AS_INT = -1717986919;
-  private final Long IDENTIFICATION_NUMBER_AS_LONG = 99999999L;
+  private final String IDENTIFICATION_NUMBER_AS_STRING_LARGE = "90000023";
+  private final int IDENTIFICATION_NUMBER_AS_INT = -1879048157;
 
   @Test
   void testFromBcdRepresentation() {
@@ -31,13 +30,23 @@ class IdentificationNumberTest {
   }
 
   @Test
-  void testFromTextualRepresentation() {
+  void testFromTextualRepresentation() throws ProtocolAdapterException {
 
     final IdentificationNumber identificationNumber =
         IdentificationNumber.fromTextualRepresentation(this.IDENTIFICATION_NUMBER_AS_STRING);
 
     assertThat(identificationNumber.getIdentificationNumberInBcdRepresentationAsLong())
         .isEqualTo(this.IDENTIFICATION_NUMBER_IN_BCD_AS_LONG);
+  }
+
+  @Test
+  void testIntRepresentation() throws ProtocolAdapterException {
+
+    final IdentificationNumber identificationNumber =
+        IdentificationNumber.fromTextualRepresentation(this.IDENTIFICATION_NUMBER_AS_STRING);
+
+    assertThat(identificationNumber.getIntRepresentation())
+        .isEqualTo(Integer.parseInt(identificationNumber.getTextualRepresentation(), 16));
   }
 
   @Test
@@ -48,8 +57,6 @@ class IdentificationNumberTest {
 
     assertThat(identificationNumber.getIntRepresentation())
         .isEqualTo(this.IDENTIFICATION_NUMBER_AS_INT);
-    assertThat(identificationNumber.getLongRepresentation())
-        .isEqualTo(this.IDENTIFICATION_NUMBER_AS_LONG);
   }
 
   @Test

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/mbus/IdentificationNumberTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/mbus/IdentificationNumberTest.java
@@ -8,7 +8,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import org.junit.jupiter.api.Test;
-import org.opensmartgridplatform.adapter.protocol.dlms.exceptions.ProtocolAdapterException;
 
 class IdentificationNumberTest {
 
@@ -30,7 +29,7 @@ class IdentificationNumberTest {
   }
 
   @Test
-  void testFromTextualRepresentation() throws ProtocolAdapterException {
+  void testFromTextualRepresentation() {
 
     final IdentificationNumber identificationNumber =
         IdentificationNumber.fromTextualRepresentation(this.IDENTIFICATION_NUMBER_AS_STRING);
@@ -40,7 +39,7 @@ class IdentificationNumberTest {
   }
 
   @Test
-  void testIntRepresentation() throws ProtocolAdapterException {
+  void testIntRepresentation() {
 
     final IdentificationNumber identificationNumber =
         IdentificationNumber.fromTextualRepresentation(this.IDENTIFICATION_NUMBER_AS_STRING);
@@ -50,7 +49,7 @@ class IdentificationNumberTest {
   }
 
   @Test
-  void testFromTextualRepresentationIntOverflow() throws ProtocolAdapterException {
+  void testFromTextualRepresentationIntOverflow() {
 
     final IdentificationNumber identificationNumber =
         IdentificationNumber.fromTextualRepresentation(this.IDENTIFICATION_NUMBER_AS_STRING_LARGE);


### PR DESCRIPTION
Conversion from textual representation of (Mbus)IdentificationNumber to numerical representation fails for numbers outside the integer range. Therefor text representation must be converted to long first. The four most significant bytes should be empty (zero) and can be ignored. The four least significant bytes are then used to make an integer representation.