### PR TITLE
Do not drop permit table, which removes the need to have a rollback scenario

### DIFF
--- a/osgp/platform/osgp-throttling-service/src/main/resources/db/migration/V20240730093600001__remove_permit.sql
+++ b/osgp/platform/osgp-throttling-service/src/main/resources/db/migration/V20240730093600001__remove_permit.sql
@@ -1,1 +1,0 @@
-DROP TABLE permit;


### PR DESCRIPTION
The migration drops the PERMIT table. In case of a rollback the table drop should be reverted. To prevent this scenarion we can remove the table when throttling is confirmed to work as desired in production.

Story to remove table is created.