### PR TITLE
upgrade-cxf-core-only

### DIFF
--- a/integration-tests/cucumber-tests-platform-smartmetering/pom.xml
+++ b/integration-tests/cucumber-tests-platform-smartmetering/pom.xml
@@ -18,11 +18,6 @@ SPDX-License-Identifier: Apache-2.0
     <relativePath>../parent-integration-tests/pom.xml</relativePath>
   </parent>
 
-  <properties>
-    <!-- override version in super pom -->
-    <cxf.version>4.0.3</cxf.version>
-  </properties>
-
   <artifactId>cucumber-tests-platform-smartmetering</artifactId>
   <packaging>jar</packaging>
   <name>cucumber-tests-platform-smartmetering</name>
@@ -200,9 +195,18 @@ SPDX-License-Identifier: Apache-2.0
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-rs-client</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.cxf</groupId>
+          <artifactId>cxf-core</artifactId>
+        </exclusion>
+      </exclusions>
       <version>${cxf.version}</version>
     </dependency>
-
+    <dependency>
+      <groupId>org.apache.cxf</groupId>
+      <artifactId>cxf-core</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/pom.xml
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/pom.xml
@@ -284,18 +284,68 @@ SPDX-License-Identifier: Apache-2.0
     <!-- Apache CXF RESTfull WS WebClient -->
     <dependency>
       <groupId>org.apache.cxf</groupId>
-      <artifactId>cxf-core</artifactId>
+      <artifactId>cxf-rt-rs-client</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.cxf</groupId>
+          <artifactId>cxf-core</artifactId>
+        </exclusion>
+      </exclusions>
       <version>${cxf.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-transports-http</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.cxf</groupId>
+          <artifactId>cxf-core</artifactId>
+        </exclusion>
+      </exclusions>
       <version>${cxf.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.cxf</groupId>
-      <artifactId>cxf-rt-rs-client</artifactId>
+      <artifactId>cxf-rt-transports-http-hc</artifactId>
       <version>${cxf.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.cxf</groupId>
+          <artifactId>cxf-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpcore-nio</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.cxf</groupId>
+      <artifactId>cxf-rt-rs-extension-search</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.cxf</groupId>
+          <artifactId>cxf-core</artifactId>
+        </exclusion>
+      </exclusions>
+      <version>${cxf.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.cxf</groupId>
+      <artifactId>cxf-rt-rs-extension-providers</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.cxf</groupId>
+          <artifactId>cxf-core</artifactId>
+        </exclusion>
+      </exclusions>
+      <version>${cxf.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.cxf</groupId>
+      <artifactId>cxf-core</artifactId>
     </dependency>
 
     <!-- Spring JMS -->

--- a/osgp/protocol-adapter-dlms/osgp-protocol-simulator-dlms/osgp-simulator-dlms-triggered/pom.xml
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-simulator-dlms/osgp-simulator-dlms-triggered/pom.xml
@@ -243,14 +243,32 @@ SPDX-License-Identifier: Apache-2.0
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-frontend-jaxrs</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.cxf</groupId>
+          <artifactId>cxf-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-rs-security-cors</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.cxf</groupId>
+          <artifactId>cxf-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-rs-service-description</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.cxf</groupId>
+          <artifactId>cxf-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.jakarta.rs</groupId>

--- a/osgp/protocol-adapter-dlms/osgp-protocol-simulator-dlms/pom.xml
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-simulator-dlms/pom.xml
@@ -24,9 +24,6 @@ SPDX-License-Identifier: Apache-2.0
     <display.version>${project.version}-${BUILD_TAG}</display.version>
     <commons.collections.version>4.4</commons.collections.version>
     <spring.boot.version>3.3.5</spring.boot.version>
-    <!-- override version in super pom -->
-    <cxf.version>4.0.3</cxf.version>
-
     <skipITs>true</skipITs>
   </properties>
 
@@ -37,16 +34,34 @@ SPDX-License-Identifier: Apache-2.0
       <dependency>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt-frontend-jaxrs</artifactId>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-core</artifactId>
+          </exclusion>
+        </exclusions>
         <version>${cxf.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt-rs-security-cors</artifactId>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-core</artifactId>
+          </exclusion>
+        </exclusions>
         <version>${cxf.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt-rs-service-description</artifactId>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-core</artifactId>
+          </exclusion>
+        </exclusions>
         <version>${cxf.version}</version>
       </dependency>
       <dependency>

--- a/osgp/protocol-adapter-dlms/osgp-protocol-simulator-dlms/simulator/dlms-device-simulator/pom.xml
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-simulator-dlms/simulator/dlms-device-simulator/pom.xml
@@ -102,6 +102,10 @@ SPDX-License-Identifier: Apache-2.0
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-transports-http-hc</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.cxf</groupId>
+      <artifactId>cxf-core</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.openmuc</groupId>

--- a/super/pom.xml
+++ b/super/pom.xml
@@ -120,7 +120,8 @@ SPDX-License-Identifier: Apache-2.0
     <jakarta.annotation.version>3.0.0</jakarta.annotation.version>
     <license.maven.plugin>3.0</license.maven.plugin>
     <jackson.version>2.15.3</jackson.version>
-    <cxf.version>4.0.5</cxf.version>
+    <cxf.version>4.0.3</cxf.version>
+    <cxf.core.version>4.0.5</cxf.core.version>
     <quartz.version>2.3.2</quartz.version>
     <hikaricp.version>3.4.5</hikaricp.version>
     <micrometer.version>1.13.1</micrometer.version>
@@ -631,11 +632,23 @@ SPDX-License-Identifier: Apache-2.0
       <dependency>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt-rs-client</artifactId>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-core</artifactId>
+          </exclusion>
+        </exclusions>
         <version>${cxf.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt-transports-http</artifactId>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-core</artifactId>
+          </exclusion>
+        </exclusions>
         <version>${cxf.version}</version>
       </dependency>
       <dependency>
@@ -643,6 +656,10 @@ SPDX-License-Identifier: Apache-2.0
         <artifactId>cxf-rt-transports-http-hc</artifactId>
         <version>${cxf.version}</version>
         <exclusions>
+          <exclusion>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-core</artifactId>
+          </exclusion>
           <exclusion>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore-nio</artifactId>
@@ -652,14 +669,31 @@ SPDX-License-Identifier: Apache-2.0
       <dependency>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt-rs-extension-search</artifactId>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-core</artifactId>
+          </exclusion>
+        </exclusions>
         <version>${cxf.version}</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-rt-rs-extension-providers</artifactId>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-core</artifactId>
+          </exclusion>
+        </exclusions>
         <version>${cxf.version}</version>
         <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.cxf</groupId>
+        <artifactId>cxf-core</artifactId>
+        <version>${cxf.core.version}</version>
       </dependency>
 
       <!-- Jackson -->


### PR DESCRIPTION
Upgraded only org.apache.cxf:cxf-core library to version 4.0.5 All other org.apache.cxf libraries are kept on version 4.0.3.
cxf-core has a critical level CVE. while the other org.apache.cxf libraries can not be upgrade without major rework of the Build and test pipeline