### PR TITLE
dependabot-okio-opensaml

### DIFF
--- a/osgp/protocol-adapter-dlms/osgp-jasper-interface/pom.xml
+++ b/osgp/protocol-adapter-dlms/osgp-jasper-interface/pom.xml
@@ -160,12 +160,6 @@ SPDX-License-Identifier: Apache-2.0
       <artifactId>spring-ws-test</artifactId>
     </dependency>
 
-    <!-- Apache ws support -->
-    <dependency>
-      <groupId>org.apache.ws.security</groupId>
-      <artifactId>wss4j</artifactId>
-    </dependency>
-
     <!-- Logging -->
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/main/java/org/opensmartgridplatform/adapter/protocol/jasper/infra/ws/JasperWirelessSmsSoapClient.java
+++ b/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/main/java/org/opensmartgridplatform/adapter/protocol/jasper/infra/ws/JasperWirelessSmsSoapClient.java
@@ -10,7 +10,7 @@ import com.jasperwireless.api.ws.service.ObjectFactory;
 import com.jasperwireless.api.ws.service.SendSMSRequest;
 import com.jasperwireless.api.ws.service.SendSMSResponse;
 import java.util.List;
-import org.apache.ws.security.WSConstants;
+import org.apache.wss4j.common.WSS4JConstants;
 import org.opensmartgridplatform.adapter.protocol.jasper.client.JasperWirelessSmsClient;
 import org.opensmartgridplatform.jasper.config.JasperWirelessAccess;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -107,13 +107,13 @@ public class JasperWirelessSmsSoapClient implements JasperWirelessSmsClient {
             getSMSDetailsRequest, new SoapActionCallback(SERVICE_GET_SMSDETAILS));
   }
 
-  // Sonar marks 'setSecurementPasswordType(WSConstants.PW_TEXT)' as exposing a password.
+  // Sonar marks 'setSecurementPasswordType(WSS4JConstants.PW_TEXT)' as exposing a password.
   // This is wrong, it just sets the password *type*
   @SuppressWarnings("java:S6437")
   private void setUsernameToken(
       final Wss4jSecurityInterceptor interceptor, final String user, final String pass) {
     interceptor.setSecurementUsername(user);
     interceptor.setSecurementPassword(pass);
-    interceptor.setSecurementPasswordType(WSConstants.PW_TEXT);
+    interceptor.setSecurementPasswordType(WSS4JConstants.PW_TEXT);
   }
 }

--- a/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/main/java/org/opensmartgridplatform/adapter/protocol/jasper/infra/ws/JasperWirelessTerminalSoapClient.java
+++ b/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/main/java/org/opensmartgridplatform/adapter/protocol/jasper/infra/ws/JasperWirelessTerminalSoapClient.java
@@ -9,7 +9,7 @@ import com.jasperwireless.api.ws.service.GetSessionInfoResponse;
 import com.jasperwireless.api.ws.service.ObjectFactory;
 import com.jasperwireless.api.ws.service.SessionInfoType;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.ws.security.WSConstants;
+import org.apache.wss4j.common.WSS4JConstants;
 import org.opensmartgridplatform.adapter.protocol.jasper.client.JasperWirelessTerminalClient;
 import org.opensmartgridplatform.jasper.config.JasperWirelessAccess;
 import org.opensmartgridplatform.jasper.exceptions.OsgpJasperException;
@@ -91,13 +91,13 @@ public class JasperWirelessTerminalSoapClient implements JasperWirelessTerminalC
         sessionInfoType.getDateSessionEnded().toGregorianCalendar().getTime());
   }
 
-  // Sonar marks 'setSecurementPasswordType(WSConstants.PW_TEXT)' as exposing a password.
+  // Sonar marks 'setSecurementPasswordType(WSS4JConstants.PW_TEXT)' as exposing a password.
   // This is wrong, it just sets the password *type*
   @SuppressWarnings("java:S6437")
   private static void setUsernameToken(
       final Wss4jSecurityInterceptor interceptor, final String user, final String pass) {
     interceptor.setSecurementUsername(user);
     interceptor.setSecurementPassword(pass);
-    interceptor.setSecurementPasswordType(WSConstants.PW_TEXT);
+    interceptor.setSecurementPasswordType(WSS4JConstants.PW_TEXT);
   }
 }

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/pom.xml
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/pom.xml
@@ -214,12 +214,6 @@ SPDX-License-Identifier: Apache-2.0
       <artifactId>jakarta.inject-api</artifactId>
     </dependency>
 
