### PR TITLE
OPS: Suppress supposed Sonar issue

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,8 @@
+# Globally exclude some false Sonar warnings
+# Source: https://www.baeldung.com/sonar-exclude-violations#using-sonar-projectproperties
+
+sonar.issue.ignore.multicriteria=gxf
+
+# Rule: Correct this malformed property placeholder.
+# Target: @PropertySource(value = "file:${osgp/Global/config}")
+sonar.issue.ignore.multicriteria.gxf.ruleKey=java:S6857


### PR DESCRIPTION
The warning is false; this notation is valid in Spring and has been working for years. It's a indirect JNDI lookup