### PR TITLE
Revert "Bump org.apache.kafka:kafka-clients from 3.6.1 to 3.9.0"

### DIFF
--- a/super/pom.xml
+++ b/super/pom.xml
@@ -139,7 +139,7 @@ SPDX-License-Identifier: Apache-2.0
     <postgresql.version>42.7.2</postgresql.version>
     <jakarta.xml.soap-api.version>3.0.1</jakarta.xml.soap-api.version>
     <!-- to avoid conflicts with spring-kafka-test the older kafka version 2.4.1 is used-->
-    <kafka.version>3.9.0</kafka.version>
+    <kafka.version>3.6.1</kafka.version>
     <avro.version>1.11.4</avro.version>
     <spring.kafka.version>3.1.4</spring.kafka.version>
     <!-- spring-kafka-test needs a 2.12 version of the scala libraries -->


### PR DESCRIPTION
This reverts commit e43b06cb42fe7f58b443c696e44fb64a96c14799.