-    <!-- Apache ws support -->
-    <dependency>
-      <groupId>org.apache.ws.security</groupId>
-      <artifactId>wss4j</artifactId>
-    </dependency>
-
     <!-- Joda Time (Date/Time util) -->
     <dependency>
       <groupId>joda-time</groupId>

--- a/super/pom.xml
+++ b/super/pom.xml
@@ -59,8 +59,7 @@ SPDX-License-Identifier: Apache-2.0
     <assertj.version>3.16.1</assertj.version>
     <xmlunit.version>1.6</xmlunit.version>
     <mockito.core.version>4.8.0</mockito.core.version>
-    <okhttp3.mockwebserver.version>4.9.1</okhttp3.mockwebserver.version>
-    <apache.wss4j.version>1.6.19</apache.wss4j.version>
+    <okhttp3.mockwebserver.version>4.12.0</okhttp3.mockwebserver.version>
     <servlet.version>6.1.0</servlet.version>
     <servlet.jstl.version>3.0.0</servlet.jstl.version>
     <hibernate.version>6.3.1.Final</hibernate.version>
@@ -584,23 +583,6 @@ SPDX-License-Identifier: Apache-2.0
         <groupId>jakarta.annotation</groupId>
         <artifactId>jakarta.annotation-api</artifactId>
         <version>${jakarta.annotation.version}</version>
-      </dependency>
-
-      <!-- ws support -->
-      <dependency>
-        <groupId>org.apache.ws.security</groupId>
-        <artifactId>wss4j</artifactId>
-        <version>${apache.wss4j.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.apache.santuario</groupId>
-            <artifactId>xmlsec</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
 
       <!-- Servlet API 3.0 -->


### PR DESCRIPTION
Solved moderate severity dependabot issues below by
- upgrading com.squareup.okhttp3:mockwebserver:4.9.1 --> 4.12.0 (osgp-throttling-client)
- removing org.apache.ws.security:wss4j:1.6.19 (2015) dependency (osgp-jasper-interface) by replacing WSConstants with WSS4JConstants (org.apache.wss4j:wss4j-ws-security-common)

https://github.com/OSGP/open-smart-grid-platform/security/dependabot/69 [Moderate](https://github.com/OSGP/open-smart-grid-platform/security/dependabot?q=is%3Aopen+severity%3Amoderate)
#69 opened last year • Detected in org.opensaml:opensaml (Maven) • pom.xml

https://github.com/OSGP/open-smart-grid-platform/security/dependabot/68 [Moderate](https://github.com/OSGP/open-smart-grid-platform/security/dependabot?q=is%3Aopen+severity%3Amoderate)
#68 opened last year • Detected in org.opensaml:opensaml (Maven) • pom.xml

https://github.com/OSGP/open-smart-grid-platform/security/dependabot/67 [Moderate](https://github.com/OSGP/open-smart-grid-platform/security/dependabot?q=is%3Aopen+severity%3Amoderate)
#67 opened last year • Detected in org.opensaml:opensaml (Maven) • pom.xml

https://github.com/OSGP/open-smart-grid-platform/security/dependabot/66 [Moderate](https://github.com/OSGP/open-smart-grid-platform/security/dependabot?q=is%3Aopen+severity%3Amoderate)
#66 opened last year • Detected in org.opensaml:opensaml (Maven) • pom.xml

https://github.com/OSGP/open-smart-grid-platform/security/dependabot/135 [Moderate](https://github.com/OSGP/open-smart-grid-platform/security/dependabot?q=is%3Aopen+severity%3Amoderate) [Development](https://github.com/OSGP/open-smart-grid-platform/security/dependabot?q=is%3Aopen+severity%3Amoderate+scope%3Adevelopment)