### PR TITLE
sonarcloud-issues-2024-12-06

### DIFF
--- a/integration-tests/cucumber-tests-core/src/test/java/org/opensmartgridplatform/cucumber/core/DateTimeHelper.java
+++ b/integration-tests/cucumber-tests-core/src/test/java/org/opensmartgridplatform/cucumber/core/DateTimeHelper.java
@@ -93,8 +93,7 @@ public class DateTimeHelper {
       case "yesterday":
         retval = retval.minusDays(1);
         break;
-      case "now":
-      case "today":
+      case "now", "today":
         break;
       default:
         throw new IllegalArgumentException(
@@ -110,8 +109,7 @@ public class DateTimeHelper {
     if (whenMatcher.groupCount() > 1 && whenMatcher.group(2).equals("at")) {
 
       switch (whenMatcher.group(3)) {
-        case "midday":
-        case "noon":
+        case "midday", "noon":
           retval = retval.withHour(12);
           break;
         case "midnight":
@@ -147,6 +145,8 @@ public class DateTimeHelper {
         case "years":
           retval = retval.plusYears(numberToAddOrSubstract);
           break;
+        default:
+          // do nothing
       }
     } else {
       switch (what) {
@@ -168,6 +168,8 @@ public class DateTimeHelper {
         case "years":
           retval = retval.minusYears(numberToAddOrSubstract);
           break;
+        default:
+          // do nothing
       }
     }
 
@@ -192,7 +194,7 @@ public class DateTimeHelper {
     try {
       dateTime = getDateTime(startDate);
     } catch (final IllegalArgumentException e) {
-      LOGGER.debug("The string {} could not be parsed by DateTimeHelper.getDateTime");
+      LOGGER.debug("The string {} could not be parsed by DateTimeHelper.getDateTime", startDate);
       dateTime = JavaTimeHelpers.parseToZonedDateTime(startDate);
     }
     if (dateTime == null) {

--- a/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/config/AdapterWsCorePersistenceConfig.java
+++ b/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/config/AdapterWsCorePersistenceConfig.java
@@ -28,8 +28,6 @@ public class AdapterWsCorePersistenceConfig extends ApplicationPersistenceConfig
   @Value("${entitymanager.packages.to.scan.osgp_adapter_ws_core}")
   private String entitymanagerPackagesToScan;
 
-  public AdapterWsCorePersistenceConfig() {}
-
   @Override
   protected String getDatabaseName() {
     return this.databaseName;

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/config/AdapterProtocolDlmsPersistenceConfig.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/config/AdapterProtocolDlmsPersistenceConfig.java
@@ -23,8 +23,6 @@ import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
     basePackageClasses = {DlmsDeviceRepository.class})
 public class AdapterProtocolDlmsPersistenceConfig extends ApplicationPersistenceConfiguration {
 
-  public AdapterProtocolDlmsPersistenceConfig() {}
-
   @Value("${db.name.osgp_adapter_protocol_dlms}")
   private String databaseName;
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/config/AdapterWsSmartMeteringPersistenceConfig.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/config/AdapterWsSmartMeteringPersistenceConfig.java
@@ -30,8 +30,6 @@ public class AdapterWsSmartMeteringPersistenceConfig extends ApplicationPersiste
   @Value("${entitymanager.packages.to.scan}")
   private String entitymanagerPackagesToScan;
 
-  public AdapterWsSmartMeteringPersistenceConfig() {}
-
   @Override
   protected String getDatabaseName() {
     return this.databaseName;

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/config/DlmsSimulatorConfig.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/config/DlmsSimulatorConfig.java
@@ -14,8 +14,6 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class DlmsSimulatorConfig extends AbstractConfig {
 
-  public DlmsSimulatorConfig() {}
-
   @Value("${dynamic.properties.base.url}")
   private String dynamicPropertiesBaseUrl;
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/config/SecretManagementPersistenceConfig.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/config/SecretManagementPersistenceConfig.java
@@ -31,8 +31,6 @@ public class SecretManagementPersistenceConfig extends ApplicationPersistenceCon
   @Value("${entitymanager.packages.to.scan.secret_management}")
   private String entitymanagerPackagesToScan;
 
-  public SecretManagementPersistenceConfig() {}
-
   /**
    * Method for creating the Data Source.
    *

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringbundle/BundledGetPowerQualityProfileDataSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringbundle/BundledGetPowerQualityProfileDataSteps.java
@@ -195,8 +195,6 @@ public class BundledGetPowerQualityProfileDataSteps extends BaseBundleSteps {
         .isEqualTo(Long.valueOf(expectedCaptureObject.get(DATA_INDEX)));
     assertThat(captureObject.getUnit())
         .isEqualTo(OsgpUnitType.valueOf(expectedCaptureObject.get(UNIT)));
-
-    this.validateValues(captureObject, expectedCaptureObjects);
   }
 
   private Map<String, String> getExpectedCaptureObject(
@@ -213,9 +211,6 @@ public class BundledGetPowerQualityProfileDataSteps extends BaseBundleSteps {
     assertThat(optExpectedCaptureObject).isPresent();
     return optExpectedCaptureObject.get();
   }
-
-  private void validateValues(
-      final CaptureObject captureObject, final List<Map<String, String>> expectedCaptureObjects) {}
 
   private void logData(final PowerQualityProfileData powerQualityProfileData) {
     log.info("| classId | logicalName | attributeIndex | dataIndex | unit |");

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/SetPushSetupSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/SetPushSetupSteps.java
@@ -18,6 +18,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.opensmartgridplatform.adapter.ws.schema.smartmetering.adhoc.GetSpecificAttributeValueAsyncRequest;
 import org.opensmartgridplatform.adapter.ws.schema.smartmetering.adhoc.GetSpecificAttributeValueAsyncResponse;
 import org.opensmartgridplatform.adapter.ws.schema.smartmetering.adhoc.GetSpecificAttributeValueRequest;
@@ -30,13 +31,9 @@ import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smar
 import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ws.smartmetering.adhoc.SmartMeteringAdHocResponseClient;
 import org.opensmartgridplatform.dlms.interfaceclass.attribute.PushSetupAttribute;
 import org.opensmartgridplatform.shared.exceptionhandling.WebServiceSecurityException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public class SetPushSetupSteps {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(SetPushSetupSteps.class);
 
   @Autowired
   private SmartMeteringAdHocRequestClient<
@@ -50,14 +47,13 @@ public class SetPushSetupSteps {
 
   static void storeInScenario(final Map<String, String> settings, final String correlationUid) {
     ScenarioContext.current().put(PlatformSmartmeteringKeys.KEY_CORRELATION_UID, correlationUid);
-    List.of(
+    Stream.of(
             HOSTNAME,
             PORT,
             PUSH_OBJECT_ATTRIBUTE_IDS,
             PUSH_OBJECT_CLASS_IDS,
             PUSH_OBJECT_DATA_INDEXES,
             PUSH_OBJECT_OBIS_CODES)
-        .stream()
         .forEach(key -> ScenarioContext.current().put(key, settings.get(key)));
   }
 
@@ -77,6 +73,9 @@ public class SetPushSetupSteps {
         break;
       case COMMUNICATION_WINDOW:
         this.checkCommunicationWindow(pushSetupType, specificAttributeValues);
+        break;
+      default:
+        // other checks are not implemented
         break;
     }
   }
@@ -120,37 +119,36 @@ public class SetPushSetupSteps {
     assertThat(pushObjectDataIndexes)
         .as("test request is expected to have 3 data indexes")
         .hasSize(3);
-    final String expected =
-        String.format(
-            "DataObject: Choice=ARRAY, ResultData isComplex, value=[java.util.LinkedList]: [\n"
-                + "\tDataObject: Choice=STRUCTURE, ResultData isComplex, value=[java.util.LinkedList]: [\n"
-                + "\tDataObject: Choice=LONG_UNSIGNED, ResultData isNumber, value=[java.lang.Integer]: %s\n"
-                + "\tDataObject: Choice=OCTET_STRING, ResultData isByteArray, value=[[B]: logical name: %s\n"
-                + "\tDataObject: Choice=INTEGER, ResultData isNumber, value=[java.lang.Byte]: %s\n"
-                + "\tDataObject: Choice=LONG_UNSIGNED, ResultData isNumber, value=[java.lang.Integer]: %s\n]\n\n"
-                + "\tDataObject: Choice=STRUCTURE, ResultData isComplex, value=[java.util.LinkedList]: [\n"
-                + "\tDataObject: Choice=LONG_UNSIGNED, ResultData isNumber, value=[java.lang.Integer]: %s\n"
-                + "\tDataObject: Choice=OCTET_STRING, ResultData isByteArray, value=[[B]: logical name: %s\n"
-                + "\tDataObject: Choice=INTEGER, ResultData isNumber, value=[java.lang.Byte]: %s\n"
-                + "\tDataObject: Choice=LONG_UNSIGNED, ResultData isNumber, value=[java.lang.Integer]: %s\n]\n\n"
-                + "\tDataObject: Choice=STRUCTURE, ResultData isComplex, value=[java.util.LinkedList]: [\n"
-                + "\tDataObject: Choice=LONG_UNSIGNED, ResultData isNumber, value=[java.lang.Integer]: %s\n"
-                + "\tDataObject: Choice=OCTET_STRING, ResultData isByteArray, value=[[B]: logical name: %s\n"
-                + "\tDataObject: Choice=INTEGER, ResultData isNumber, value=[java.lang.Byte]: %s\n"
-                + "\tDataObject: Choice=LONG_UNSIGNED, ResultData isNumber, value=[java.lang.Integer]: %s\n]\n\n]\n",
-            pushObjectClassIds.get(0),
-            pushObjectObisCodes.get(0),
-            pushObjectAttributeIds.get(0),
-            pushObjectDataIndexes.get(0),
-            pushObjectClassIds.get(1),
-            pushObjectObisCodes.get(1),
-            pushObjectAttributeIds.get(1),
-            pushObjectDataIndexes.get(1),
-            pushObjectClassIds.get(2),
-            pushObjectObisCodes.get(2),
-            pushObjectAttributeIds.get(2),
-            pushObjectDataIndexes.get(2));
-    return expected;
+    return String.format(
+        """
+                DataObject: Choice=ARRAY, ResultData isComplex, value=[java.util.LinkedList]: [\n
+                \tDataObject: Choice=STRUCTURE, ResultData isComplex, value=[java.util.LinkedList]: [\n
+                \tDataObject: Choice=LONG_UNSIGNED, ResultData isNumber, value=[java.lang.Integer]: %s\n
+                \tDataObject: Choice=OCTET_STRING, ResultData isByteArray, value=[[B]: logical name: %s\n
+                \tDataObject: Choice=INTEGER, ResultData isNumber, value=[java.lang.Byte]: %s\n
+                \tDataObject: Choice=LONG_UNSIGNED, ResultData isNumber, value=[java.lang.Integer]: %s\n]\n\n
+                \tDataObject: Choice=STRUCTURE, ResultData isComplex, value=[java.util.LinkedList]: [\n
+                \tDataObject: Choice=LONG_UNSIGNED, ResultData isNumber, value=[java.lang.Integer]: %s\n
+                \tDataObject: Choice=OCTET_STRING, ResultData isByteArray, value=[[B]: logical name: %s\n
+                \tDataObject: Choice=INTEGER, ResultData isNumber, value=[java.lang.Byte]: %s\n
+                \tDataObject: Choice=LONG_UNSIGNED, ResultData isNumber, value=[java.lang.Integer]: %s\n]\n\n
+                \tDataObject: Choice=STRUCTURE, ResultData isComplex, value=[java.util.LinkedList]: [\n
+                \tDataObject: Choice=LONG_UNSIGNED, ResultData isNumber, value=[java.lang.Integer]: %s\n
+                \tDataObject: Choice=OCTET_STRING, ResultData isByteArray, value=[[B]: logical name: %s\n
+                \tDataObject: Choice=INTEGER, ResultData isNumber, value=[java.lang.Byte]: %s\n
+                \tDataObject: Choice=LONG_UNSIGNED, ResultData isNumber, value=[java.lang.Integer]: %s\n]\n\n]\n""",
+        pushObjectClassIds.get(0),
+        pushObjectObisCodes.get(0),
+        pushObjectAttributeIds.get(0),
+        pushObjectDataIndexes.get(0),
+        pushObjectClassIds.get(1),
+        pushObjectObisCodes.get(1),
+        pushObjectAttributeIds.get(1),
+        pushObjectDataIndexes.get(1),
+        pushObjectClassIds.get(2),
+        pushObjectObisCodes.get(2),
+        pushObjectAttributeIds.get(2),
+        pushObjectDataIndexes.get(2));
   }
 
   private static String getStringFromScenario(final String key) {

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/SetPushSetupSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/SetPushSetupSteps.java
@@ -122,26 +122,26 @@ public class SetPushSetupSteps {
     return String.format(
         """
            DataObject: Choice=ARRAY, ResultData isComplex, value=[java.util.LinkedList]: [
-             DataObject: Choice=STRUCTURE, ResultData isComplex, value=[java.util.LinkedList]: [
-               DataObject: Choice=LONG_UNSIGNED, ResultData isNumber, value=[java.lang.Integer]: %s
-               DataObject: Choice=OCTET_STRING, ResultData isByteArray, value=[[B]: logical name: %s
-               DataObject: Choice=INTEGER, ResultData isNumber, value=[java.lang.Byte]: %s
-               DataObject: Choice=LONG_UNSIGNED, ResultData isNumber, value=[java.lang.Integer]: %s
-             ]
+           \tDataObject: Choice=STRUCTURE, ResultData isComplex, value=[java.util.LinkedList]: [
+           \tDataObject: Choice=LONG_UNSIGNED, ResultData isNumber, value=[java.lang.Integer]: %s
+           \tDataObject: Choice=OCTET_STRING, ResultData isByteArray, value=[[B]: logical name: %s
+           \tDataObject: Choice=INTEGER, ResultData isNumber, value=[java.lang.Byte]: %s
+           \tDataObject: Choice=LONG_UNSIGNED, ResultData isNumber, value=[java.lang.Integer]: %s
+           ]
 
-             DataObject: Choice=STRUCTURE, ResultData isComplex, value=[java.util.LinkedList]: [
-               DataObject: Choice=LONG_UNSIGNED, ResultData isNumber, value=[java.lang.Integer]: %s
-               DataObject: Choice=OCTET_STRING, ResultData isByteArray, value=[[B]: logical name: %s
-               DataObject: Choice=INTEGER, ResultData isNumber, value=[java.lang.Byte]: %s
-               DataObject: Choice=LONG_UNSIGNED, ResultData isNumber, value=[java.lang.Integer]: %s
-             ]
+           \tDataObject: Choice=STRUCTURE, ResultData isComplex, value=[java.util.LinkedList]: [
+           \tDataObject: Choice=LONG_UNSIGNED, ResultData isNumber, value=[java.lang.Integer]: %s
+           \tDataObject: Choice=OCTET_STRING, ResultData isByteArray, value=[[B]: logical name: %s
+           \tDataObject: Choice=INTEGER, ResultData isNumber, value=[java.lang.Byte]: %s
+           \tDataObject: Choice=LONG_UNSIGNED, ResultData isNumber, value=[java.lang.Integer]: %s
+           ]
 
-             DataObject: Choice=STRUCTURE, ResultData isComplex, value=[java.util.LinkedList]: [
-               DataObject: Choice=LONG_UNSIGNED, ResultData isNumber, value=[java.lang.Integer]: %s
-               DataObject: Choice=OCTET_STRING, ResultData isByteArray, value=[[B]: logical name: %s
-               DataObject: Choice=INTEGER, ResultData isNumber, value=[java.lang.Byte]: %s
-               DataObject: Choice=LONG_UNSIGNED, ResultData isNumber, value=[java.lang.Integer]: %s
-             ]
+           \tDataObject: Choice=STRUCTURE, ResultData isComplex, value=[java.util.LinkedList]: [
+           \tDataObject: Choice=LONG_UNSIGNED, ResultData isNumber, value=[java.lang.Integer]: %s
+           \tDataObject: Choice=OCTET_STRING, ResultData isByteArray, value=[[B]: logical name: %s
+           \tDataObject: Choice=INTEGER, ResultData isNumber, value=[java.lang.Byte]: %s
+           \tDataObject: Choice=LONG_UNSIGNED, ResultData isNumber, value=[java.lang.Integer]: %s
+           ]
 
            ]""",
         pushObjectClassIds.get(0),

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/SetPushSetupSteps.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/steps/ws/smartmetering/smartmeteringconfiguration/SetPushSetupSteps.java
@@ -121,22 +121,29 @@ public class SetPushSetupSteps {
         .hasSize(3);
     return String.format(
         """
-                DataObject: Choice=ARRAY, ResultData isComplex, value=[java.util.LinkedList]: [\n
-                \tDataObject: Choice=STRUCTURE, ResultData isComplex, value=[java.util.LinkedList]: [\n
-                \tDataObject: Choice=LONG_UNSIGNED, ResultData isNumber, value=[java.lang.Integer]: %s\n
-                \tDataObject: Choice=OCTET_STRING, ResultData isByteArray, value=[[B]: logical name: %s\n
-                \tDataObject: Choice=INTEGER, ResultData isNumber, value=[java.lang.Byte]: %s\n
-                \tDataObject: Choice=LONG_UNSIGNED, ResultData isNumber, value=[java.lang.Integer]: %s\n]\n\n
-                \tDataObject: Choice=STRUCTURE, ResultData isComplex, value=[java.util.LinkedList]: [\n
-                \tDataObject: Choice=LONG_UNSIGNED, ResultData isNumber, value=[java.lang.Integer]: %s\n
-                \tDataObject: Choice=OCTET_STRING, ResultData isByteArray, value=[[B]: logical name: %s\n
-                \tDataObject: Choice=INTEGER, ResultData isNumber, value=[java.lang.Byte]: %s\n
-                \tDataObject: Choice=LONG_UNSIGNED, ResultData isNumber, value=[java.lang.Integer]: %s\n]\n\n
-                \tDataObject: Choice=STRUCTURE, ResultData isComplex, value=[java.util.LinkedList]: [\n
-                \tDataObject: Choice=LONG_UNSIGNED, ResultData isNumber, value=[java.lang.Integer]: %s\n
-                \tDataObject: Choice=OCTET_STRING, ResultData isByteArray, value=[[B]: logical name: %s\n
-                \tDataObject: Choice=INTEGER, ResultData isNumber, value=[java.lang.Byte]: %s\n
-                \tDataObject: Choice=LONG_UNSIGNED, ResultData isNumber, value=[java.lang.Integer]: %s\n]\n\n]\n""",
+           DataObject: Choice=ARRAY, ResultData isComplex, value=[java.util.LinkedList]: [
+             DataObject: Choice=STRUCTURE, ResultData isComplex, value=[java.util.LinkedList]: [
+               DataObject: Choice=LONG_UNSIGNED, ResultData isNumber, value=[java.lang.Integer]: %s
+               DataObject: Choice=OCTET_STRING, ResultData isByteArray, value=[[B]: logical name: %s
+               DataObject: Choice=INTEGER, ResultData isNumber, value=[java.lang.Byte]: %s
+               DataObject: Choice=LONG_UNSIGNED, ResultData isNumber, value=[java.lang.Integer]: %s
+             ]
+
+             DataObject: Choice=STRUCTURE, ResultData isComplex, value=[java.util.LinkedList]: [
+               DataObject: Choice=LONG_UNSIGNED, ResultData isNumber, value=[java.lang.Integer]: %s
+               DataObject: Choice=OCTET_STRING, ResultData isByteArray, value=[[B]: logical name: %s
+               DataObject: Choice=INTEGER, ResultData isNumber, value=[java.lang.Byte]: %s
+               DataObject: Choice=LONG_UNSIGNED, ResultData isNumber, value=[java.lang.Integer]: %s
+             ]
+
+             DataObject: Choice=STRUCTURE, ResultData isComplex, value=[java.util.LinkedList]: [
+               DataObject: Choice=LONG_UNSIGNED, ResultData isNumber, value=[java.lang.Integer]: %s
+               DataObject: Choice=OCTET_STRING, ResultData isByteArray, value=[[B]: logical name: %s
+               DataObject: Choice=INTEGER, ResultData isNumber, value=[java.lang.Byte]: %s
+               DataObject: Choice=LONG_UNSIGNED, ResultData isNumber, value=[java.lang.Integer]: %s
+             ]
+
+           ]""",
         pushObjectClassIds.get(0),
         pushObjectObisCodes.get(0),
         pushObjectAttributeIds.get(0),

--- a/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/config/CorePersistenceConfig.java
+++ b/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/config/CorePersistenceConfig.java
@@ -29,8 +29,6 @@ public class CorePersistenceConfig extends ApplicationPersistenceConfiguration {
   @Value("${entitymanager.packages.to.scan.core}")
   private String entitymanagerPackagesToScan;
 
-  public CorePersistenceConfig() {}
-
   /**
    * Method for creating the Data Source.
    *

--- a/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/config/LoggingPersistenceConfig.java
+++ b/integration-tests/cucumber-tests-platform/src/test/java/org/opensmartgridplatform/cucumber/platform/config/LoggingPersistenceConfig.java
@@ -28,8 +28,6 @@ public class LoggingPersistenceConfig extends ApplicationPersistenceConfiguratio
   @Value("${entitymanager.packages.to.scan.logging}")
   private String entitymanagerPackagesToScan;
 
-  public LoggingPersistenceConfig() {}
-
   @Override
   protected String getDatabaseName() {
     return this.databaseName;

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/test/java/org/opensmartgridplatform/adapter/domain/smartmetering/application/services/MonitoringServiceTest.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/test/java/org/opensmartgridplatform/adapter/domain/smartmetering/application/services/MonitoringServiceTest.java
@@ -42,8 +42,6 @@ class MonitoringServiceTest {
 
   public static final String NETWORK_ADDRESS = "127.0.0.1";
 
-  private static final String DEVICE_MODEL_CODE = "BK-G4 ETB WR";
-
   public static final int BTS_580 = 580;
 
   public static final int CELL_ID_1 = 1;
@@ -123,8 +121,6 @@ class MonitoringServiceTest {
         MonitoringService.class.getMethod(methodName, MessageMetadata.class, clazz);
     method.invoke(this.monitoringService, messageMetadata, mock(clazz));
   }
-
-  private void verifyMessageMetadata() {}
 
   private static SmartMeter mockSmartMeter(final String deviceModelCode, final Short channel) {
     final DeviceModel deviceModel = mock(DeviceModel.class);

--- a/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/test/java/org/opensmartgridplatform/adapter/protocol/jasper/rest/client/JasperWirelessTerminalRestClientTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/test/java/org/opensmartgridplatform/adapter/protocol/jasper/rest/client/JasperWirelessTerminalRestClientTest.java
@@ -34,7 +34,7 @@ import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
 
 @ExtendWith(MockitoExtension.class)
-public class JasperWirelessTerminalRestClientTest {
+class JasperWirelessTerminalRestClientTest {
 
   private static final String SERVICE_GET_SESSION_INFO = "/rws/api/%s/devices/%s/sessionInfo";
   private static final String ICCID = "12345";
@@ -69,7 +69,7 @@ public class JasperWirelessTerminalRestClientTest {
   }
 
   @Test
-  public void testOk() throws OsgpJasperException {
+  void testOk() throws OsgpJasperException {
 
     when(this.jasperwirelessRestTemplate.exchange(
             eq(URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(GetSessionInfoResponse.class)))
@@ -83,7 +83,7 @@ public class JasperWirelessTerminalRestClientTest {
   }
 
   @Test
-  public void testExpiredSession() throws OsgpJasperException {
+  void testExpiredSession() throws OsgpJasperException {
 
     when(this.jasperwirelessRestTemplate.exchange(
             eq(URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(GetSessionInfoResponse.class)))
@@ -97,7 +97,7 @@ public class JasperWirelessTerminalRestClientTest {
   }
 
   @Test
-  public void testNeverHadSession() throws OsgpJasperException {
+  void testNeverHadSession() throws OsgpJasperException {
 
     when(this.jasperwirelessRestTemplate.exchange(
             eq(URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(GetSessionInfoResponse.class)))
@@ -111,7 +111,7 @@ public class JasperWirelessTerminalRestClientTest {
   }
 
   @Test
-  public void testInvalidIccId() throws OsgpJasperException {
+  void testInvalidIccId() {
 
     when(this.jasperwirelessRestTemplate.exchange(
             eq(URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(GetSessionInfoResponse.class)))
@@ -127,7 +127,7 @@ public class JasperWirelessTerminalRestClientTest {
   }
 
   @Test
-  public void testUnmappedErrorException() throws OsgpJasperException {
+  void testUnmappedErrorException() {
 
     when(this.jasperwirelessRestTemplate.exchange(
             eq(URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(GetSessionInfoResponse.class)))
@@ -156,9 +156,9 @@ public class JasperWirelessTerminalRestClientTest {
 
   private ResponseEntity<GetSessionInfoResponse> createResponseEntity(
       final HttpStatus httpStatus, final SessionType sessionType) {
-    Date endSession;
-    Date startSession;
-    String ipAddress;
+    final Date endSession;
+    final Date startSession;
+    final String ipAddress;
     switch (sessionType) {
       case EXPIRED_SESSION:
         startSession = new Date(Instant.now().minus(6, ChronoUnit.MINUTES).toEpochMilli());
@@ -170,10 +170,6 @@ public class JasperWirelessTerminalRestClientTest {
         endSession = null;
         ipAddress = IP_ADDRESS;
         break;
-      case NEVER_HAD_SESSION:
-        startSession = null;
-        endSession = null;
-        ipAddress = null;
       default:
         startSession = null;
         endSession = null;

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/application/services/FirmwareServiceTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/application/services/FirmwareServiceTest.java
@@ -56,24 +56,24 @@ public class FirmwareServiceTest {
   @InjectMocks private FirmwareService firmwareService;
 
   private static MessageMetadata messageMetadata;
-  private static final String firmwareIdentification = "firmware-file-1";
-  private static final String imageIdentifier = "496d6167654964656e746966696572";
-  private static final String deviceIdentification = "device-1";
+  private static final String FIRMWARE_IDENTIFICATION = "firmware-file-1";
+  private static final String IMAGE_IDENTIFIER = "496d6167654964656e746966696572";
+  private static final String DEVICE_IDENTIFICATION = "device-1";
   private static UpdateFirmwareRequestDto updateFirmwareRequestDto;
-  private static final String validMD5firmwareDigest = "48b5773e8b37a602d38a521e98cfc6a1";
+  private static final String VALID_MD5_FIRMWARE_DIGEST = "48b5773e8b37a602d38a521e98cfc6a1";
 
   @BeforeAll
   public static void init() {
     messageMetadata = MessageMetadata.newBuilder().withCorrelationUid("123456").build();
     updateFirmwareRequestDto =
-        createUpdateFirmwareRequestDto(HashTypeDto.MD5, validMD5firmwareDigest);
+        createUpdateFirmwareRequestDto(HashTypeDto.MD5, VALID_MD5_FIRMWARE_DIGEST);
   }
 
   private static UpdateFirmwareRequestDto createUpdateFirmwareRequestDto(
       final HashTypeDto hashTypeDto, final String firmwareDigest) {
     return new UpdateFirmwareRequestDto(
-        deviceIdentification,
-        new UpdateFirmwareRequestDataDto(firmwareIdentification, hashTypeDto, firmwareDigest));
+        DEVICE_IDENTIFICATION,
+        new UpdateFirmwareRequestDataDto(FIRMWARE_IDENTIFICATION, hashTypeDto, firmwareDigest));
   }
 
   @Test
@@ -87,15 +87,15 @@ public class FirmwareServiceTest {
 
   @Test
   void updateFirmwareWhenAllInCache() throws OsgpException {
-    final byte[] firmwareFile = firmwareIdentification.getBytes();
-    final byte[] firmwareImageIdentifier = Hex.decode(imageIdentifier);
+    final byte[] firmwareFile = FIRMWARE_IDENTIFICATION.getBytes();
+    final byte[] firmwareImageIdentifier = Hex.decode(IMAGE_IDENTIFIER);
 
-    when(this.firmwareFileCachingRepository.isAvailable(firmwareIdentification)).thenReturn(true);
-    when(this.firmwareFileCachingRepository.retrieve(firmwareIdentification))
+    when(this.firmwareFileCachingRepository.isAvailable(FIRMWARE_IDENTIFICATION)).thenReturn(true);
+    when(this.firmwareFileCachingRepository.retrieve(FIRMWARE_IDENTIFICATION))
         .thenReturn(firmwareFile);
-    when(this.firmwareImageIdentifierCachingRepository.isAvailable(firmwareIdentification))
+    when(this.firmwareImageIdentifierCachingRepository.isAvailable(FIRMWARE_IDENTIFICATION))
         .thenReturn(true);
-    when(this.firmwareImageIdentifierCachingRepository.retrieve(firmwareIdentification))
+    when(this.firmwareImageIdentifierCachingRepository.retrieve(FIRMWARE_IDENTIFICATION))
         .thenReturn(firmwareImageIdentifier);
 
     this.firmwareService.updateFirmware(
@@ -118,17 +118,17 @@ public class FirmwareServiceTest {
 
   @Test
   void updateFirmwareWhenFirmwareFileNotInCache() throws OsgpException {
-    final byte[] firmwareFile = firmwareIdentification.getBytes();
-    final byte[] firmwareImageIdentifier = Hex.decode(imageIdentifier);
+    final byte[] firmwareFile = FIRMWARE_IDENTIFICATION.getBytes();
+    final byte[] firmwareImageIdentifier = Hex.decode(IMAGE_IDENTIFIER);
 
-    when(this.firmwareFileCachingRepository.isAvailable(firmwareIdentification)).thenReturn(false);
-    when(this.firmwareFileStoreService.readFirmwareFile(firmwareIdentification))
+    when(this.firmwareFileCachingRepository.isAvailable(FIRMWARE_IDENTIFICATION)).thenReturn(false);
+    when(this.firmwareFileStoreService.readFirmwareFile(FIRMWARE_IDENTIFICATION))
         .thenReturn(firmwareFile);
-    when(this.firmwareFileCachingRepository.retrieve(firmwareIdentification))
+    when(this.firmwareFileCachingRepository.retrieve(FIRMWARE_IDENTIFICATION))
         .thenReturn(firmwareFile);
-    when(this.firmwareImageIdentifierCachingRepository.isAvailable(firmwareIdentification))
+    when(this.firmwareImageIdentifierCachingRepository.isAvailable(FIRMWARE_IDENTIFICATION))
         .thenReturn(true);
-    when(this.firmwareImageIdentifierCachingRepository.retrieve(firmwareIdentification))
+    when(this.firmwareImageIdentifierCachingRepository.retrieve(FIRMWARE_IDENTIFICATION))
         .thenReturn(firmwareImageIdentifier);
 
     this.firmwareService.updateFirmware(
@@ -137,8 +137,8 @@ public class FirmwareServiceTest {
         updateFirmwareRequestDto,
         messageMetadata);
 
-    verify(this.firmwareFileStoreService).readFirmwareFile(firmwareIdentification);
-    verify(this.firmwareFileCachingRepository).store(firmwareIdentification, firmwareFile);
+    verify(this.firmwareFileStoreService).readFirmwareFile(FIRMWARE_IDENTIFICATION);
+    verify(this.firmwareFileCachingRepository).store(FIRMWARE_IDENTIFICATION, firmwareFile);
     verify(this.firmwareImageIdentifierCachingRepository, never())
         .store(anyString(), any(byte[].class));
     verify(this.updateFirmwareCommandExecutor, times(1))
@@ -151,18 +151,18 @@ public class FirmwareServiceTest {
 
   @Test
   void updateFirmwareWhenImageIdentifierNotInCache() throws OsgpException {
-    final byte[] firmwareFile = firmwareIdentification.getBytes();
-    final byte[] firmwareImageIdentifier = Hex.decode(imageIdentifier);
+    final byte[] firmwareFile = FIRMWARE_IDENTIFICATION.getBytes();
+    final byte[] firmwareImageIdentifier = Hex.decode(IMAGE_IDENTIFIER);
 
-    when(this.firmwareFileCachingRepository.isAvailable(firmwareIdentification)).thenReturn(true);
-    when(this.firmwareFileCachingRepository.retrieve(firmwareIdentification))
+    when(this.firmwareFileCachingRepository.isAvailable(FIRMWARE_IDENTIFICATION)).thenReturn(true);
+    when(this.firmwareFileCachingRepository.retrieve(FIRMWARE_IDENTIFICATION))
         .thenReturn(firmwareFile);
 
-    when(this.firmwareImageIdentifierCachingRepository.isAvailable(firmwareIdentification))
+    when(this.firmwareImageIdentifierCachingRepository.isAvailable(FIRMWARE_IDENTIFICATION))
         .thenReturn(false);
-    when(this.firmwareFileStoreService.readImageIdentifier(firmwareIdentification))
+    when(this.firmwareFileStoreService.readImageIdentifier(FIRMWARE_IDENTIFICATION))
         .thenReturn(firmwareImageIdentifier);
-    when(this.firmwareImageIdentifierCachingRepository.retrieve(firmwareIdentification))
+    when(this.firmwareImageIdentifierCachingRepository.retrieve(FIRMWARE_IDENTIFICATION))
         .thenReturn(firmwareImageIdentifier);
 
     this.firmwareService.updateFirmware(
@@ -171,10 +171,10 @@ public class FirmwareServiceTest {
         updateFirmwareRequestDto,
         messageMetadata);
 
-    verify(this.firmwareFileStoreService).readImageIdentifier(firmwareIdentification);
+    verify(this.firmwareFileStoreService).readImageIdentifier(FIRMWARE_IDENTIFICATION);
     verify(this.firmwareImageIdentifierCachingRepository)
-        .store(firmwareIdentification, firmwareImageIdentifier);
-    verify(this.firmwareFileStoreService, never()).readFirmwareFile(firmwareIdentification);
+        .store(FIRMWARE_IDENTIFICATION, firmwareImageIdentifier);
+    verify(this.firmwareFileStoreService, never()).readFirmwareFile(FIRMWARE_IDENTIFICATION);
     verify(this.firmwareFileCachingRepository, never()).store(anyString(), any(byte[].class));
     verify(this.updateFirmwareCommandExecutor, times(1))
         .execute(
@@ -187,14 +187,14 @@ public class FirmwareServiceTest {
   @Test
   void updateFirmwareWhenFirmwareFileNotInCacheAndNotValid() throws OsgpException {
 
-    final byte[] firmwareFile = firmwareIdentification.getBytes();
+    final byte[] firmwareFile = FIRMWARE_IDENTIFICATION.getBytes();
     final HashTypeDto sha256 = HashTypeDto.SHA256;
 
-    when(this.firmwareFileCachingRepository.isAvailable(firmwareIdentification)).thenReturn(false);
-    when(this.firmwareFileStoreService.readFirmwareFile(firmwareIdentification))
+    when(this.firmwareFileCachingRepository.isAvailable(FIRMWARE_IDENTIFICATION)).thenReturn(false);
+    when(this.firmwareFileStoreService.readFirmwareFile(FIRMWARE_IDENTIFICATION))
         .thenReturn(firmwareFile);
 
-    updateFirmwareRequestDto = createUpdateFirmwareRequestDto(sha256, validMD5firmwareDigest);
+    updateFirmwareRequestDto = createUpdateFirmwareRequestDto(sha256, VALID_MD5_FIRMWARE_DIGEST);
     assertThatExceptionOfType(ProtocolAdapterException.class)
         .isThrownBy(
             () -> {
@@ -204,11 +204,12 @@ public class FirmwareServiceTest {
                   updateFirmwareRequestDto,
                   messageMetadata);
             })
-        .withMessageContainingAll(firmwareIdentification, sha256.getAlgorithmName());
+        .withMessageContainingAll(FIRMWARE_IDENTIFICATION, sha256.getAlgorithmName());
 
-    verify(this.firmwareFileStoreService).readFirmwareFile(firmwareIdentification);
-    verify(this.firmwareFileCachingRepository, never()).store(firmwareIdentification, firmwareFile);
-    verify(this.firmwareFileCachingRepository, never()).retrieve(firmwareIdentification);
+    verify(this.firmwareFileStoreService).readFirmwareFile(FIRMWARE_IDENTIFICATION);
+    verify(this.firmwareFileCachingRepository, never())
+        .store(FIRMWARE_IDENTIFICATION, firmwareFile);
+    verify(this.firmwareFileCachingRepository, never()).retrieve(FIRMWARE_IDENTIFICATION);
     verifyNoInteractions(this.firmwareImageIdentifierCachingRepository);
     verifyNoInteractions(this.updateFirmwareCommandExecutor);
   }
@@ -216,10 +217,10 @@ public class FirmwareServiceTest {
   @Test
   void updateFirmwareWhenFirmwareFileNotInCacheAndNotOnStore() throws OsgpException {
 
-    final byte[] firmwareFile = firmwareIdentification.getBytes();
+    final byte[] firmwareFile = FIRMWARE_IDENTIFICATION.getBytes();
 
-    when(this.firmwareFileCachingRepository.isAvailable(firmwareIdentification)).thenReturn(false);
-    when(this.firmwareFileStoreService.readFirmwareFile(firmwareIdentification)).thenReturn(null);
+    when(this.firmwareFileCachingRepository.isAvailable(FIRMWARE_IDENTIFICATION)).thenReturn(false);
+    when(this.firmwareFileStoreService.readFirmwareFile(FIRMWARE_IDENTIFICATION)).thenReturn(null);
 
     assertThatExceptionOfType(ProtocolAdapterException.class)
         .isThrownBy(
@@ -230,11 +231,12 @@ public class FirmwareServiceTest {
                   updateFirmwareRequestDto,
                   messageMetadata);
             })
-        .withMessageContainingAll(firmwareIdentification);
+        .withMessageContainingAll(FIRMWARE_IDENTIFICATION);
 
-    verify(this.firmwareFileStoreService).readFirmwareFile(firmwareIdentification);
-    verify(this.firmwareFileCachingRepository, never()).store(firmwareIdentification, firmwareFile);
-    verify(this.firmwareFileCachingRepository, never()).retrieve(firmwareIdentification);
+    verify(this.firmwareFileStoreService).readFirmwareFile(FIRMWARE_IDENTIFICATION);
+    verify(this.firmwareFileCachingRepository, never())
+        .store(FIRMWARE_IDENTIFICATION, firmwareFile);
+    verify(this.firmwareFileCachingRepository, never()).retrieve(FIRMWARE_IDENTIFICATION);
     verifyNoInteractions(this.firmwareImageIdentifierCachingRepository);
     verifyNoInteractions(this.updateFirmwareCommandExecutor);
   }
@@ -242,11 +244,11 @@ public class FirmwareServiceTest {
   @Test
   void updateFirmwareWhenStoreThrowsException() throws OsgpException {
 
-    final byte[] firmwareFile = firmwareIdentification.getBytes();
+    final byte[] firmwareFile = FIRMWARE_IDENTIFICATION.getBytes();
     final String storeExceptionMessage = "firmware file store failed!";
 
-    when(this.firmwareFileCachingRepository.isAvailable(firmwareIdentification)).thenReturn(false);
-    when(this.firmwareFileStoreService.readFirmwareFile(firmwareIdentification))
+    when(this.firmwareFileCachingRepository.isAvailable(FIRMWARE_IDENTIFICATION)).thenReturn(false);
+    when(this.firmwareFileStoreService.readFirmwareFile(FIRMWARE_IDENTIFICATION))
         .thenThrow(new ProtocolAdapterException(storeExceptionMessage));
 
     assertThatExceptionOfType(ProtocolAdapterException.class)
@@ -260,8 +262,9 @@ public class FirmwareServiceTest {
             })
         .withMessage(storeExceptionMessage);
 
-    verify(this.firmwareFileCachingRepository, never()).store(firmwareIdentification, firmwareFile);
-    verify(this.firmwareFileCachingRepository, never()).retrieve(firmwareIdentification);
+    verify(this.firmwareFileCachingRepository, never())
+        .store(FIRMWARE_IDENTIFICATION, firmwareFile);
+    verify(this.firmwareFileCachingRepository, never()).retrieve(FIRMWARE_IDENTIFICATION);
     verifyNoInteractions(this.firmwareImageIdentifierCachingRepository);
     verifyNoInteractions(this.updateFirmwareCommandExecutor);
   }

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/application/services/MacGenerationServiceTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/application/services/MacGenerationServiceTest.java
@@ -30,7 +30,7 @@ public class MacGenerationServiceTest {
   @InjectMocks MacGenerationService macGenerationService;
   @Mock SecretManagementService secretManagementService;
 
-  static final String fwFilename1 = "test-short-v00400011-snffffffff-newmods.bin";
+  static final String FW_FILENAME_1 = "test-short-v00400011-snffffffff-newmods.bin";
 
   final byte[] firmwareUpdateAuthenticationKey1 = Hex.decode("F9AA0123456789012345D7AFCCD41BD1");
   private final String deviceIdentification1 = "G0035161000054016";
@@ -46,7 +46,7 @@ public class MacGenerationServiceTest {
 
   @BeforeAll
   public static void init() throws IOException, ProtocolAdapterException {
-    byteArray1 = Files.readAllBytes(new ClassPathResource(fwFilename1).getFile().toPath());
+    byteArray1 = Files.readAllBytes(new ClassPathResource(FW_FILENAME_1).getFile().toPath());
     // Same firmware file but now with wildcarded mbusversion (Florian firmware)
     final FirmwareFile firmwareFile2 = new FirmwareFile(byteArray1);
     firmwareFile2.setMbusVersion(255);

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/firmware/firmwarefile/FirmwareFileTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/firmware/firmwarefile/FirmwareFileTest.java
@@ -42,7 +42,7 @@ class FirmwareFileTest {
     final FirmwareFileHeader header = firmwareFile.getHeader();
     log.debug(header.toString());
     assertThat(header.getFirmwareImageMagicNumberHex())
-        .contains(FirmwareFile.VALID_FIRMWARE_IMAGE_MAGIC_NUMBERS);
+        .isIn(FirmwareFile.VALID_FIRMWARE_IMAGE_MAGIC_NUMBERS);
     assertThat(header.getHeaderVersionInt()).isZero();
     assertThat(header.getHeaderLengthInt()).isEqualTo(35);
     assertThat(header.getFirmwareImageVersionHex()).isEqualTo("11004000");

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/firmware/firmwarefile/FirmwareFileTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/firmware/firmwarefile/FirmwareFileTest.java
@@ -9,7 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -26,25 +25,25 @@ import org.opensmartgridplatform.adapter.protocol.dlms.exceptions.ProtocolAdapte
 import org.springframework.core.io.ClassPathResource;
 
 @Slf4j
-public class FirmwareFileTest {
+class FirmwareFileTest {
 
-  private static final String filename = "test-short-v00400011-snffffffff-newmods.bin";
+  private static final String FILENAME = "test-short-v00400011-snffffffff-newmods.bin";
 
   private static byte[] byteArray;
 
   @BeforeEach
   public void init() throws IOException {
-    byteArray = Files.readAllBytes(new ClassPathResource(filename).getFile().toPath());
+    byteArray = Files.readAllBytes(new ClassPathResource(FILENAME).getFile().toPath());
   }
 
   @Test
-  public void testHeader() throws UnsupportedEncodingException {
+  void testHeader() {
     final FirmwareFile firmwareFile = new FirmwareFile(byteArray);
     final FirmwareFileHeader header = firmwareFile.getHeader();
     log.debug(header.toString());
-    assertThat(FirmwareFile.VALID_FIRMWARE_IMAGE_MAGIC_NUMBERS)
-        .contains(header.getFirmwareImageMagicNumberHex());
-    assertThat(header.getHeaderVersionInt()).isEqualTo(0);
+    assertThat(header.getFirmwareImageMagicNumberHex())
+        .contains(FirmwareFile.VALID_FIRMWARE_IMAGE_MAGIC_NUMBERS);
+    assertThat(header.getHeaderVersionInt()).isZero();
     assertThat(header.getHeaderLengthInt()).isEqualTo(35);
     assertThat(header.getFirmwareImageVersionHex()).isEqualTo("11004000");
     assertThat(header.getFirmwareImageLengthInt()).isEqualTo(1000 - (35 + 16));
@@ -62,8 +61,7 @@ public class FirmwareFileTest {
   }
 
   @Test
-  public void testFittingMbusDeviceIdentificationNumber()
-      throws IOException, ProtocolAdapterException {
+  void testFittingMbusDeviceIdentificationNumber() {
 
     final FirmwareFile firmwareFile = this.createPartialWildcardFirmwareFile("FFFF0000");
 
@@ -75,8 +73,7 @@ public class FirmwareFileTest {
   }
 
   @Test
-  public void testFittingMbusDeviceIdentificationNumberWithFullWildcard()
-      throws IOException, ProtocolAdapterException {
+  void testFittingMbusDeviceIdentificationNumberWithFullWildcard() {
 
     final FirmwareFile firmwareFile = this.createPartialWildcardFirmwareFile("FFFFFFFF");
 
@@ -89,8 +86,7 @@ public class FirmwareFileTest {
   }
 
   @Test
-  public void testMisfitMbusDeviceIdentificationNumber()
-      throws IOException, ProtocolAdapterException {
+  void testMisfitMbusDeviceIdentificationNumber() {
     final FirmwareFile firmwareFile = this.createPartialWildcardFirmwareFile("FFFF0000");
     final String reversedWildcard = "0000FFFF";
     final String identificationNumber = "00010000";
@@ -146,17 +142,16 @@ public class FirmwareFileTest {
 
   private FirmwareFile createPartialWildcardFirmwareFile(final String hexWildcard) {
     final byte[] clonedByteArray = byteArray.clone();
-    final byte[] byteArray = new BigInteger(hexWildcard.toLowerCase(), 16).toByteArray();
-    clonedByteArray[22] = byteArray[1];
-    clonedByteArray[23] = byteArray[2];
-    clonedByteArray[24] = byteArray[3];
-    clonedByteArray[25] = byteArray[4];
-    final FirmwareFile firmwareFile = new FirmwareFile(clonedByteArray);
-    return firmwareFile;
+    final byte[] sourceByteArray = new BigInteger(hexWildcard.toLowerCase(), 16).toByteArray();
+    clonedByteArray[22] = sourceByteArray[1];
+    clonedByteArray[23] = sourceByteArray[2];
+    clonedByteArray[24] = sourceByteArray[3];
+    clonedByteArray[25] = sourceByteArray[4];
+    return new FirmwareFile(clonedByteArray);
   }
 
   @Test
-  public void testMbusDeviceIdentificationNumber() throws IOException, ProtocolAdapterException {
+  void testMbusDeviceIdentificationNumber() throws ProtocolAdapterException {
     final String id = "10000540";
     final IdentificationNumber mbusDeviceIdentificationNumberInput =
         IdentificationNumber.fromTextualRepresentation(id);
@@ -178,7 +173,7 @@ public class FirmwareFileTest {
   }
 
   @Test
-  public void testImageIdentifierForMbusDevice() throws ProtocolAdapterException {
+  void testImageIdentifierForMbusDevice() throws ProtocolAdapterException {
     final FirmwareFile firmwareFile = new FirmwareFile(byteArray);
     firmwareFile.setMbusDeviceIdentificationNumber(
         IdentificationNumber.fromTextualRepresentation("16019864"));

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/stub/DlmsConnectionStub.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/commands/stub/DlmsConnectionStub.java
@@ -129,13 +129,19 @@ public class DlmsConnectionStub implements DlmsConnection {
   }
 
   @Override
-  public void changeClientGlobalAuthenticationKey(final byte[] var1) {}
+  public void changeClientGlobalAuthenticationKey(final byte[] var1) {
+    // not implemented for this stub class
+  }
 
   @Override
-  public void changeClientGlobalEncryptionKey(final byte[] var1) {}
+  public void changeClientGlobalEncryptionKey(final byte[] var1) {
+    // not implemented for this stub class
+  }
 
   @Override
-  public void disconnect() {}
+  public void disconnect() {
+    // not implemented for this stub class
+  }
 
   @Override
   public void close() {

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/stub/DlmsPersistenceConfigStub.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/stub/DlmsPersistenceConfigStub.java
@@ -59,10 +59,14 @@ public class DlmsPersistenceConfigStub extends AbstractPersistenceConfig {
       }
 
       @Override
-      public void setLogWriter(final PrintWriter out) throws SQLException {}
+      public void setLogWriter(final PrintWriter out) throws SQLException {
+        // not implemented for this stub class
+      }
 
       @Override
-      public void setLoginTimeout(final int seconds) throws SQLException {}
+      public void setLoginTimeout(final int seconds) throws SQLException {
+        // not implemented for this stub class
+      }
 
       @Override
       public int getLoginTimeout() throws SQLException {

--- a/osgp/shared/shared/src/test/java/org/opensmartgridplatform/shared/application/config/scheduling/TestJob.java
+++ b/osgp/shared/shared/src/test/java/org/opensmartgridplatform/shared/application/config/scheduling/TestJob.java
@@ -11,5 +11,7 @@ import org.quartz.JobExecutionException;
 class TestJob implements Job {
 
   @Override
-  public void execute(final JobExecutionContext jobExecutionContext) throws JobExecutionException {}
+  public void execute(final JobExecutionContext jobExecutionContext) throws JobExecutionException {
+    // this dummy test job does not do anything on execution
+  }
 }


### PR DESCRIPTION
Blocker and High sonarcloud issues:
- Switch cases should end with an unconditional "break" statement java:S128
- "switch" statements should have "default" clauses java:S131
- Methods should not be empty java:S1186
  - It's no longer required (since version 4.3) for @Configuration annotated classes to have a default/no args constructor 
- Constant names should comply with a naming convention java:S115