### PR TITLE
feature/SMHE-2024-05-28-sonar-issues

### DIFF
--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/PushNotificationAlarm.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/PushNotificationAlarm.java
@@ -59,7 +59,7 @@ public class PushNotificationAlarm {
       default:
         throw new IllegalArgumentException(
             String.format(
-                "'New M-Bus device discovered channel {}' is not an valid alarm", channel));
+                "'New M-Bus device discovered channel %d' is not an valid alarm", channel));
     }
   }
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/support/ws/smartmetering/SmartMeteringBaseClient.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/support/ws/smartmetering/SmartMeteringBaseClient.java
@@ -91,7 +91,7 @@ public abstract class SmartMeteringBaseClient extends BaseClient {
         this.notificationService.getNotification(nextWait, TimeUnit.MILLISECONDS);
 
     if (notification == null) {
-      LOGGER.info("Did not receive a notification within " + nextWait + " milliseconds");
+      LOGGER.info("Did not receive a notification within {} milliseconds.", nextWait);
     }
     return notification;
   }


### PR DESCRIPTION
Solves below sonar issue in smartmetering part

String contains no format specifiers.
Format strings should be used correctly [java:S3457](https://sonarcloud.io/organizations/gxf/rules?open=java%3AS3457&rule_key=java%3AS3457)