### PR TITLE
feature/object-config-mbus-command-executors

### DIFF
--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/AcceptanceTests.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/AcceptanceTests.java
@@ -16,7 +16,7 @@ import org.junit.runner.RunWith;
       "classpath:features/osgp-adapter-ws-core",
       "classpath:features/osgp-adapter-ws-smartmetering"
     },
-    tags = {"not @Skip", "@MBusDevice"},
+    tags = {"not @Skip", "not @NightlyBuildOnly"},
     glue = {
       "classpath:org.opensmartgridplatform.cucumber.platform.glue",
       "classpath:org.opensmartgridplatform.cucumber.platform.common.glue",

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/AcceptanceTests.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/AcceptanceTests.java
@@ -16,7 +16,7 @@ import org.junit.runner.RunWith;
       "classpath:features/osgp-adapter-ws-core",
       "classpath:features/osgp-adapter-ws-smartmetering"
     },
-    tags = {"not @Skip", "not @NightlyBuildOnly"},
+    tags = {"not @Skip", "@MBusDevice"},
     glue = {
       "classpath:org.opensmartgridplatform.cucumber.platform.glue",
       "classpath:org.opensmartgridplatform.cucumber.platform.common.glue",

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/ad-hoc/ScanMbusChannels.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/ad-hoc/ScanMbusChannels.feature
@@ -23,25 +23,25 @@ Feature: SmartMetering Scan M-Bus Channels
       | MbusManufacturerIdentification | LGB               |
       | MbusVersion                    |                66 |
       | MbusDeviceTypeIdentification   |                 3 |
-    And device simulation of "<deviceIdentification>" with M-Bus client version 0 values for channel 1
+    And device simulation of "<deviceIdentification>" with M-Bus client version <mbusversion> values for channel 1
       | MbusPrimaryAddress             | 9        |
-      | MbusIdentificationNumber       | <mbusid> |
+      | MbusIdentificationNumber       | 12056731 |
       | MbusManufacturerIdentification | LGB      |
       | MbusVersion                    | 66       |
       | MbusDeviceTypeIdentification   | 3        |
-    And device simulation of "<deviceIdentification>" with M-Bus client version 0 values for channel 2
+    And device simulation of "<deviceIdentification>" with M-Bus client version <mbusversion> values for channel 2
       | MbusPrimaryAddress             | 0 |
       | MbusIdentificationNumber       | 0 |
       | MbusManufacturerIdentification | 0 |
       | MbusVersion                    | 0 |
       | MbusDeviceTypeIdentification   | 0 |
-    And device simulation of "<deviceIdentification>" with M-Bus client version 0 values for channel 3
+    And device simulation of "<deviceIdentification>" with M-Bus client version <mbusversion> values for channel 3
       | MbusPrimaryAddress             | 0 |
       | MbusIdentificationNumber       | 0 |
       | MbusManufacturerIdentification | 0 |
       | MbusVersion                    | 0 |
       | MbusDeviceTypeIdentification   | 0 |
-    And device simulation of "<deviceIdentification>" with M-Bus client version 0 values for channel 4
+    And device simulation of "<deviceIdentification>" with M-Bus client version <mbusversion> values for channel 4
       | MbusPrimaryAddress             | 0 |
       | MbusIdentificationNumber       | 0 |
       | MbusManufacturerIdentification | 0 |
@@ -50,37 +50,37 @@ Feature: SmartMetering Scan M-Bus Channels
     When the scan M-Bus channels request is received
       | DeviceIdentification | <deviceIdentification> |
     Then the found M-bus devices are in the response
-      | Result                                 | OK                |
+      | Result                                 | OK                     |
       | DeviceIdentification                   | <deviceIdentification> |
-      | Channel1MbusIdentificationNumber       |   <mbusid_in_response> |
-      | Channel1MbusManufacturerIdentification | LGB               |
-      | Channel1MbusVersion                    |                66 |
-      | Channel1MbusDeviceTypeIdentification   |                 3 |
-      | Channel2MbusIdentificationNumber       |          00000000 |
-      | Channel2MbusManufacturerIdentification |                   |
-      | Channel2MbusVersion                    |                 0 |
-      | Channel2MbusDeviceTypeIdentification   |                 0 |
-      | Channel3MbusIdentificationNumber       |          00000000 |
-      | Channel3MbusManufacturerIdentification |                   |
-      | Channel3MbusVersion                    |                 0 |
-      | Channel3MbusDeviceTypeIdentification   |                 0 |
-      | Channel4MbusIdentificationNumber       |          00000000 |
-      | Channel4MbusManufacturerIdentification |                   |
-      | Channel4MbusVersion                    |                 0 |
-      | Channel4MbusDeviceTypeIdentification   |                 0 |
+      | Channel1MbusIdentificationNumber       |               12056731 |
+      | Channel1MbusManufacturerIdentification | LGB                    |
+      | Channel1MbusVersion                    |                     66 |
+      | Channel1MbusDeviceTypeIdentification   |                      3 |
+      | Channel2MbusIdentificationNumber       |               00000000 |
+      | Channel2MbusManufacturerIdentification |                        |
+      | Channel2MbusVersion                    |                      0 |
+      | Channel2MbusDeviceTypeIdentification   |                      0 |
+      | Channel3MbusIdentificationNumber       |               00000000 |
+      | Channel3MbusManufacturerIdentification |                        |
+      | Channel3MbusVersion                    |                      0 |
+      | Channel3MbusDeviceTypeIdentification   |                      0 |
+      | Channel4MbusIdentificationNumber       |               00000000 |
+      | Channel4MbusManufacturerIdentification |                        |
+      | Channel4MbusVersion                    |                      0 |
+      | Channel4MbusDeviceTypeIdentification   |                      0 |
 
   Examples:
-      | deviceIdentification | protocol | version | mbusid   | mbusid_in_response |
-      | TEST1024000000001    | DSMR     | 4.2.2   | 12056731 |           12056731 |
+      | deviceIdentification | protocol | version | mbusversion |
+      | TEST1024000000001    | DSMR     | 4.2.2   |           0 |
   @NightlyBuildOnly
   Examples:
-      | deviceIdentification | protocol | version | mbusid   | mbusid_in_response |
-      | TEST1024000000001    | DSMR     | 2.2     | 12056731 |           12056731 |
-      | TEST1031000000001    | SMR      | 4.3     | 12056731 |           12056731 |
-      | TEST1027000000001    | SMR      | 5.0.0   |        1 |           00000001 |
-      | TEST1028000000001    | SMR      | 5.1     |        1 |           00000001 |
-      | TEST1029000000001    | SMR      | 5.2     |        1 |           00000001 |
-      | TEST1030000000001    | SMR      | 5.5     |        1 |           00000001 |
+      | deviceIdentification | protocol | version | mbusversion |
+      | TEST1024000000001    | DSMR     | 2.2     |           0 |
+      | TEST1031000000001    | SMR      | 4.3     |           0 |
+      | TEST1027000000001    | SMR      | 5.0.0   |           1 |
+      | TEST1028000000001    | SMR      | 5.1     |           1 |
+      | TEST1029000000001    | SMR      | 5.2     |           1 |
+      | TEST1030000000001    | SMR      | 5.5     |           1 |
 
   Scenario: Scan the four m-bus channels of an SMR5 gateway device
     Given a dlms device

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/ad-hoc/ScanMbusChannels.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/ad-hoc/ScanMbusChannels.feature
@@ -2,55 +2,57 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-@SmartMetering @Platform @SmartMeteringAdHoc
+@SmartMetering @Platform @SmartMeteringAdHoc @MBusDevice
 Feature: SmartMetering Scan M-Bus Channels
   As a grid operator
   I want to be able to scan the M-Bus channels 
   So I can use the outcome in my installation flow
-
-  Scenario: Scan the four m-bus channels of a DSMR4 gateway device
+  
+  Scenario Outline: Scan the four m-bus channels of a <protocol> <version> gateway device
     Given a dlms device
-      | DeviceIdentification | TEST1024000000001 |
-      | DeviceType           | SMART_METER_E     |
+      | DeviceIdentification | <deviceIdentification> |
+      | DeviceType           | SMART_METER_E          |
+      | Protocol             | <protocol>             |
+      | ProtocolVersion      | <version>              |
     And a dlms device
       | DeviceIdentification           | TESTG101205673101 |
       | DeviceType                     | SMART_METER_G     |
-      | GatewayDeviceIdentification    | TEST1024000000001 |
+      | GatewayDeviceIdentification    | <deviceIdentification> |
       | Channel                        |                 1 |
       | MbusIdentificationNumber       |          12056731 |
       | MbusManufacturerIdentification | LGB               |
       | MbusVersion                    |                66 |
       | MbusDeviceTypeIdentification   |                 3 |
-    And device simulation of "TEST1024000000001" with M-Bus client version 0 values for channel 1
+    And device simulation of "<deviceIdentification>" with M-Bus client version 0 values for channel 1
       | MbusPrimaryAddress             | 9        |
-      | MbusIdentificationNumber       | 12056731 |
+      | MbusIdentificationNumber       | <mbusid> |
       | MbusManufacturerIdentification | LGB      |
       | MbusVersion                    | 66       |
       | MbusDeviceTypeIdentification   | 3        |
-    And device simulation of "TEST1024000000001" with M-Bus client version 0 values for channel 2
+    And device simulation of "<deviceIdentification>" with M-Bus client version 0 values for channel 2
       | MbusPrimaryAddress             | 0 |
       | MbusIdentificationNumber       | 0 |
       | MbusManufacturerIdentification | 0 |
       | MbusVersion                    | 0 |
       | MbusDeviceTypeIdentification   | 0 |
-    And device simulation of "TEST1024000000001" with M-Bus client version 0 values for channel 3
+    And device simulation of "<deviceIdentification>" with M-Bus client version 0 values for channel 3
       | MbusPrimaryAddress             | 0 |
       | MbusIdentificationNumber       | 0 |
       | MbusManufacturerIdentification | 0 |
       | MbusVersion                    | 0 |
       | MbusDeviceTypeIdentification   | 0 |
-    And device simulation of "TEST1024000000001" with M-Bus client version 0 values for channel 4
+    And device simulation of "<deviceIdentification>" with M-Bus client version 0 values for channel 4
       | MbusPrimaryAddress             | 0 |
       | MbusIdentificationNumber       | 0 |
       | MbusManufacturerIdentification | 0 |
       | MbusVersion                    | 0 |
       | MbusDeviceTypeIdentification   | 0 |
     When the scan M-Bus channels request is received
-      | DeviceIdentification | TEST1024000000001 |
+      | DeviceIdentification | <deviceIdentification> |
     Then the found M-bus devices are in the response
       | Result                                 | OK                |
-      | DeviceIdentification                   | TEST1024000000001 |
-      | Channel1MbusIdentificationNumber       |          12056731 |
+      | DeviceIdentification                   | <deviceIdentification> |
+      | Channel1MbusIdentificationNumber       |   <mbusid_in_response> |
       | Channel1MbusManufacturerIdentification | LGB               |
       | Channel1MbusVersion                    |                66 |
       | Channel1MbusDeviceTypeIdentification   |                 3 |
@@ -66,6 +68,19 @@ Feature: SmartMetering Scan M-Bus Channels
       | Channel4MbusManufacturerIdentification |                   |
       | Channel4MbusVersion                    |                 0 |
       | Channel4MbusDeviceTypeIdentification   |                 0 |
+
+  Examples:
+      | deviceIdentification | protocol | version | mbusid   | mbusid_in_response |
+      | TEST1024000000001    | DSMR     | 4.2.2   | 12056731 |           12056731 |
+  @NightlyBuildOnly
+  Examples:
+      | deviceIdentification | protocol | version | mbusid   | mbusid_in_response |
+      | TEST1024000000001    | DSMR     | 2.2     | 12056731 |           12056731 |
+      | TEST1031000000001    | SMR      | 4.3     | 12056731 |           12056731 |
+      | TEST1027000000001    | SMR      | 5.0.0   |        1 |           00000001 |
+      | TEST1028000000001    | SMR      | 5.1     |        1 |           00000001 |
+      | TEST1029000000001    | SMR      | 5.2     |        1 |           00000001 |
+      | TEST1030000000001    | SMR      | 5.5     |        1 |           00000001 |
 
   Scenario: Scan the four m-bus channels of an SMR5 gateway device
     Given a dlms device

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/bundle/BundledClearMBusStatusOnAllChannels.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/bundle/BundledClearMBusStatusOnAllChannels.feature
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-@SmartMetering @Platform
+@SmartMetering @Platform @MBusDevice
 Feature: SmartMetering Bundle - Clear M-Bus alarm status on all channels of a E meter
   As a grid operator
   I want to be able to clear the M-Bus alarm status on all channels of a E meter
@@ -22,6 +22,9 @@ Feature: SmartMetering Bundle - Clear M-Bus alarm status on all channels of a E 
     Examples:
       | deviceIdentification  | protocol | version |
       | TEST1028000000001     | SMR      | 5.1     |
+    @NightlyBuildOnly
+    Examples:
+      | deviceIdentification  | protocol | version |
       | TEST1029000000001     | SMR      | 5.2     |
       | TEST1030000000001     | SMR      | 5.5     |
 
@@ -40,7 +43,10 @@ Feature: SmartMetering Bundle - Clear M-Bus alarm status on all channels of a E 
 
     Examples:
       | deviceIdentification  | protocol | version | message |
-      | TEST1024000000001     | DSMR     | 2.2     | Did not find READ_MBUS_STATUS object for device 24000000001 for channel 1 |
       | TEST1024000000001     | DSMR     | 4.2.2   | Did not find READ_MBUS_STATUS object for device 24000000001 for channel 1 |
+    @NightlyBuildOnly
+    Examples:
+      | deviceIdentification  | protocol | version | message |
+      | TEST1024000000001     | DSMR     | 2.2     | Did not find READ_MBUS_STATUS object for device 24000000001 for channel 1 |
       | TEST1031000000001     | SMR      | 4.3     | Did not find READ_MBUS_STATUS object for device 31000000001 for channel 1 |
       | TEST1027000000001     | SMR      | 5.0.0   | Did not find CLEAR_MBUS_STATUS object for device 27000000001 for channel 1 |

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/bundle/BundledDecoupleMBusDeviceByChannel.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/bundle/BundledDecoupleMBusDeviceByChannel.feature
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-@SmartMetering @Platform
+@SmartMetering @Platform @MBusDevice
 Feature: SmartMetering Bundle - Decouple M-Bus Device By Channel
   As a grid operator
   I want to be able to decouple an M-Bus device by channel to a smart meter

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/bundle/BundledGetMbusEncryptionKeyStatus.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/bundle/BundledGetMbusEncryptionKeyStatus.feature
@@ -2,23 +2,36 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-@SmartMetering @Platform
+@SmartMetering @Platform @MBusDevice
 Feature: SmartMetering Bundle - GetMbusEncryptionKeyStatus
   As a grid operator 
   I want to retrieve the encryption key status for an M-Bus device from a meter via a bundle request
 
-  Scenario: Get encryption key status for an M-Bus device in a bundle request
+  Scenario Outline: Get encryption key status for an M-Bus device in a bundle request (<protocol> <version>)
     Given a dlms device
-      | DeviceIdentification | TEST1024000000001 |
-      | DeviceType           | SMART_METER_E     |
+      | DeviceIdentification | <deviceIdentification> |
+      | DeviceType           | SMART_METER_E          |
+      | Protocol             | <protocol>             |
+      | ProtocolVersion      | <version>              |
     And a dlms device
       | DeviceIdentification        | TESTG102400000001 |
       | DeviceType                  | SMART_METER_G     |
-      | GatewayDeviceIdentification | TEST1024000000001 |
+      | GatewayDeviceIdentification | <deviceIdentification> |
       | Channel                     |                 1 |
     And a bundle request
-      | DeviceIdentification | TEST1024000000001 |
+      | DeviceIdentification | <deviceIdentification> |
     And the bundle request contains a get M-Bus encryption key status action with parameters
       | MBusDeviceIdentification | TESTG102400000001      |
     When the bundle request is received
     Then the bundle response should contain a get M-Bus encryption key status response
+
+  Examples:
+      | deviceIdentification | protocol | version |
+      | TEST1024000000001    | DSMR     | 4.2.2   |
+  @NightlyBuildOnly
+  Examples:
+      | deviceIdentification | protocol | version |
+      | TEST1027000000001    | SMR      | 5.0.0   |
+      | TEST1028000000001    | SMR      | 5.1     |
+      | TEST1029000000001    | SMR      | 5.2     |
+      | TEST1030000000001    | SMR      | 5.5     |

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/bundle/BundledGetMbusEncryptionKeyStatus.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/bundle/BundledGetMbusEncryptionKeyStatus.feature
@@ -14,10 +14,10 @@ Feature: SmartMetering Bundle - GetMbusEncryptionKeyStatus
       | Protocol             | <protocol>             |
       | ProtocolVersion      | <version>              |
     And a dlms device
-      | DeviceIdentification        | TESTG102400000001 |
-      | DeviceType                  | SMART_METER_G     |
+      | DeviceIdentification        | TESTG102400000001      |
+      | DeviceType                  | SMART_METER_G          |
       | GatewayDeviceIdentification | <deviceIdentification> |
-      | Channel                     |                 1 |
+      | Channel                     |                      1 |
     And a bundle request
       | DeviceIdentification | <deviceIdentification> |
     And the bundle request contains a get M-Bus encryption key status action with parameters

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/bundle/BundledScanMbusChannels.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/bundle/BundledScanMbusChannels.feature
@@ -2,55 +2,57 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-@SmartMetering @Platform
+@SmartMetering @Platform @MBusDevice
 Feature: SmartMetering Bundle - ScanMbusChannels
   As a grid operator 
   I want to be able to scan the M-Bus channels via a bundle request
 
-  Scenario: Bundled Scan M-Bus Channels Action
+ Scenario Outline: Bundled Scan M-Bus Channels Action (<protocol> <version>)
     Given a dlms device
-      | DeviceIdentification | TEST1024000000001 |
-      | DeviceType           | SMART_METER_E     |
+      | DeviceIdentification | <deviceIdentification> |
+      | DeviceType           | SMART_METER_E          |
+      | Protocol             | <protocol>             |
+      | ProtocolVersion      | <version>              |
     And a dlms device
       | DeviceIdentification           | TESTG101205673101 |
       | DeviceType                     | SMART_METER_G     |
-      | GatewayDeviceIdentification    | TEST1024000000001 |
+      | GatewayDeviceIdentification    | <deviceIdentification> |
       | Channel                        |                 1 |
       | MbusIdentificationNumber       |          12056731 |
       | MbusManufacturerIdentification | LGB               |
       | MbusVersion                    |                66 |
       | MbusDeviceTypeIdentification   |                 3 |
-    And device simulation of "TEST1024000000001" with M-Bus client version 0 values for channel 1
+    And device simulation of "<deviceIdentification>" with M-Bus client version 0 values for channel 1
       | MbusPrimaryAddress             | 9        |
-      | MbusIdentificationNumber       | 12056731 |
+      | MbusIdentificationNumber       | <mbusid> |
       | MbusManufacturerIdentification | LGB      |
       | MbusVersion                    | 66       |
       | MbusDeviceTypeIdentification   | 3        |
-    And device simulation of "TEST1024000000001" with M-Bus client version 0 values for channel 2
+    And device simulation of "<deviceIdentification>" with M-Bus client version 0 values for channel 2
       | MbusPrimaryAddress             | 0 |
       | MbusIdentificationNumber       | 0 |
       | MbusManufacturerIdentification | 0 |
       | MbusVersion                    | 0 |
       | MbusDeviceTypeIdentification   | 0 |
-    And device simulation of "TEST1024000000001" with M-Bus client version 0 values for channel 3
+    And device simulation of "<deviceIdentification>" with M-Bus client version 0 values for channel 3
       | MbusPrimaryAddress             | 0 |
       | MbusIdentificationNumber       | 0 |
       | MbusManufacturerIdentification | 0 |
       | MbusVersion                    | 0 |
       | MbusDeviceTypeIdentification   | 0 |
-    And device simulation of "TEST1024000000001" with M-Bus client version 0 values for channel 4
+    And device simulation of "<deviceIdentification>" with M-Bus client version 0 values for channel 4
       | MbusPrimaryAddress             | 0 |
       | MbusIdentificationNumber       | 0 |
       | MbusManufacturerIdentification | 0 |
       | MbusVersion                    | 0 |
       | MbusDeviceTypeIdentification   | 0 |
     And a bundle request
-      | DeviceIdentification | TEST1024000000001 |
+      | DeviceIdentification | <deviceIdentification> |
     And the bundle request contains a scan mbus channels action
     When the bundle request is received
     Then the bundle response should contain a scan mbus channels response with values
-      | DeviceIdentification                   | TEST1024000000001 |
-      | Channel1MbusIdentificationNumber       |          12056731 |
+      | DeviceIdentification                   | <deviceIdentification> |
+      | Channel1MbusIdentificationNumber       |   <mbusid_in_response> |
       | Channel1MbusManufacturerIdentification | LGB               |
       | Channel1MbusVersion                    |                66 |
       | Channel1MbusDeviceTypeIdentification   |                 3 |
@@ -66,3 +68,17 @@ Feature: SmartMetering Bundle - ScanMbusChannels
       | Channel4MbusManufacturerIdentification |                   |
       | Channel4MbusVersion                    |                 0 |
       | Channel4MbusDeviceTypeIdentification   |                 0 |
+
+
+    Examples:
+      | deviceIdentification | protocol | version | mbusid   | mbusid_in_response |
+      | TEST1024000000001    | DSMR     | 4.2.2   | 12056731 |           12056731 |
+    @NightlyBuildOnly
+    Examples:
+      | deviceIdentification | protocol | version | mbusid   | mbusid_in_response |
+      | TEST1024000000001    | DSMR     | 2.2     | 12056731 |           12056731 |
+      | TEST1031000000001    | SMR      | 4.3     | 12056731 |           12056731 |
+      | TEST1027000000001    | SMR      | 5.0.0   |        1 |           00000001 |
+      | TEST1028000000001    | SMR      | 5.1     |        1 |           00000001 |
+      | TEST1029000000001    | SMR      | 5.2     |        1 |           00000001 |
+      | TEST1030000000001    | SMR      | 5.5     |        1 |           00000001 |

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/bundle/BundledScanMbusChannels.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/bundle/BundledScanMbusChannels.feature
@@ -14,33 +14,33 @@ Feature: SmartMetering Bundle - ScanMbusChannels
       | Protocol             | <protocol>             |
       | ProtocolVersion      | <version>              |
     And a dlms device
-      | DeviceIdentification           | TESTG101205673101 |
-      | DeviceType                     | SMART_METER_G     |
+      | DeviceIdentification           | TESTG101205673101      |
+      | DeviceType                     | SMART_METER_G          |
       | GatewayDeviceIdentification    | <deviceIdentification> |
-      | Channel                        |                 1 |
-      | MbusIdentificationNumber       |          12056731 |
-      | MbusManufacturerIdentification | LGB               |
-      | MbusVersion                    |                66 |
-      | MbusDeviceTypeIdentification   |                 3 |
-    And device simulation of "<deviceIdentification>" with M-Bus client version 0 values for channel 1
+      | Channel                        |                      1 |
+      | MbusIdentificationNumber       |               12056731 |
+      | MbusManufacturerIdentification | LGB                    |
+      | MbusVersion                    |                     66 |
+      | MbusDeviceTypeIdentification   |                      3 |
+    And device simulation of "<deviceIdentification>" with M-Bus client version <mbusversion> values for channel 1
       | MbusPrimaryAddress             | 9        |
-      | MbusIdentificationNumber       | <mbusid> |
+      | MbusIdentificationNumber       | 12056731 |
       | MbusManufacturerIdentification | LGB      |
       | MbusVersion                    | 66       |
       | MbusDeviceTypeIdentification   | 3        |
-    And device simulation of "<deviceIdentification>" with M-Bus client version 0 values for channel 2
+    And device simulation of "<deviceIdentification>" with M-Bus client version <mbusversion> values for channel 2
       | MbusPrimaryAddress             | 0 |
       | MbusIdentificationNumber       | 0 |
       | MbusManufacturerIdentification | 0 |
       | MbusVersion                    | 0 |
       | MbusDeviceTypeIdentification   | 0 |
-    And device simulation of "<deviceIdentification>" with M-Bus client version 0 values for channel 3
+    And device simulation of "<deviceIdentification>" with M-Bus client version <mbusversion> values for channel 3
       | MbusPrimaryAddress             | 0 |
       | MbusIdentificationNumber       | 0 |
       | MbusManufacturerIdentification | 0 |
       | MbusVersion                    | 0 |
       | MbusDeviceTypeIdentification   | 0 |
-    And device simulation of "<deviceIdentification>" with M-Bus client version 0 values for channel 4
+    And device simulation of "<deviceIdentification>" with M-Bus client version <mbusversion> values for channel 4
       | MbusPrimaryAddress             | 0 |
       | MbusIdentificationNumber       | 0 |
       | MbusManufacturerIdentification | 0 |
@@ -52,33 +52,33 @@ Feature: SmartMetering Bundle - ScanMbusChannels
     When the bundle request is received
     Then the bundle response should contain a scan mbus channels response with values
       | DeviceIdentification                   | <deviceIdentification> |
-      | Channel1MbusIdentificationNumber       |   <mbusid_in_response> |
-      | Channel1MbusManufacturerIdentification | LGB               |
-      | Channel1MbusVersion                    |                66 |
-      | Channel1MbusDeviceTypeIdentification   |                 3 |
-      | Channel2MbusIdentificationNumber       |          00000000 |
-      | Channel2MbusManufacturerIdentification |                   |
-      | Channel2MbusVersion                    |                 0 |
-      | Channel2MbusDeviceTypeIdentification   |                 0 |
-      | Channel3MbusIdentificationNumber       |          00000000 |
-      | Channel3MbusManufacturerIdentification |                   |
-      | Channel3MbusVersion                    |                 0 |
-      | Channel3MbusDeviceTypeIdentification   |                 0 |
-      | Channel4MbusIdentificationNumber       |          00000000 |
-      | Channel4MbusManufacturerIdentification |                   |
-      | Channel4MbusVersion                    |                 0 |
-      | Channel4MbusDeviceTypeIdentification   |                 0 |
+      | Channel1MbusIdentificationNumber       |               12056731 |
+      | Channel1MbusManufacturerIdentification | LGB                    |
+      | Channel1MbusVersion                    |                     66 |
+      | Channel1MbusDeviceTypeIdentification   |                      3 |
+      | Channel2MbusIdentificationNumber       |               00000000 |
+      | Channel2MbusManufacturerIdentification |                        |
+      | Channel2MbusVersion                    |                      0 |
+      | Channel2MbusDeviceTypeIdentification   |                      0 |
+      | Channel3MbusIdentificationNumber       |               00000000 |
+      | Channel3MbusManufacturerIdentification |                        |
+      | Channel3MbusVersion                    |                      0 |
+      | Channel3MbusDeviceTypeIdentification   |                      0 |
+      | Channel4MbusIdentificationNumber       |               00000000 |
+      | Channel4MbusManufacturerIdentification |                        |
+      | Channel4MbusVersion                    |                      0 |
+      | Channel4MbusDeviceTypeIdentification   |                      0 |
 
 
     Examples:
-      | deviceIdentification | protocol | version | mbusid   | mbusid_in_response |
-      | TEST1024000000001    | DSMR     | 4.2.2   | 12056731 |           12056731 |
+      | deviceIdentification | protocol | version | mbusversion |
+      | TEST1024000000001    | DSMR     | 4.2.2   |           0 |
     @NightlyBuildOnly
     Examples:
-      | deviceIdentification | protocol | version | mbusid   | mbusid_in_response |
-      | TEST1024000000001    | DSMR     | 2.2     | 12056731 |           12056731 |
-      | TEST1031000000001    | SMR      | 4.3     | 12056731 |           12056731 |
-      | TEST1027000000001    | SMR      | 5.0.0   |        1 |           00000001 |
-      | TEST1028000000001    | SMR      | 5.1     |        1 |           00000001 |
-      | TEST1029000000001    | SMR      | 5.2     |        1 |           00000001 |
-      | TEST1030000000001    | SMR      | 5.5     |        1 |           00000001 |
+      | deviceIdentification | protocol | version | mbusversion |
+      | TEST1024000000001    | DSMR     | 2.2     |           0 |
+      | TEST1031000000001    | SMR      | 4.3     |           0 |
+      | TEST1027000000001    | SMR      | 5.0.0   |           1 |
+      | TEST1028000000001    | SMR      | 5.1     |           1 |
+      | TEST1029000000001    | SMR      | 5.2     |           1 |
+      | TEST1030000000001    | SMR      | 5.5     |           1 |

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/configuration/Firmware.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/configuration/Firmware.feature
@@ -118,7 +118,6 @@ Feature: SmartMetering Configuration - Firmware
   @NightlyBuildOnly
     Examples:
       | deviceIdentification | protocol | version |
-      | TEST1024000000001    | DSMR     | 2.2     |
       | TEST1031000000001    | SMR      | 4.3     |
       | TEST1027000000001    | SMR      | 5.0.0   |
       | TEST1028000000001    | SMR      | 5.1     |

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/configuration/Firmware.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/configuration/Firmware.feature
@@ -88,8 +88,8 @@ Feature: SmartMetering Configuration - Firmware
       | DeviceType           | SMART_METER_E          |
       | ManufacturerCode     | KAI                    |
       | DeviceModelCode      | MA105                  |
-      | protocolName         | <protocol>             |
-      | protocolVersion      | <version>              |
+      | Protocol             | <protocol>             |
+      | ProtocolVersion      | <version>              |
     And receiving an add or change firmware request
       | FirmwareFileIdentification  | TEST_FW_FILE_0003      |
       | FirmwareFile                | 0000000000230011004000310000001000020801e91effffffff500303000000000000831c9d5aa5b4ffbfd057035a8a7896a4abe7afa36687fbc48944bcee0343eed3a75aab882ec1cf57820adfd4394e262d5fa821c678e71c05c47e1c69c4bfffe1fd |

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/configuration/GetMbusEncryptionKeyStatus.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/configuration/GetMbusEncryptionKeyStatus.feature
@@ -2,24 +2,38 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-@SmartMetering @Platform @SmartMeteringConfiguration @NightlyBuildOnly
-Feature: SmartMetering - Configuration - M-Bus encryption key status
+@SmartMetering @Platform @SmartMeteringConfiguration @MBusDevice @NightlyBuildOnly
+Feature: SmartMetering Configuration - M-Bus encryption key status
   As a product owner
   I want to be able to retrieve the encryption key status from an M-Bus device
   So that I have insight into the status encryption key replacement
 
-  Scenario: Get M-Bus encryption key status from coupled M-Bus device
+  Scenario Outline: Get M-Bus encryption key status of coupled M-Bus device from <protocol> <version> gateway
     Given a dlms device
-      | DeviceIdentification | TEST1024000000001 |
-      | DeviceType           | SMART_METER_E     |
+      | DeviceIdentification | <deviceIdentification> |
+      | DeviceType           | SMART_METER_E          |
+      | Protocol             | <protocol>             |
+      | ProtocolVersion      | <version>              |
     And a dlms device
-      | DeviceIdentification        | TESTG102400000001 |
-      | DeviceType                  | SMART_METER_G     |
-      | GatewayDeviceIdentification | TEST1024000000001 |
-      | Channel                     |                 1 |
+      | DeviceIdentification        | TESTG102400000001      |
+      | DeviceType                  | SMART_METER_G          |
+      | GatewayDeviceIdentification | <deviceIdentification> |
+      | Channel                     |                      1 |
     When a get M-Bus encryption key status request is received
       | DeviceIdentification | TESTG102400000001 |
     Then the get M-Bus encryption key status request should return an encryption key status
+
+  Examples:
+      | deviceIdentification | protocol | version |
+      | TEST1024000000001    | DSMR     | 4.2.2   |
+  @NightlyBuildOnly
+  Examples:
+      | deviceIdentification | protocol | version |
+      | TEST1031000000001    | SMR      | 4.3     |
+      | TEST1027000000001    | SMR      | 5.0.0   |
+      | TEST1028000000001    | SMR      | 5.1     |
+      | TEST1029000000001    | SMR      | 5.2     |
+      | TEST1030000000001    | SMR      | 5.5     |
 
   Scenario: Get M-Bus encryption key status from decoupled M-Bus device
     Given a dlms device

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/configuration/GetMbusEncryptionKeyStatusByChannel.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/configuration/GetMbusEncryptionKeyStatusByChannel.feature
@@ -2,13 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-@SmartMetering @Platform @SmartMeteringConfiguration @MBusDevice @NightlyBuildOnly
-Feature: SmartMetering - Configuration - M-Bus encryption key status by channel
+@SmartMetering @Platform @SmartMeteringConfiguration @MBusDevice @NightlyBuildOnly @HBM
+Feature: SmartMetering Configuration - M-Bus encryption key status by channel
   As a product owner
   I want to be able to retrieve the encryption key status from an M-Bus device using the gateway device identification and a channel
   So that I have insight into the encryption key status
 
-  Scenario Outline: Get M-Bus encryption key status from coupled M-Bus device by using Channel id and Gateway device id (<protocol> <version> )
+  Scenario Outline: Get M-Bus encryption key status from coupled M-Bus device on channel <ch> and Gateway device id (<protocol> <version> )
     Given a dlms device
       | DeviceIdentification | <deviceIdentification> |
       | DeviceType           | SMART_METER_E          |
@@ -17,40 +17,41 @@ Feature: SmartMetering - Configuration - M-Bus encryption key status by channel
     And a dlms device
       | DeviceIdentification           | TESTG101205673101      |
       | DeviceType                     | SMART_METER_G          |
-      | Protocol                       | DSMR                   |
-      | ProtocolVersion                | 4.2.2                  |
       | GatewayDeviceIdentification    | <deviceIdentification> |
-      | Channel                        |                      1 |
+      | Channel                        |                   <ch> |
       | MbusIdentificationNumber       | 12056731               |
       | MbusManufacturerIdentification | LGB                    |
       | MbusVersion                    |                     66 |
       | MbusDeviceTypeIdentification   |                      3 |
-    And device simulation of "<deviceIdentification>" with M-Bus client version 0 values for channel 1
+    And device simulation of "<deviceIdentification>" with M-Bus client version <mbusversion> values for channel <ch>
       | MbusPrimaryAddress             | 9        |
-      | MbusIdentificationNumber       | <mbusid> |
+      | MbusIdentificationNumber       | 12056731 |
       | MbusManufacturerIdentification | LGB      |
       | MbusVersion                    | 66       |
       | MbusDeviceTypeIdentification   | 3        |
       | MbusEncryptionKeyStatus        | 4        |
     When a get M-Bus encryption key status by channel request is received
       | DeviceIdentification | <deviceIdentification> |
-      | Channel              |                 1 |
+      | Channel              |                   <ch> |
     Then the get M-Bus encryption key status by channel response is returned
-      | DeviceIdentification | <deviceIdentification>     |
-      | Channel              |                     1 |
-      | EncryptionKeyStatus  | ENCRYPTION_KEY_IN_USE |
+      | DeviceIdentification | <deviceIdentification> |
+      | Channel              |                   <ch> |
+      | EncryptionKeyStatus  | ENCRYPTION_KEY_IN_USE  |
 
     Examples:
-      | deviceIdentification | protocol | version | mbusid   |
-      | TEST1024000000001    | DSMR     | 4.2.2   | 12056731 |
+      | deviceIdentification | protocol | version | mbusversion | ch |
+      | TEST1024000000001    | DSMR     | 4.2.2   |           0 |  1 |
   @NightlyBuildOnly
     Examples:
-      | deviceIdentification | protocol | version | mbusid   |
-      | TEST1031000000001    | SMR      | 4.3     | 12056731 |
-      | TEST1027000000001    | SMR      | 5.0.0   |        1 |
-      | TEST1028000000001    | SMR      | 5.1     |        1 |
-      | TEST1029000000001    | SMR      | 5.2     |        1 |
-      | TEST1030000000001    | SMR      | 5.5     |        1 |
+      | deviceIdentification | protocol | version | mbusversion | ch |
+      | TEST1024000000001    | DSMR     | 4.2.2   |           0 |  2 |
+      | TEST1024000000001    | DSMR     | 4.2.2   |           0 |  3 |
+      | TEST1024000000001    | DSMR     | 4.2.2   |           0 |  4 |
+      | TEST1031000000001    | SMR      | 4.3     |           0 |  1 |
+      | TEST1027000000001    | SMR      | 5.0.0   |           1 |  1 |
+      | TEST1028000000001    | SMR      | 5.1     |           1 |  1 |
+      | TEST1029000000001    | SMR      | 5.2     |           1 |  1 |
+      | TEST1030000000001    | SMR      | 5.5     |           1 |  1 |
 
   Scenario: Get M-Bus encryption key status using Channel and Gateway device id, no device on that channel
     Given a dlms device

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/configuration/GetMbusEncryptionKeyStatusByChannel.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/configuration/GetMbusEncryptionKeyStatusByChannel.feature
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-@SmartMetering @Platform @SmartMeteringConfiguration @MBusDevice @NightlyBuildOnly @HBM
+@SmartMetering @Platform @SmartMeteringConfiguration @MBusDevice @NightlyBuildOnly
 Feature: SmartMetering Configuration - M-Bus encryption key status by channel
   As a product owner
   I want to be able to retrieve the encryption key status from an M-Bus device using the gateway device identification and a channel

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/configuration/GetMbusEncryptionKeyStatusByChannel.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/configuration/GetMbusEncryptionKeyStatusByChannel.feature
@@ -2,39 +2,55 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-@SmartMetering @Platform @SmartMeteringConfiguration @NightlyBuildOnly
+@SmartMetering @Platform @SmartMeteringConfiguration @MBusDevice @NightlyBuildOnly
 Feature: SmartMetering - Configuration - M-Bus encryption key status by channel
   As a product owner
   I want to be able to retrieve the encryption key status from an M-Bus device using the gateway device identification and a channel
   So that I have insight into the encryption key status
 
-  Scenario: Get M-Bus encryption key status from coupled M-Bus device by using Channel id and Gateway device id
+  Scenario Outline: Get M-Bus encryption key status from coupled M-Bus device by using Channel id and Gateway device id (<protocol> <version> )
     Given a dlms device
-      | DeviceIdentification | TEST1024000000001 |
-      | DeviceType           | SMART_METER_E     |
+      | DeviceIdentification | <deviceIdentification> |
+      | DeviceType           | SMART_METER_E          |
+      | Protocol             | <protocol>             |
+      | ProtocolVersion      | <version>              |
     And a dlms device
-      | DeviceIdentification           | TESTG101205673101 |
-      | DeviceType                     | SMART_METER_G     |
-      | GatewayDeviceIdentification    | TEST1024000000001 |
-      | Channel                        |                 1 |
-      | MbusIdentificationNumber       |          12056731 |
-      | MbusManufacturerIdentification | LGB               |
-      | MbusVersion                    |                66 |
-      | MbusDeviceTypeIdentification   |                 3 |
-    And device simulation of "TEST1024000000001" with M-Bus client version 0 values for channel 1
+      | DeviceIdentification           | TESTG101205673101      |
+      | DeviceType                     | SMART_METER_G          |
+      | Protocol                       | DSMR                   |
+      | ProtocolVersion                | 4.2.2                  |
+      | GatewayDeviceIdentification    | <deviceIdentification> |
+      | Channel                        |                      1 |
+      | MbusIdentificationNumber       | 12056731               |
+      | MbusManufacturerIdentification | LGB                    |
+      | MbusVersion                    |                     66 |
+      | MbusDeviceTypeIdentification   |                      3 |
+    And device simulation of "<deviceIdentification>" with M-Bus client version 0 values for channel 1
       | MbusPrimaryAddress             | 9        |
-      | MbusIdentificationNumber       | 12056731 |
+      | MbusIdentificationNumber       | <mbusid> |
       | MbusManufacturerIdentification | LGB      |
       | MbusVersion                    | 66       |
       | MbusDeviceTypeIdentification   | 3        |
       | MbusEncryptionKeyStatus        | 4        |
     When a get M-Bus encryption key status by channel request is received
-      | DeviceIdentification | TEST1024000000001 |
+      | DeviceIdentification | <deviceIdentification> |
       | Channel              |                 1 |
     Then the get M-Bus encryption key status by channel response is returned
-      | DeviceIdentification | TEST1024000000001     |
+      | DeviceIdentification | <deviceIdentification>     |
       | Channel              |                     1 |
       | EncryptionKeyStatus  | ENCRYPTION_KEY_IN_USE |
+
+    Examples:
+      | deviceIdentification | protocol | version | mbusid   |
+      | TEST1024000000001    | DSMR     | 4.2.2   | 12056731 |
+  @NightlyBuildOnly
+    Examples:
+      | deviceIdentification | protocol | version | mbusid   |
+      | TEST1031000000001    | SMR      | 4.3     | 12056731 |
+      | TEST1027000000001    | SMR      | 5.0.0   |        1 |
+      | TEST1028000000001    | SMR      | 5.1     |        1 |
+      | TEST1029000000001    | SMR      | 5.2     |        1 |
+      | TEST1030000000001    | SMR      | 5.5     |        1 |
 
   Scenario: Get M-Bus encryption key status using Channel and Gateway device id, no device on that channel
     Given a dlms device

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/installation/AddMBusDevice.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/installation/AddMBusDevice.feature
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-@SmartMetering @Platform
+@SmartMetering @Platform @SmartMeteringInstallation @MBusDevice
 Feature: SmartMetering Installation - Add M-Bus device
   As a grid operator
   I want to be able to add a new M-Bus device

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/installation/AdministrativeDecoupleMBusDevice.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/installation/AdministrativeDecoupleMBusDevice.feature
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-@SmartMetering @Platform @NightlyBuildOnly @SmartMeteringInstallation @MBusDevice
+@SmartMetering @Platform @SmartMeteringInstallation @MBusDevice @NightlyBuildOnly
 Feature: SmartMetering Installation - Administrative Decouple M-Bus Device
   As a grid operator
   I want to be able to administratively decouple an M-Bus device

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/installation/CoupleMBusDevice.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/installation/CoupleMBusDevice.feature
@@ -14,46 +14,46 @@ Feature: SmartMetering Installation - Couple M-Bus Device
       | Protocol             | <protocol>             |
       | ProtocolVersion      | <version>              |
     And a dlms device
-      | DeviceIdentification           | <mbusidentification>    |
+      | DeviceIdentification           | TESTG101205673117       |
       | DeviceType                     | SMART_METER_G           |
       | DeviceLifecycleStatus          | <DeviceLifeCycleStatus> |
-      | MbusIdentificationNumber       |                <mbusid> |
+      | MbusIdentificationNumber       |                12056731 |
       | MbusManufacturerIdentification | LGB                     |
       | MbusVersion                    |                      66 |
       | MbusDeviceTypeIdentification   |                       3 |
-    And device simulation of "<deviceIdentification>" with M-Bus client version 0 values for channel 1
+    And device simulation of "<deviceIdentification>" with M-Bus client version <mbusversion> values for channel 1
       | MbusPrimaryAddress             |        9 |
-      | MbusIdentificationNumber       | <mbusid> |
+      | MbusIdentificationNumber       | 12056731 |
       | MbusManufacturerIdentification | LGB      |
       | MbusVersion                    |       66 |
       | MbusDeviceTypeIdentification   |        3 |
-    When the Couple G-meter "<mbusidentification>" request is received for E-meter "<deviceIdentification>"
+    When the Couple G-meter "TESTG101205673117" request is received for E-meter "<deviceIdentification>"
     Then the Couple response has the following values
-      | MbusDeviceIdentification | <mbusidentification> |
+      | MbusDeviceIdentification | TESTG101205673117 |
       | Channel                  |                 1 |
       | PrimaryAddress           |                 9 |
-    And the M-Bus device "<mbusidentification>" is coupled to device "<deviceIdentification>" on M-Bus channel "1" with PrimaryAddress "9"
+    And the M-Bus device "TESTG101205673117" is coupled to device "<deviceIdentification>" on M-Bus channel "1" with PrimaryAddress "9"
 
     Examples:
-      | DeviceLifeCycleStatus      | deviceIdentification | protocol | version | mbusid   | mbusidentification |
-      | REGISTERED                 | TEST1024000000001    | DSMR     | 4.2.2   | 12056731 | TESTG101205673117  |
+      | DeviceLifeCycleStatus      | deviceIdentification | protocol | version | mbusversion |
+      | REGISTERED                 | TEST1024000000001    | DSMR     | 4.2.2   |           0 |
     @NightlyBuildOnly
     Examples:
-      | DeviceLifeCycleStatus      | deviceIdentification | protocol | version | mbusid   | mbusidentification |
-      | NEW_IN_INVENTORY           | TEST1024000000001    | DSMR     | 4.2.2   | 12056731 | TESTG101205673117  |
-      | READY_FOR_USE              | TEST1024000000001    | DSMR     | 4.2.2   | 12056731 | TESTG101205673117  |
-      | REGISTERED_BUILD_IN_FAILED | TEST1024000000001    | DSMR     | 4.2.2   | 12056731 | TESTG101205673117  |
-      | REGISTERED_INSTALL_FAILED  | TEST1024000000001    | DSMR     | 4.2.2   | 12056731 | TESTG101205673117  |
-      | REGISTERED_UPDATE_FAILED   | TEST1024000000001    | DSMR     | 4.2.2   | 12056731 | TESTG101205673117  |
-      | RETURNED_TO_INVENTORY      | TEST1024000000001    | DSMR     | 4.2.2   | 12056731 | TESTG101205673117  |
-      | UNDER_TEST                 | TEST1024000000001    | DSMR     | 4.2.2   | 12056731 | TESTG101205673117  |
-      | DESTROYED                  | TEST1024000000001    | DSMR     | 4.2.2   | 12056731 | TESTG101205673117  |
-      | REGISTERED                 | TEST1024000000001    | DSMR     | 2.2     | 12056731 | TESTG101205673117  |
-      | REGISTERED                 | TEST1031000000001    | SMR      | 4.3     | 12056731 | TESTG101205673117  |
-      | REGISTERED                 | TEST1027000000001    | SMR      | 5.0.0   | 00000001 | TESTG100000000117  |
-      | REGISTERED                 | TEST1028000000001    | SMR      | 5.1     | 00000001 | TESTG100000000117  |
-      | REGISTERED                 | TEST1029000000001    | SMR      | 5.2     | 00000001 | TESTG100000000117  |
-      | REGISTERED                 | TEST1030000000001    | SMR      | 5.5     | 00000001 | TESTG100000000117  |
+      | DeviceLifeCycleStatus      | deviceIdentification | protocol | version | mbusversion |
+      | NEW_IN_INVENTORY           | TEST1024000000001    | DSMR     | 4.2.2   |           0 |
+      | READY_FOR_USE              | TEST1024000000001    | DSMR     | 4.2.2   |           0 |
+      | REGISTERED_BUILD_IN_FAILED | TEST1024000000001    | DSMR     | 4.2.2   |           0 |
+      | REGISTERED_INSTALL_FAILED  | TEST1024000000001    | DSMR     | 4.2.2   |           0 |
+      | REGISTERED_UPDATE_FAILED   | TEST1024000000001    | DSMR     | 4.2.2   |           0 |
+      | RETURNED_TO_INVENTORY      | TEST1024000000001    | DSMR     | 4.2.2   |           0 |
+      | UNDER_TEST                 | TEST1024000000001    | DSMR     | 4.2.2   |           0 |
+      | DESTROYED                  | TEST1024000000001    | DSMR     | 4.2.2   |           0 |
+      | REGISTERED                 | TEST1024000000001    | DSMR     | 2.2     |           0 |
+      | REGISTERED                 | TEST1031000000001    | SMR      | 4.3     |           0 |
+      | REGISTERED                 | TEST1027000000001    | SMR      | 5.0.0   |           1 |
+      | REGISTERED                 | TEST1028000000001    | SMR      | 5.1     |           1 |
+      | REGISTERED                 | TEST1029000000001    | SMR      | 5.2     |           1 |
+      | REGISTERED                 | TEST1030000000001    | SMR      | 5.5     |           1 |
 
   @NightlyBuildOnly
   Scenario: Couple G-meter "TESTG101205673117" with missing attributes to E-meter "TEST1024000000001" on first channel

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/installation/CoupleMBusDevice.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/installation/CoupleMBusDevice.feature
@@ -7,42 +7,53 @@ Feature: SmartMetering Installation - Couple M-Bus Device
   As a grid operator
   I want to be able to couple an M-Bus device to a smart meter
 
-  Scenario Outline: Couple G-meter "TESTG101205673117" to E-meter "TEST1024000000001" on first channel
+  Scenario Outline: Couple G-meter "TESTG101205673117" to a <protocol> <version> E-meter on first channel
     Given a dlms device
-      | DeviceIdentification | TEST1024000000001 |
-      | DeviceType           | SMART_METER_E     |
+      | DeviceIdentification | <deviceIdentification> |
+      | DeviceType           | SMART_METER_E          |
+      | Protocol             | <protocol>             |
+      | ProtocolVersion      | <version>              |
     And a dlms device
-      | DeviceIdentification           | TESTG101205673117       |
+      | DeviceIdentification           | <mbusidentification>    |
       | DeviceType                     | SMART_METER_G           |
       | DeviceLifecycleStatus          | <DeviceLifeCycleStatus> |
-      | MbusIdentificationNumber       |                12056731 |
+      | MbusIdentificationNumber       |                <mbusid> |
       | MbusManufacturerIdentification | LGB                     |
       | MbusVersion                    |                      66 |
       | MbusDeviceTypeIdentification   |                       3 |
-    And device simulation of "TEST1024000000001" with M-Bus client version 0 values for channel 1
+    And device simulation of "<deviceIdentification>" with M-Bus client version 0 values for channel 1
       | MbusPrimaryAddress             |        9 |
-      | MbusIdentificationNumber       | 12056731 |
+      | MbusIdentificationNumber       | <mbusid> |
       | MbusManufacturerIdentification | LGB      |
       | MbusVersion                    |       66 |
       | MbusDeviceTypeIdentification   |        3 |
-    When the Couple G-meter "TESTG101205673117" request is received for E-meter "TEST1024000000001"
+    When the Couple G-meter "<mbusidentification>" request is received for E-meter "<deviceIdentification>"
     Then the Couple response has the following values
-      | MbusDeviceIdentification | TESTG101205673117 |
+      | MbusDeviceIdentification | <mbusidentification> |
       | Channel                  |                 1 |
       | PrimaryAddress           |                 9 |
-    And the M-Bus device "TESTG101205673117" is coupled to device "TEST1024000000001" on M-Bus channel "1" with PrimaryAddress "9"
+    And the M-Bus device "<mbusidentification>" is coupled to device "<deviceIdentification>" on M-Bus channel "1" with PrimaryAddress "9"
 
     Examples:
-      | DeviceLifeCycleStatus      |
-      | NEW_IN_INVENTORY           |
-      | READY_FOR_USE              |
-      | REGISTERED                 |
-      | REGISTERED_BUILD_IN_FAILED |
-      | REGISTERED_INSTALL_FAILED  |
-      | REGISTERED_UPDATE_FAILED   |
-      | RETURNED_TO_INVENTORY      |
-      | UNDER_TEST                 |
-      | DESTROYED                  |
+      | DeviceLifeCycleStatus      | deviceIdentification | protocol | version | mbusid   | mbusidentification |
+      | REGISTERED                 | TEST1024000000001    | DSMR     | 4.2.2   | 12056731 | TESTG101205673117  |
+    @NightlyBuildOnly
+    Examples:
+      | DeviceLifeCycleStatus      | deviceIdentification | protocol | version | mbusid   | mbusidentification |
+      | NEW_IN_INVENTORY           | TEST1024000000001    | DSMR     | 4.2.2   | 12056731 | TESTG101205673117  |
+      | READY_FOR_USE              | TEST1024000000001    | DSMR     | 4.2.2   | 12056731 | TESTG101205673117  |
+      | REGISTERED_BUILD_IN_FAILED | TEST1024000000001    | DSMR     | 4.2.2   | 12056731 | TESTG101205673117  |
+      | REGISTERED_INSTALL_FAILED  | TEST1024000000001    | DSMR     | 4.2.2   | 12056731 | TESTG101205673117  |
+      | REGISTERED_UPDATE_FAILED   | TEST1024000000001    | DSMR     | 4.2.2   | 12056731 | TESTG101205673117  |
+      | RETURNED_TO_INVENTORY      | TEST1024000000001    | DSMR     | 4.2.2   | 12056731 | TESTG101205673117  |
+      | UNDER_TEST                 | TEST1024000000001    | DSMR     | 4.2.2   | 12056731 | TESTG101205673117  |
+      | DESTROYED                  | TEST1024000000001    | DSMR     | 4.2.2   | 12056731 | TESTG101205673117  |
+      | REGISTERED                 | TEST1024000000001    | DSMR     | 2.2     | 12056731 | TESTG101205673117  |
+      | REGISTERED                 | TEST1031000000001    | SMR      | 4.3     | 12056731 | TESTG101205673117  |
+      | REGISTERED                 | TEST1027000000001    | SMR      | 5.0.0   | 00000001 | TESTG100000000117  |
+      | REGISTERED                 | TEST1028000000001    | SMR      | 5.1     | 00000001 | TESTG100000000117  |
+      | REGISTERED                 | TEST1029000000001    | SMR      | 5.2     | 00000001 | TESTG100000000117  |
+      | REGISTERED                 | TEST1030000000001    | SMR      | 5.5     | 00000001 | TESTG100000000117  |
 
   @NightlyBuildOnly
   Scenario: Couple G-meter "TESTG101205673117" with missing attributes to E-meter "TEST1024000000001" on first channel

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/installation/CoupleMBusDeviceByChannel.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/installation/CoupleMBusDeviceByChannel.feature
@@ -7,43 +7,55 @@ Feature: SmartMetering Installation - Couple M-Bus Device by Channel
   As a grid operator
   I want to be able to couple an M-Bus device to a smart meter on a specific channel
 
-  @NightlyBuildOnly
-  Scenario Outline: Couple a connected and bound G-meter "TESTG101205673117" to E-meter "TEST1024000000001" on channel 1
+  Scenario Outline: Couple a connected and bound G-meter "TESTG101205673117" to a <protocol> <version> E-meter on channel 1
     Given a dlms device
-      | DeviceIdentification | TEST1024000000001 |
-      | DeviceType           | SMART_METER_E     |
-    And device simulation of "TEST1024000000001" with M-Bus client version 0 values for channel 1
+      | DeviceIdentification | <deviceIdentification> |
+      | DeviceType           | SMART_METER_E          |
+      | Protocol             | <protocol>             |
+      | ProtocolVersion      | <version>              |
+    And device simulation of "<deviceIdentification>" with M-Bus client version 0 values for channel 1
       | MbusPrimaryAddress             |        3 |
-      | MbusIdentificationNumber       | 12056731 |
+      | MbusIdentificationNumber       | <mbusid> |
       | MbusManufacturerIdentification | LGB      |
       | MbusVersion                    |       66 |
       | MbusDeviceTypeIdentification   |        3 |
     And a dlms device
       | DeviceIdentification           | TESTG101205673117       |
       | DeviceType                     | SMART_METER_G           |
+      | Protocol                       | DSMR                    |
+      | ProtocolVersion                | 4.2.2                   |
       | DeviceLifecycleStatus          | <DeviceLifeCycleStatus> |
-      | MbusIdentificationNumber       |                12056731 |
+      | MbusIdentificationNumber       |                <mbusid> |
       | MbusPrimaryAddress             |                       9 |
       | MbusManufacturerIdentification | LGB                     |
       | MbusVersion                    |                      66 |
       | MbusDeviceTypeIdentification   |                       3 |
     When the Couple M-Bus Device By Channel request is received
-      | DeviceIdentification | TEST1024000000001 |
+      | DeviceIdentification | <deviceIdentification> |
       | Channel              |                 1 |
     Then the Couple M-Bus Device By Channel response is "OK"
-    And the M-Bus device "TESTG101205673117" is coupled to device "TEST1024000000001" on M-Bus channel "1" with PrimaryAddress "3"
+    And the M-Bus device "TESTG101205673117" is coupled to device "<deviceIdentification>" on M-Bus channel "1" with PrimaryAddress "3"
 
     Examples:
-      | DeviceLifeCycleStatus      |
-      | NEW_IN_INVENTORY           |
-      | READY_FOR_USE              |
-      | REGISTERED                 |
-      | REGISTERED_BUILD_IN_FAILED |
-      | REGISTERED_INSTALL_FAILED  |
-      | REGISTERED_UPDATE_FAILED   |
-      | RETURNED_TO_INVENTORY      |
-      | UNDER_TEST                 |
-      | DESTROYED                  |
+      | DeviceLifeCycleStatus      | deviceIdentification | protocol | version | mbusid   |
+      | REGISTERED                 | TEST1024000000001    | DSMR     | 4.2.2   | 12056731 |
+    @NightlyBuildOnly
+    Examples:
+      | DeviceLifeCycleStatus      | deviceIdentification | protocol | version | mbusid   |
+      | NEW_IN_INVENTORY           | TEST1024000000001    | DSMR     | 4.2.2   | 12056731 |
+      | READY_FOR_USE              | TEST1024000000001    | DSMR     | 4.2.2   | 12056731 |
+      | REGISTERED_BUILD_IN_FAILED | TEST1024000000001    | DSMR     | 4.2.2   | 12056731 |
+      | REGISTERED_INSTALL_FAILED  | TEST1024000000001    | DSMR     | 4.2.2   | 12056731 |
+      | REGISTERED_UPDATE_FAILED   | TEST1024000000001    | DSMR     | 4.2.2   | 12056731 |
+      | RETURNED_TO_INVENTORY      | TEST1024000000001    | DSMR     | 4.2.2   | 12056731 |
+      | UNDER_TEST                 | TEST1024000000001    | DSMR     | 4.2.2   | 12056731 |
+      | DESTROYED                  | TEST1024000000001    | DSMR     | 4.2.2   | 12056731 |
+      | REGISTERED                 | TEST1024000000001    | DSMR     | 2.2     | 12056731 |
+      | REGISTERED                 | TEST1031000000001    | SMR      | 4.3     | 12056731 |
+      | REGISTERED                 | TEST1027000000001    | SMR      | 5.0.0   | 00000001 |
+      | REGISTERED                 | TEST1028000000001    | SMR      | 5.1     | 00000001 |
+      | REGISTERED                 | TEST1029000000001    | SMR      | 5.2     | 00000001 |
+      | REGISTERED                 | TEST1030000000001    | SMR      | 5.5     | 00000001 |
 
   @NightlyBuildOnly
   Scenario: Couple a connected and bound G-meter "TESTG101205673117" to E-meter "TEST1024000000001" on channel 1, device is in use

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/installation/CoupleMBusDeviceByChannel.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/installation/CoupleMBusDeviceByChannel.feature
@@ -7,15 +7,15 @@ Feature: SmartMetering Installation - Couple M-Bus Device by Channel
   As a grid operator
   I want to be able to couple an M-Bus device to a smart meter on a specific channel
 
-  Scenario Outline: Couple a connected and bound G-meter "TESTG101205673117" to a <protocol> <version> E-meter on channel 1
+  Scenario Outline: Couple a connected and bound G-meter "TESTG101205673117" to a <protocol> <version> E-meter on channel <ch>
     Given a dlms device
       | DeviceIdentification | <deviceIdentification> |
       | DeviceType           | SMART_METER_E          |
       | Protocol             | <protocol>             |
       | ProtocolVersion      | <version>              |
-    And device simulation of "<deviceIdentification>" with M-Bus client version 0 values for channel 1
+    And device simulation of "<deviceIdentification>" with M-Bus client version <mbusversion> values for channel <ch>
       | MbusPrimaryAddress             |        3 |
-      | MbusIdentificationNumber       | <mbusid> |
+      | MbusIdentificationNumber       | 12056731 |
       | MbusManufacturerIdentification | LGB      |
       | MbusVersion                    |       66 |
       | MbusDeviceTypeIdentification   |        3 |
@@ -25,37 +25,40 @@ Feature: SmartMetering Installation - Couple M-Bus Device by Channel
       | Protocol                       | DSMR                    |
       | ProtocolVersion                | 4.2.2                   |
       | DeviceLifecycleStatus          | <DeviceLifeCycleStatus> |
-      | MbusIdentificationNumber       |                <mbusid> |
+      | MbusIdentificationNumber       |                12056731 |
       | MbusPrimaryAddress             |                       9 |
       | MbusManufacturerIdentification | LGB                     |
       | MbusVersion                    |                      66 |
       | MbusDeviceTypeIdentification   |                       3 |
     When the Couple M-Bus Device By Channel request is received
       | DeviceIdentification | <deviceIdentification> |
-      | Channel              |                 1 |
+      | Channel              |                   <ch> |
     Then the Couple M-Bus Device By Channel response is "OK"
-    And the M-Bus device "TESTG101205673117" is coupled to device "<deviceIdentification>" on M-Bus channel "1" with PrimaryAddress "3"
+    And the M-Bus device "TESTG101205673117" is coupled to device "<deviceIdentification>" on M-Bus channel "<ch>" with PrimaryAddress "3"
 
     Examples:
-      | DeviceLifeCycleStatus      | deviceIdentification | protocol | version | mbusid   |
-      | REGISTERED                 | TEST1024000000001    | DSMR     | 4.2.2   | 12056731 |
+      | DeviceLifeCycleStatus      | deviceIdentification | protocol | version | mbusversion | ch |
+      | REGISTERED                 | TEST1024000000001    | DSMR     | 4.2.2   |           0 |  1 |
     @NightlyBuildOnly
     Examples:
-      | DeviceLifeCycleStatus      | deviceIdentification | protocol | version | mbusid   |
-      | NEW_IN_INVENTORY           | TEST1024000000001    | DSMR     | 4.2.2   | 12056731 |
-      | READY_FOR_USE              | TEST1024000000001    | DSMR     | 4.2.2   | 12056731 |
-      | REGISTERED_BUILD_IN_FAILED | TEST1024000000001    | DSMR     | 4.2.2   | 12056731 |
-      | REGISTERED_INSTALL_FAILED  | TEST1024000000001    | DSMR     | 4.2.2   | 12056731 |
-      | REGISTERED_UPDATE_FAILED   | TEST1024000000001    | DSMR     | 4.2.2   | 12056731 |
-      | RETURNED_TO_INVENTORY      | TEST1024000000001    | DSMR     | 4.2.2   | 12056731 |
-      | UNDER_TEST                 | TEST1024000000001    | DSMR     | 4.2.2   | 12056731 |
-      | DESTROYED                  | TEST1024000000001    | DSMR     | 4.2.2   | 12056731 |
-      | REGISTERED                 | TEST1024000000001    | DSMR     | 2.2     | 12056731 |
-      | REGISTERED                 | TEST1031000000001    | SMR      | 4.3     | 12056731 |
-      | REGISTERED                 | TEST1027000000001    | SMR      | 5.0.0   | 00000001 |
-      | REGISTERED                 | TEST1028000000001    | SMR      | 5.1     | 00000001 |
-      | REGISTERED                 | TEST1029000000001    | SMR      | 5.2     | 00000001 |
-      | REGISTERED                 | TEST1030000000001    | SMR      | 5.5     | 00000001 |
+      | DeviceLifeCycleStatus      | deviceIdentification | protocol | version | mbusversion | ch |
+      | REGISTERED                 | TEST1024000000001    | DSMR     | 4.2.2   |           0 |  2 |
+      | REGISTERED                 | TEST1024000000001    | DSMR     | 4.2.2   |           0 |  3 |
+      | REGISTERED                 | TEST1024000000001    | DSMR     | 4.2.2   |           0 |  4 |
+      | NEW_IN_INVENTORY           | TEST1024000000001    | DSMR     | 4.2.2   |           0 |  1 |
+      | READY_FOR_USE              | TEST1024000000001    | DSMR     | 4.2.2   |           0 |  1 |
+      | REGISTERED_BUILD_IN_FAILED | TEST1024000000001    | DSMR     | 4.2.2   |           0 |  1 |
+      | REGISTERED_INSTALL_FAILED  | TEST1024000000001    | DSMR     | 4.2.2   |           0 |  1 |
+      | REGISTERED_UPDATE_FAILED   | TEST1024000000001    | DSMR     | 4.2.2   |           0 |  1 |
+      | RETURNED_TO_INVENTORY      | TEST1024000000001    | DSMR     | 4.2.2   |           0 |  1 |
+      | UNDER_TEST                 | TEST1024000000001    | DSMR     | 4.2.2   |           0 |  1 |
+      | DESTROYED                  | TEST1024000000001    | DSMR     | 4.2.2   |           0 |  1 |
+      | REGISTERED                 | TEST1024000000001    | DSMR     | 2.2     |           0 |  1 |
+      | REGISTERED                 | TEST1031000000001    | SMR      | 4.3     |           0 |  1 |
+      | REGISTERED                 | TEST1027000000001    | SMR      | 5.0.0   |           1 |  1 |
+      | REGISTERED                 | TEST1028000000001    | SMR      | 5.1     |           1 |  1 |
+      | REGISTERED                 | TEST1029000000001    | SMR      | 5.2     |           1 |  1 |
+      | REGISTERED                 | TEST1030000000001    | SMR      | 5.5     |           1 |  1 |
 
   @NightlyBuildOnly
   Scenario: Couple a connected and bound G-meter "TESTG101205673117" to E-meter "TEST1024000000001" on channel 1, device is in use

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/installation/DecoupleMBusDevice.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/installation/DecoupleMBusDevice.feature
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-@SmartMetering @Platform @NightlyBuildOnly @MBusDevice @DecoupleMBusDevice
+@SmartMetering @Platform @SmartMeteringInstallation @MBusDevice @DecoupleMBusDevice @NightlyBuildOnly
 Feature: SmartMetering Installation - Decouple M-Bus Device
   As a grid operator
   I want to be able to decouple an M-Bus device from a smart meter
@@ -11,8 +11,8 @@ Feature: SmartMetering Installation - Decouple M-Bus Device
     Given a dlms device
       | DeviceIdentification | <deviceIdentification> |
       | DeviceType           | SMART_METER_E          |
-      | protocolName         | <protocol>             |
-      | protocolVersion      | <version>              |
+      | Protocol             | <protocol>             |
+      | ProtocolVersion      | <version>              |
     And a dlms device
       | DeviceIdentification        | TESTG102400000001      |
       | DeviceType                  | SMART_METER_G          |

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/installation/DecoupleMBusDeviceByChannel.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/installation/DecoupleMBusDeviceByChannel.feature
@@ -7,42 +7,45 @@ Feature: SmartMetering Installation - Decouple M-Bus Device By Channel
   As a grid operator
   I want to be able to decouple an M-Bus device by channel to a smart meter
 
-  Scenario Outline: Decouple M-Bus Device By Channel on a administratively decoupled E-meter (<protocol> <version>)
+  Scenario Outline: Decouple M-Bus Device By Channel (<ch>) on a administratively decoupled E-meter (<protocol> <version>)
     Given a dlms device
       | DeviceIdentification | <deviceIdentification> |
       | DeviceType           | SMART_METER_E          |
       | Protocol             | <protocol>             |
       | ProtocolVersion      | <version>              |
-    And device simulation of "<deviceIdentification>" with M-Bus client version 0 values for channel 1
+    And device simulation of "<deviceIdentification>" with M-Bus client version <mbusversion> values for channel <ch>
       | MbusPrimaryAddress             | 9        |
       | MbusIdentificationNumber       | <mbusid> |
       | MbusManufacturerIdentification | LGB      |
       | MbusVersion                    | 66       |
       | MbusDeviceTypeIdentification   | 3        |
-    When the Decouple M-Bus Device By Channel "1" from E-meter "<deviceIdentification>" request is received
+    When the Decouple M-Bus Device By Channel "<ch>" from E-meter "<deviceIdentification>" request is received
     Then the Decouple M-Bus Device By Channel response is "OK" with responsedata
       | ResultString                   | <result_string>      |
       | MbusIdentificationNumber       | <mbusid_in_response> |
       | MbusDeviceIdentification       |                      |
-    And the values for the M-Bus client for channel 1 on device simulator "<deviceIdentification>" are
+    And the values for the M-Bus client for channel <ch> on device simulator "<deviceIdentification>" are
       | MbusPrimaryAddress             | 0 |
       | MbusIdentificationNumber       | 0 |
       | MbusManufacturerIdentification | 0 |
       | MbusVersion                    | 0 |
       | MbusDeviceTypeIdentification   | 0 |
     Examples:
-      | deviceIdentification | protocol | version | mbusid   | mbusid_in_response                     | result_string                                                                                        |
-      | TEST1024000000001    | DSMR     | 4.2.2   | 12056731 | 12056731                               | Decouple Mbus Device was successful                                                                  |
+      | deviceIdentification | protocol | version | mbusversion | ch | mbusid   | mbusid_in_response                     | result_string                                                                                        |
+      | TEST1024000000001    | DSMR     | 4.2.2   |           0 |  1 | 12056731 | 12056731                               | Decouple Mbus Device was successful                                                                  |
     @NightlyBuildOnly
     Examples:
-      | deviceIdentification | protocol | version | mbusid   | mbusid_in_response                     | result_string                                                                                        |
-      | TEST1024000000001    | DSMR     | 2.2     | 12056731 | 12056731                               | Decouple Mbus Device was successful                                                                  |
-      | TEST1031000000001    | SMR      | 4.3     | 12056731 | 12056731                               | Decouple Mbus Device was successful                                                                  |
-      | TEST1027000000001    | SMR      | 5.0.0   |        1 | 00000001                               | Decouple Mbus Device was successful                                                                  |
-      | TEST1028000000001    | SMR      | 5.1     |        1 | 00000001                               | Decouple Mbus Device was successful                                                                  |
-      | TEST1029000000001    | SMR      | 5.2     |        1 | 00000001                               | Decouple Mbus Device was successful                                                                  |
-      | TEST1030000000001    | SMR      | 5.5     |        1 | 00000001                               | Decouple Mbus Device was successful                                                                  |
-      | TEST1024000000001    | DSMR     | 4.2.2   | A2056731 | DOUBLE_LONG_UNSIGNED Value: 2718263089 | Channel information could not be correctly interpreted. Mbus Device was successful decoupled anyway. |
+      | deviceIdentification | protocol | version | mbusversion | ch | mbusid   | mbusid_in_response                     | result_string                                                                                        |
+      | TEST1024000000001    | DSMR     | 4.2.2   |           0 |  2 | 12056731 | 12056731                               | Decouple Mbus Device was successful                                                                  |
+      | TEST1024000000001    | DSMR     | 4.2.2   |           0 |  3 | 12056731 | 12056731                               | Decouple Mbus Device was successful                                                                  |
+      | TEST1024000000001    | DSMR     | 4.2.2   |           0 |  4 | 12056731 | 12056731                               | Decouple Mbus Device was successful                                                                  |
+      | TEST1024000000001    | DSMR     | 2.2     |           0 |  1 | 12056731 | 12056731                               | Decouple Mbus Device was successful                                                                  |
+      | TEST1031000000001    | SMR      | 4.3     |           0 |  1 | 12056731 | 12056731                               | Decouple Mbus Device was successful                                                                  |
+      | TEST1027000000001    | SMR      | 5.0.0   |           1 |  1 | 12056731 | 12056731                               | Decouple Mbus Device was successful                                                                  |
+      | TEST1028000000001    | SMR      | 5.1     |           1 |  1 | 12056731 | 12056731                               | Decouple Mbus Device was successful                                                                  |
+      | TEST1029000000001    | SMR      | 5.2     |           1 |  1 | 12056731 | 12056731                               | Decouple Mbus Device was successful                                                                  |
+      | TEST1030000000001    | SMR      | 5.5     |           1 |  1 | 12056731 | 12056731                               | Decouple Mbus Device was successful                                                                  |
+      | TEST1024000000001    | DSMR     | 4.2.2   |           0 |  1 | A2056731 | DOUBLE_LONG_UNSIGNED Value: 2718263089 | Channel information could not be correctly interpreted. Mbus Device was successful decoupled anyway. |
 
   Scenario: Decouple M-Bus Device By Channel on a administratively decoupled E-meter with empty channel
     Given a dlms device

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/installation/DecoupleMBusDeviceByChannel.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/installation/DecoupleMBusDeviceByChannel.feature
@@ -7,31 +7,42 @@ Feature: SmartMetering Installation - Decouple M-Bus Device By Channel
   As a grid operator
   I want to be able to decouple an M-Bus device by channel to a smart meter
 
-  Scenario Outline: Decouple M-Bus Device By Channel on a administratively decoupled E-meter
+  Scenario Outline: Decouple M-Bus Device By Channel on a administratively decoupled E-meter (<protocol> <version>)
     Given a dlms device
-      | DeviceIdentification | TEST1024000000001 |
-      | DeviceType           | SMART_METER_E     |
-    And device simulation of "TEST1024000000001" with M-Bus client version 0 values for channel 1
+      | DeviceIdentification | <deviceIdentification> |
+      | DeviceType           | SMART_METER_E          |
+      | Protocol             | <protocol>             |
+      | ProtocolVersion      | <version>              |
+    And device simulation of "<deviceIdentification>" with M-Bus client version 0 values for channel 1
       | MbusPrimaryAddress             | 9        |
       | MbusIdentificationNumber       | <mbusid> |
       | MbusManufacturerIdentification | LGB      |
       | MbusVersion                    | 66       |
       | MbusDeviceTypeIdentification   | 3        |
-    When the Decouple M-Bus Device By Channel "1" from E-meter "TEST1024000000001" request is received
+    When the Decouple M-Bus Device By Channel "1" from E-meter "<deviceIdentification>" request is received
     Then the Decouple M-Bus Device By Channel response is "OK" with responsedata
       | ResultString                   | <result_string>      |
       | MbusIdentificationNumber       | <mbusid_in_response> |
       | MbusDeviceIdentification       |                      |
-    And the values for the M-Bus client for channel 1 on device simulator "TEST1024000000001" are
+    And the values for the M-Bus client for channel 1 on device simulator "<deviceIdentification>" are
       | MbusPrimaryAddress             | 0 |
       | MbusIdentificationNumber       | 0 |
       | MbusManufacturerIdentification | 0 |
       | MbusVersion                    | 0 |
       | MbusDeviceTypeIdentification   | 0 |
     Examples:
-      | mbusid   | mbusid_in_response                     | result_string                                                                                        |
-      | 12056731 | 12056731                               | Decouple Mbus Device was successful                                                                  |
-      | A2056731 | DOUBLE_LONG_UNSIGNED Value: 2718263089 | Channel information could not be correctly interpreted. Mbus Device was successful decoupled anyway. |
+      | deviceIdentification | protocol | version | mbusid   | mbusid_in_response                     | result_string                                                                                        |
+      | TEST1024000000001    | DSMR     | 4.2.2   | 12056731 | 12056731                               | Decouple Mbus Device was successful                                                                  |
+    @NightlyBuildOnly
+    Examples:
+      | deviceIdentification | protocol | version | mbusid   | mbusid_in_response                     | result_string                                                                                        |
+      | TEST1024000000001    | DSMR     | 2.2     | 12056731 | 12056731                               | Decouple Mbus Device was successful                                                                  |
+      | TEST1031000000001    | SMR      | 4.3     | 12056731 | 12056731                               | Decouple Mbus Device was successful                                                                  |
+      | TEST1027000000001    | SMR      | 5.0.0   |        1 | 00000001                               | Decouple Mbus Device was successful                                                                  |
+      | TEST1028000000001    | SMR      | 5.1     |        1 | 00000001                               | Decouple Mbus Device was successful                                                                  |
+      | TEST1029000000001    | SMR      | 5.2     |        1 | 00000001                               | Decouple Mbus Device was successful                                                                  |
+      | TEST1030000000001    | SMR      | 5.5     |        1 | 00000001                               | Decouple Mbus Device was successful                                                                  |
+      | TEST1024000000001    | DSMR     | 4.2.2   | A2056731 | DOUBLE_LONG_UNSIGNED Value: 2718263089 | Channel information could not be correctly interpreted. Mbus Device was successful decoupled anyway. |
 
   Scenario: Decouple M-Bus Device By Channel on a administratively decoupled E-meter with empty channel
     Given a dlms device

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/management/ClearMBusStatusOnAllChannels.feature
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/features/osgp-adapter-ws-smartmetering/management/ClearMBusStatusOnAllChannels.feature
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-@SmartMetering @Platform @SmartMeteringManagement @NightlyBuildOnly
+@SmartMetering @Platform @SmartMeteringManagement @MBusDevice @NightlyBuildOnly
 Feature: SmartMetering Management - Clear M-Bus alarm status on all channels of a E meter
   As a grid operator
   I want to be able to clear the M-Bus alarm status on all channels of a E meter

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/mbus/DeviceChannelsHelper.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/mbus/DeviceChannelsHelper.java
@@ -376,7 +376,8 @@ public class DeviceChannelsHelper {
   private DataObjectAttrExecutor getMbusAttributeExecutor(
       final CosemObjectAccessor cosemObjectAccessor,
       final MbusClientAttribute attribute,
-      final DataObject value) {
+      final DataObject value)
+      throws NotSupportedByProtocolException {
 
     final AttributeAddress attributeAddress = cosemObjectAccessor.createAttributeAddress(attribute);
 

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/mbus/GetMbusEncryptionKeyStatusByChannelCommandExecutor.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/mbus/GetMbusEncryptionKeyStatusByChannelCommandExecutor.java
@@ -14,7 +14,6 @@ import org.opensmartgridplatform.dto.valueobjects.smartmetering.GetMbusEncryptio
 import org.opensmartgridplatform.dto.valueobjects.smartmetering.GetMbusEncryptionKeyStatusByChannelResponseDto;
 import org.opensmartgridplatform.shared.exceptionhandling.OsgpException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -23,13 +22,15 @@ public class GetMbusEncryptionKeyStatusByChannelCommandExecutor
         GetMbusEncryptionKeyStatusByChannelRequestDataDto,
         GetMbusEncryptionKeyStatusByChannelResponseDto> {
 
-  @Autowired
-  private GetMbusEncryptionKeyStatusCommandExecutor getMbusEncryptionKeyStatusCommandExecutor;
+  private final GetMbusEncryptionKeyStatusCommandExecutor getMbusEncryptionKeyStatusCommandExecutor;
+  private final GetMBusDeviceOnChannelCommandExecutor getMBusDeviceOnChannelCommandExecutor;
 
-  @Autowired private GetMBusDeviceOnChannelCommandExecutor getMBusDeviceOnChannelCommandExecutor;
-
-  public GetMbusEncryptionKeyStatusByChannelCommandExecutor() {
+  public GetMbusEncryptionKeyStatusByChannelCommandExecutor(
+      final GetMbusEncryptionKeyStatusCommandExecutor getMbusEncryptionKeyStatusCommandExecutor,
+      final GetMBusDeviceOnChannelCommandExecutor getMBusDeviceOnChannelCommandExecutor) {
     super(GetMbusEncryptionKeyStatusByChannelRequestDataDto.class);
+    this.getMbusEncryptionKeyStatusCommandExecutor = getMbusEncryptionKeyStatusCommandExecutor;
+    this.getMBusDeviceOnChannelCommandExecutor = getMBusDeviceOnChannelCommandExecutor;
   }
 
   @Override
@@ -58,7 +59,7 @@ public class GetMbusEncryptionKeyStatusByChannelCommandExecutor
 
     final EncryptionKeyStatusTypeDto encryptionKeyStatusType =
         this.getMbusEncryptionKeyStatusCommandExecutor.getEncryptionKeyStatusTypeDto(
-            request.getChannel(), conn);
+            request.getChannel(), conn, device);
     return new GetMbusEncryptionKeyStatusByChannelResponseDto(
         device.getDeviceIdentification(), encryptionKeyStatusType, request.getChannel());
   }

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/mbus/GetMbusEncryptionKeyStatusCommandExecutor.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/mbus/GetMbusEncryptionKeyStatusCommandExecutor.java
@@ -4,48 +4,43 @@
 
 package org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.mbus;
 
-import java.util.HashMap;
-import java.util.Map;
+import static org.opensmartgridplatform.dlms.objectconfig.DlmsObjectType.MBUS_CLIENT_SETUP;
+
+import lombok.extern.slf4j.Slf4j;
 import org.openmuc.jdlms.AttributeAddress;
-import org.openmuc.jdlms.ObisCode;
 import org.openmuc.jdlms.datatypes.DataObject;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.AbstractCommandExecutor;
+import org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.utils.CosemObjectAccessor;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.utils.JdlmsObjectToStringUtil;
+import org.opensmartgridplatform.adapter.protocol.dlms.domain.commands.utils.ObjectConfigServiceHelper;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.entities.DlmsDevice;
+import org.opensmartgridplatform.adapter.protocol.dlms.domain.entities.Protocol;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.factories.DlmsConnectionManager;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.valueobjects.EncryptionKeyStatusType;
+import org.opensmartgridplatform.adapter.protocol.dlms.exceptions.NotSupportedByProtocolException;
 import org.opensmartgridplatform.adapter.protocol.dlms.exceptions.ProtocolAdapterException;
-import org.opensmartgridplatform.dlms.interfaceclass.InterfaceClass;
 import org.opensmartgridplatform.dlms.interfaceclass.attribute.MbusClientAttribute;
 import org.opensmartgridplatform.dto.valueobjects.smartmetering.EncryptionKeyStatusTypeDto;
 import org.opensmartgridplatform.dto.valueobjects.smartmetering.GetMbusEncryptionKeyStatusRequestDto;
 import org.opensmartgridplatform.dto.valueobjects.smartmetering.GetMbusEncryptionKeyStatusResponseDto;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component()
 public class GetMbusEncryptionKeyStatusCommandExecutor
     extends AbstractCommandExecutor<
         GetMbusEncryptionKeyStatusRequestDto, GetMbusEncryptionKeyStatusResponseDto> {
 
-  private static final Logger LOGGER =
-      LoggerFactory.getLogger(GetMbusEncryptionKeyStatusCommandExecutor.class);
+  //  private static final MbusClientAttribute ATTRIBUTE_ID =
+  // MbusClientAttribute.ENCRYPTION_KEY_STATUS;
 
-  private static final int CLASS_ID = InterfaceClass.MBUS_CLIENT.id();
-  private static final Map<Short, ObisCode> OBIS_CODES = new HashMap<>();
-  private static final int ATTRIBUTE_ID = MbusClientAttribute.ENCRYPTION_KEY_STATUS.attributeId();
+  private final ObjectConfigServiceHelper objectConfigServiceHelper;
 
-  static {
-    OBIS_CODES.put((short) 1, new ObisCode("0.1.24.1.0.255"));
-    OBIS_CODES.put((short) 2, new ObisCode("0.2.24.1.0.255"));
-    OBIS_CODES.put((short) 3, new ObisCode("0.3.24.1.0.255"));
-    OBIS_CODES.put((short) 4, new ObisCode("0.4.24.1.0.255"));
-  }
-
-  public GetMbusEncryptionKeyStatusCommandExecutor() {
+  public GetMbusEncryptionKeyStatusCommandExecutor(
+      final ObjectConfigServiceHelper objectConfigServiceHelper) {
     super(GetMbusEncryptionKeyStatusRequestDto.class);
+    this.objectConfigServiceHelper = objectConfigServiceHelper;
   }
 
   @Override
@@ -57,33 +52,46 @@ public class GetMbusEncryptionKeyStatusCommandExecutor
       throws ProtocolAdapterException {
 
     final EncryptionKeyStatusTypeDto encryptionKeyStatusType =
-        this.getEncryptionKeyStatusTypeDto(request.getChannel(), conn);
+        this.getEncryptionKeyStatusTypeDto(request.getChannel(), conn, device);
     return new GetMbusEncryptionKeyStatusResponseDto(
         request.getMbusDeviceIdentification(), encryptionKeyStatusType);
   }
 
   public EncryptionKeyStatusTypeDto getEncryptionKeyStatusTypeDto(
-      final short channel, final DlmsConnectionManager conn) throws ProtocolAdapterException {
+      final short channel, final DlmsConnectionManager conn, final DlmsDevice device)
+      throws ProtocolAdapterException {
 
-    final ObisCode obisCode = OBIS_CODES.get(channel);
-
-    final AttributeAddress getParameter = new AttributeAddress(CLASS_ID, obisCode, ATTRIBUTE_ID);
+    final CosemObjectAccessor cosemObjectAccessor =
+        this.createCosemObjectAccessor(conn, device, channel);
+    final AttributeAddress attributeAddress =
+        cosemObjectAccessor.createAttributeAddress(MbusClientAttribute.ENCRYPTION_KEY_STATUS);
 
     conn.getDlmsMessageListener()
         .setDescription(
             "GetMbusEncryptionKeyStatusByChannel, retrieve attribute: "
-                + JdlmsObjectToStringUtil.describeAttributes(getParameter));
+                + JdlmsObjectToStringUtil.describeAttributes(attributeAddress));
 
-    LOGGER.debug(
+    log.debug(
         "Retrieving current M-Bus encryption key status by issuing get request for class id: {}, obis code: "
             + "{}, attribute id: {}",
-        CLASS_ID,
-        obisCode,
-        ATTRIBUTE_ID);
+        attributeAddress.getClassId(),
+        attributeAddress.getInstanceId(),
+        attributeAddress.getId());
 
-    final DataObject dataObject = this.getValidatedResultData(conn, getParameter);
+    final DataObject dataObject = this.getValidatedResultData(conn, attributeAddress);
 
     return EncryptionKeyStatusTypeDto.valueOf(
         EncryptionKeyStatusType.fromValue(dataObject.getValue()).name());
+  }
+
+  private CosemObjectAccessor createCosemObjectAccessor(
+      final DlmsConnectionManager conn, final DlmsDevice device, final short channel)
+      throws NotSupportedByProtocolException {
+    return new CosemObjectAccessor(
+        conn,
+        this.objectConfigServiceHelper,
+        MBUS_CLIENT_SETUP,
+        Protocol.forDevice(device),
+        channel);
   }
 }

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/mbus/GetMbusEncryptionKeyStatusCommandExecutor.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/mbus/GetMbusEncryptionKeyStatusCommandExecutor.java
@@ -32,9 +32,6 @@ public class GetMbusEncryptionKeyStatusCommandExecutor
     extends AbstractCommandExecutor<
         GetMbusEncryptionKeyStatusRequestDto, GetMbusEncryptionKeyStatusResponseDto> {
 
-  //  private static final MbusClientAttribute ATTRIBUTE_ID =
-  // MbusClientAttribute.ENCRYPTION_KEY_STATUS;
-
   private final ObjectConfigServiceHelper objectConfigServiceHelper;
 
   public GetMbusEncryptionKeyStatusCommandExecutor(


### PR DESCRIPTION
Implemented object config for two commandexecutors:
- GetMbusEncryptionKeyStatus(ByChannel)CommandExecutor
- ScanMbusChannelsCommandExecutor

Other 'mbus' commandexecutor use DeviceChannelsHelper and CosemObjectAccessor which were modified to use the new object config in earliers PRs. For these commandexecutor cucumber tests were extended to cover all protocol versions. 
