### PR TITLE
feature/SMHE-2011-nightly-build-fix

### DIFF
--- a/osgp/platform/osgp-adapter-ws-core/src/main/java/org/opensmartgridplatform/adapter/ws/core/application/config/ApplicationContext.java
+++ b/osgp/platform/osgp-adapter-ws-core/src/main/java/org/opensmartgridplatform/adapter/ws/core/application/config/ApplicationContext.java
@@ -61,6 +61,8 @@ public class ApplicationContext extends AbstractConfig {
   private static final String PROPERTY_NAME_FIRMWARE_PATH = "firmware.path";
   private static final String PROPERTY_NAME_FIRMWARE_DIRECTORY = "firmware.directory";
   private static final String PROPERTY_NAME_FIRMWARE_FILESTORAGE = "firmware.filestorage";
+  private static final String PROPERTY_NAME_FIRMWARE_FILESTORAGE_DIRECTORY =
+      "firmware.filestorage.directory";
   private static final String PROPERTY_NAME_FIRMWARE_IMAGEID_EXTENSION =
       "firmware.imageid.extension";
   private static final String PROPERTY_NAME_PAGING_MAXIMUM_PAGE_SIZE = "paging.maximum.pagesize";
@@ -127,6 +129,11 @@ public class ApplicationContext extends AbstractConfig {
   public boolean firmwareFileStorage() {
     return Boolean.parseBoolean(
         this.environment.getRequiredProperty(PROPERTY_NAME_FIRMWARE_FILESTORAGE));
+  }
+
+  @Bean
+  public String firmwareFileStorageDirectory() {
+    return this.environment.getRequiredProperty(PROPERTY_NAME_FIRMWARE_FILESTORAGE_DIRECTORY);
   }
 
   @Bean

--- a/osgp/platform/osgp-adapter-ws-core/src/main/java/org/opensmartgridplatform/adapter/ws/core/application/services/FirmwareFileStorageService.java
+++ b/osgp/platform/osgp-adapter-ws-core/src/main/java/org/opensmartgridplatform/adapter/ws/core/application/services/FirmwareFileStorageService.java
@@ -24,10 +24,17 @@ public class FirmwareFileStorageService {
   private final String firmwareImageIdExtension;
 
   public FirmwareFileStorageService(
-      final String firmwareDirectory, final String firmwareImageIdExtension) throws IOException {
+      final String firmwareDirectory, final String firmwareImageIdExtension)
+      throws IOException, TechnicalException {
     this.firmwareDirectory = Paths.get(firmwareDirectory);
     this.firmwareImageIdExtension = firmwareImageIdExtension;
-    Files.createDirectories(this.firmwareDirectory);
+    if (!Files.exists(this.firmwareDirectory)) {
+      throw new TechnicalException(
+          ComponentType.WS_CORE,
+          String.format(
+              "Error initializing FirmwareFileStorageService. Storage location '%s' does not exist.",
+              firmwareDirectory));
+    }
   }
 
   /**

--- a/osgp/platform/osgp-adapter-ws-core/src/main/java/org/opensmartgridplatform/adapter/ws/core/application/services/FirmwareFileStorageService.java
+++ b/osgp/platform/osgp-adapter-ws-core/src/main/java/org/opensmartgridplatform/adapter/ws/core/application/services/FirmwareFileStorageService.java
@@ -25,7 +25,7 @@ public class FirmwareFileStorageService {
 
   public FirmwareFileStorageService(
       final String firmwareDirectory, final String firmwareImageIdExtension)
-      throws IOException, TechnicalException {
+      throws TechnicalException {
     this.firmwareDirectory = Paths.get(firmwareDirectory);
     this.firmwareImageIdExtension = firmwareImageIdExtension;
     if (!Files.exists(this.firmwareDirectory)) {

--- a/osgp/platform/osgp-adapter-ws-core/src/main/java/org/opensmartgridplatform/adapter/ws/core/application/services/FirmwareFileStorageService.java
+++ b/osgp/platform/osgp-adapter-ws-core/src/main/java/org/opensmartgridplatform/adapter/ws/core/application/services/FirmwareFileStorageService.java
@@ -24,17 +24,10 @@ public class FirmwareFileStorageService {
   private final String firmwareImageIdExtension;
 
   public FirmwareFileStorageService(
-      final String firmwareDirectory, final String firmwareImageIdExtension)
+      final String firmwareFileStorageDirectory, final String firmwareImageIdExtension)
       throws TechnicalException {
-    this.firmwareDirectory = Paths.get(firmwareDirectory);
+    this.firmwareDirectory = Paths.get(firmwareFileStorageDirectory);
     this.firmwareImageIdExtension = firmwareImageIdExtension;
-    if (!Files.exists(this.firmwareDirectory)) {
-      throw new TechnicalException(
-          ComponentType.WS_CORE,
-          String.format(
-              "Error initializing FirmwareFileStorageService. Storage location '%s' does not exist.",
-              firmwareDirectory));
-    }
   }
 
   /**
@@ -50,6 +43,7 @@ public class FirmwareFileStorageService {
   public void storeFirmwareFile(final byte[] firmwareFile, final String firmwareIdentification)
       throws TechnicalException {
 
+    this.checkStorageDirectory();
     if (firmwareFile == null || firmwareFile.length == 0) {
       log.info(
           "Firmware file with identifier '{}' is null or empty. File is not stored",
@@ -78,6 +72,7 @@ public class FirmwareFileStorageService {
   public void storeImageIdentifier(
       final byte[] imageIdentifier, final String firmwareIdentification) throws TechnicalException {
 
+    this.checkStorageDirectory();
     if (imageIdentifier == null || imageIdentifier.length == 0) {
       log.info(
           "Image identifier with identifier '{}' is null or empty. Image identifier is not stored",
@@ -126,6 +121,16 @@ public class FirmwareFileStorageService {
     }
 
     return digest;
+  }
+
+  private void checkStorageDirectory() throws TechnicalException {
+    if (!Files.exists(this.firmwareDirectory)) {
+      throw new TechnicalException(
+          ComponentType.WS_CORE,
+          String.format(
+              "%s cannot be used. Configured firmware.filestorage.directory '%s' does not exist.",
+              this.getClass().getSimpleName(), this.firmwareDirectory));
+    }
   }
 
   private boolean isExistingFirmwareFile(final String firmwareIdentification) {

--- a/osgp/platform/osgp-adapter-ws-core/src/main/java/org/opensmartgridplatform/adapter/ws/core/application/services/FirmwareFileStorageService.java
+++ b/osgp/platform/osgp-adapter-ws-core/src/main/java/org/opensmartgridplatform/adapter/ws/core/application/services/FirmwareFileStorageService.java
@@ -24,8 +24,7 @@ public class FirmwareFileStorageService {
   private final String firmwareImageIdExtension;
 
   public FirmwareFileStorageService(
-      final String firmwareFileStorageDirectory, final String firmwareImageIdExtension)
-      throws TechnicalException {
+      final String firmwareFileStorageDirectory, final String firmwareImageIdExtension) {
     this.firmwareDirectory = Paths.get(firmwareFileStorageDirectory);
     this.firmwareImageIdExtension = firmwareImageIdExtension;
   }

--- a/osgp/platform/osgp-adapter-ws-core/src/main/resources/osgp-adapter-ws-core.properties
+++ b/osgp/platform/osgp-adapter-ws-core/src/main/resources/osgp-adapter-ws-core.properties
@@ -63,11 +63,12 @@ web.service.notification.organisation=OSGP
 web.service.notification.supported.tls.protocols=TLSv1.2,TLSv1.3
 #Firmware Management
 firmware.domain=127.0.0.1
-firmware.directory=/etc/osp/firmwarefiles
+firmware.directory=/var/www/html/firmware/
 firmware.path=firmware
 # Filestorage: indicates if firmware files are stored on disk (filestorage = true)
 # or in the database (filestorage = false).
 firmware.filestorage=true
+firmware.filestorage.directory=/etc/osp/firmwarefiles
 firmware.imageid.extension=imgid
 # =========================================================
 # MESSAGING CONFIG

--- a/osgp/platform/osgp-adapter-ws-core/src/main/resources/osgp-adapter-ws-core.properties
+++ b/osgp/platform/osgp-adapter-ws-core/src/main/resources/osgp-adapter-ws-core.properties
@@ -66,6 +66,7 @@ firmware.domain=127.0.0.1
 firmware.directory=/var/www/html/firmware/
 firmware.path=firmware
 # Filestorage: indicates if firmware files are stored on disk (filestorage = true)
+# in configured directory (firmware.filestorage.directory)
 # or in the database (filestorage = false).
 firmware.filestorage=true
 firmware.filestorage.directory=/etc/osp/firmwarefiles

--- a/osgp/platform/osgp-adapter-ws-core/src/test/java/org/opensmartgridplatform/adapter/ws/core/application/services/FirmwareFileStorageServiceTest.java
+++ b/osgp/platform/osgp-adapter-ws-core/src/test/java/org/opensmartgridplatform/adapter/ws/core/application/services/FirmwareFileStorageServiceTest.java
@@ -68,10 +68,8 @@ class FirmwareFileStorageServiceTest {
     assertThatThrownBy(() -> malconfiguredService.storeFirmwareFile(FIRMWARE_FILE, identification))
         .isInstanceOf(TechnicalException.class)
         .hasMessageContainingAll(
-            String.format(
-                "FirmwareFileStorageService cannot be used. Configured firmware.filestorage.directory",
-                "does not exist.",
-                nonexistingDirectory));
+            "FirmwareFileStorageService cannot be used. Configured firmware.filestorage.directory",
+            "does not exist.");
   }
 
   @Test

--- a/osgp/platform/osgp-adapter-ws-core/src/test/java/org/opensmartgridplatform/adapter/ws/core/application/services/FirmwareFileStorageServiceTest.java
+++ b/osgp/platform/osgp-adapter-ws-core/src/test/java/org/opensmartgridplatform/adapter/ws/core/application/services/FirmwareFileStorageServiceTest.java
@@ -31,7 +31,7 @@ class FirmwareFileStorageServiceTest {
   private FirmwareFileStorageService service;
 
   @BeforeEach
-  void setup() throws IOException, TechnicalException {
+  void setup() throws IOException {
     Files.createDirectories(FIRMWARE_DIRECTORY);
 
     this.service =
@@ -49,7 +49,7 @@ class FirmwareFileStorageServiceTest {
   }
 
   @Test
-  void storeFirmwareFileWhenNull() throws TechnicalException, IOException {
+  void storeFirmwareFileWhenNull() throws TechnicalException {
     final String identification = "myFirmware";
 
     this.service.storeFirmwareFile(null, identification);
@@ -58,7 +58,7 @@ class FirmwareFileStorageServiceTest {
   }
 
   @Test
-  void storeFirmwareFileWhenStorageMalConfigured() throws TechnicalException, IOException {
+  void storeFirmwareFileWhenStorageMalConfigured() {
     final String identification = "myFirmware";
 
     final String nonexistingDirectory = "target/nonexisting";
@@ -75,7 +75,7 @@ class FirmwareFileStorageServiceTest {
   }
 
   @Test
-  void storeFirmwareFileWhenEmpty() throws TechnicalException, IOException {
+  void storeFirmwareFileWhenEmpty() throws TechnicalException {
     final String identification = "myFirmware";
 
     this.service.storeFirmwareFile(new byte[0], identification);

--- a/osgp/platform/osgp-adapter-ws-core/src/test/java/org/opensmartgridplatform/adapter/ws/core/application/services/FirmwareFileStorageServiceTest.java
+++ b/osgp/platform/osgp-adapter-ws-core/src/test/java/org/opensmartgridplatform/adapter/ws/core/application/services/FirmwareFileStorageServiceTest.java
@@ -31,7 +31,7 @@ class FirmwareFileStorageServiceTest {
   private FirmwareFileStorageService service;
 
   @BeforeEach
-  void setup() throws IOException {
+  void setup() throws IOException, TechnicalException {
     Files.createDirectories(FIRMWARE_DIRECTORY);
 
     this.service =

--- a/osgp/platform/osgp-adapter-ws-core/src/test/java/org/opensmartgridplatform/adapter/ws/core/application/services/FirmwareFileStorageServiceTest.java
+++ b/osgp/platform/osgp-adapter-ws-core/src/test/java/org/opensmartgridplatform/adapter/ws/core/application/services/FirmwareFileStorageServiceTest.java
@@ -58,6 +58,23 @@ class FirmwareFileStorageServiceTest {
   }
 
   @Test
+  void storeFirmwareFileWhenStorageMalConfigured() throws TechnicalException, IOException {
+    final String identification = "myFirmware";
+
+    final String nonexistingDirectory = "target/nonexisting";
+    final FirmwareFileStorageService malconfiguredService =
+        new FirmwareFileStorageService(nonexistingDirectory, IMAGE_ID_EXTENSION);
+
+    assertThatThrownBy(() -> malconfiguredService.storeFirmwareFile(FIRMWARE_FILE, identification))
+        .isInstanceOf(TechnicalException.class)
+        .hasMessageContainingAll(
+            String.format(
+                "FirmwareFileStorageService cannot be used. Configured firmware.filestorage.directory",
+                "does not exist.",
+                nonexistingDirectory));
+  }
+
+  @Test
   void storeFirmwareFileWhenEmpty() throws TechnicalException, IOException {
     final String identification = "myFirmware";
 


### PR DESCRIPTION
Creating firmwarefiles directory on startup of FirmwareFileStorageService will potentially clean out existing directory.