### PR TITLE
Remove flyway migration to prevent rollback scenario

### DIFF
--- a/osgp/platform/osgp-throttling-service/src/main/resources/db/migration/V20240730093600001__remove_permit.sql
+++ b/osgp/platform/osgp-throttling-service/src/main/resources/db/migration/V20240730093600001__remove_permit.sql
@@ -1,1 +1,0 @@
-DROP TABLE permit;

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/pom.xml
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/pom.xml
@@ -306,11 +306,6 @@ SPDX-License-Identifier: Apache-2.0
       <version>${cxf.version}</version>
     </dependency>
 
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-    </dependency>
-
     <!-- Spring JMS -->
     <dependency>
       <groupId>org.springframework</groupId>

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/pom.xml
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/pom.xml
@@ -6,8 +6,9 @@ SPDX-FileCopyrightText: Contributors to the GXF project
 SPDX-License-Identifier: Apache-2.0
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>osgp-protocol-adapter-dlms</artifactId>
@@ -82,7 +83,7 @@ SPDX-License-Identifier: Apache-2.0
   <!-- This repository was added to be able to draw the snapshot jDLMS version from artifactory -->
   <repositories>
     <repository>
-      <snapshots/>
+      <snapshots />
       <id>osgp-snapshots</id>
       <name>osgp-snapshots</name>
       <url>https://artifactory.shs.osgp.cloud/artifactory/osgp-snapshots</url>
@@ -303,6 +304,11 @@ SPDX-License-Identifier: Apache-2.0
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-rs-client</artifactId>
       <version>${cxf.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
     </dependency>
 
     <!-- Spring JMS -->


### PR DESCRIPTION
The migration drops the PERMIT table. In case of a rollback the table drop should be reverted. To prevent this scenarion we can remove the table when throttling is confirmed to work as desired in production.

Story to remove table is created.