### PR TITLE
spring (security) version upgrade to 6.1.14 (6.2.7)

### DIFF
--- a/super/pom.xml
+++ b/super/pom.xml
@@ -49,11 +49,12 @@ SPDX-License-Identifier: Apache-2.0
     <osgp.dlms.version>6.9.0-SNAPSHOT</osgp.dlms.version>
     <osgp.shared.version>6.9.0-SNAPSHOT</osgp.shared.version>
     <osgp.jasper-interface.version>6.9.0-SNAPSHOT</osgp.jasper-interface.version>
-    <spring.version>6.1.9</spring.version>
+    <spring.version>6.1.14</spring.version>
     <spring.data.version>3.2.5</spring.data.version>
     <spring.data.commons.version>3.3.1</spring.data.commons.version>
-    <spring.security.version>6.2.3</spring.security.version>
+    <spring.security.version>6.2.7</spring.security.version>
     <spring.ws.version>4.0.11</spring.ws.version>
+    <spring.integration.version>6.3.5</spring.integration.version>
     <reactor.version>2023.0.7</reactor.version>
     <assertj.version>3.16.1</assertj.version>
     <xmlunit.version>1.6</xmlunit.version>
@@ -482,7 +483,7 @@ SPDX-License-Identifier: Apache-2.0
       <dependency>
         <groupId>org.springframework.integration</groupId>
         <artifactId>spring-integration-ip</artifactId>
-        <version>${spring.version}</version>
+        <version>${spring.integration.version}</version>
       </dependency>
       <dependency>
         <groupId>io.projectreactor</groupId>


### PR DESCRIPTION
spring (security) version upgrade to 6.1.14 (6.2.7)

critical and high vulnerabilities:
https://github.com/OSGP/open-smart-grid-platform/security/dependabot
