### PR TITLE
Bug/exception store new keys secret management service

### DIFF
--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/services/SecretManagementService.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/services/SecretManagementService.java
@@ -15,6 +15,7 @@ import java.util.function.Function;
 import org.apache.commons.codec.binary.Hex;
 import org.opensmartgridplatform.adapter.protocol.dlms.application.wsclient.SecretManagementClient;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.entities.SecurityKeyType;
+import org.opensmartgridplatform.adapter.protocol.dlms.exceptions.StoreNewKeyException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.security.RsaEncrypter;
 import org.opensmartgridplatform.ws.schema.core.secret.management.ActivateSecretsRequest;
@@ -267,7 +268,7 @@ public class SecretManagementService {
     try {
       response = this.secretManagementClient.storeSecretsRequest(messageMetadata, request);
     } catch (final RuntimeException exc) {
-      throw new IllegalStateException("Could not store keys: unexpected exception occured", exc);
+      throw new StoreNewKeyException("Could not store keys: unexpected exception occured", exc);
     }
     if (response == null) {
       throw new IllegalStateException("Could not store keys: NULL response");

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/exceptions/StoreNewKeyException.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/exceptions/StoreNewKeyException.java
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: Copyright Contributors to the GXF project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package org.opensmartgridplatform.adapter.protocol.dlms.exceptions;
+
+import java.io.Serial;
+
+public class StoreNewKeyException extends RuntimeException implements NonRetryableException {
+
+  @Serial private static final long serialVersionUID = -539165888074888682L;
+
+  public StoreNewKeyException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+
+  public StoreNewKeyException(final String message) {
+    super(message);
+  }
+}

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/application/services/SecretManagementServiceTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/application/services/SecretManagementServiceTest.java
@@ -5,6 +5,7 @@
 package org.opensmartgridplatform.adapter.protocol.dlms.application.services;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.times;
@@ -12,7 +13,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.codec.binary.Hex;
@@ -24,7 +25,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensmartgridplatform.adapter.protocol.dlms.application.wsclient.SecretManagementClient;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.entities.SecurityKeyType;
-import org.opensmartgridplatform.adapter.protocol.dlms.exceptions.ProtocolAdapterException;
+import org.opensmartgridplatform.adapter.protocol.dlms.exceptions.StoreNewKeyException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.security.RsaEncrypter;
 import org.opensmartgridplatform.ws.schema.core.secret.management.ActivateSecretsRequest;
@@ -41,7 +42,7 @@ import org.opensmartgridplatform.ws.schema.core.secret.management.TypedSecret;
 import org.opensmartgridplatform.ws.schema.core.secret.management.TypedSecrets;
 
 @ExtendWith(MockitoExtension.class)
-public class SecretManagementServiceTest {
+class SecretManagementServiceTest {
   private static final String DEVICE_IDENTIFICATION = "E000123456789";
   private static final SecurityKeyType KEY_TYPE = SecurityKeyType.E_METER_ENCRYPTION;
   private static final byte[] UNENCRYPTED_SECRET = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
@@ -72,8 +73,7 @@ public class SecretManagementServiceTest {
   }
 
   @Test
-  public void testGetKeys() {
-    // SETUP
+  void testGetKeys() {
     final List<SecurityKeyType> keyTypes = Arrays.asList(KEY_TYPE);
     final GetSecretsResponse response = new GetSecretsResponse();
     response.setResult(OsgpResultType.OK);
@@ -83,34 +83,50 @@ public class SecretManagementServiceTest {
             same(messageMetadata), any(GetSecretsRequest.class)))
         .thenReturn(response);
     when(this.decrypterForProtocolAdapterDlms.decrypt(SOAP_SECRET)).thenReturn(UNENCRYPTED_SECRET);
-    // EXECUTE
+
     final Map<SecurityKeyType, byte[]> result =
         this.secretManagementTestService.getKeys(messageMetadata, DEVICE_IDENTIFICATION, keyTypes);
-    // ASSERT
-    assertThat(result).isNotNull();
-    assertThat(result.size()).isEqualTo(1);
+
+    assertThat(result).isNotNull().hasSize(1);
     assertThat(result.keySet().iterator().next()).isEqualTo(KEY_TYPE);
     assertThat(result.values().iterator().next()).isEqualTo(UNENCRYPTED_SECRET);
   }
 
   @Test
-  public void testStoreNewKeys() {
-    final Map<SecurityKeyType, byte[]> keys = new HashMap<>();
+  void testStoreNewKeys() {
+    final Map<SecurityKeyType, byte[]> keys = new EnumMap<>(SecurityKeyType.class);
     keys.put(KEY_TYPE, UNENCRYPTED_SECRET);
     final StoreSecretsResponse response = new StoreSecretsResponse();
     response.setResult(OsgpResultType.OK);
     when(this.encrypterForSecretManagement.encrypt(UNENCRYPTED_SECRET)).thenReturn(SOAP_SECRET);
     when(this.secretManagementClient.storeSecretsRequest(same(messageMetadata), any()))
         .thenReturn(response);
-    // EXECUTE
+
     this.secretManagementTestService.storeNewKeys(messageMetadata, DEVICE_IDENTIFICATION, keys);
-    // ASSERT
+
     verify(this.secretManagementClient, times(1))
         .storeSecretsRequest(same(messageMetadata), any(StoreSecretsRequest.class));
   }
 
   @Test
-  public void testActivateKeys() throws ProtocolAdapterException {
+  void testStoreNewKeysThrowsException() {
+    final Map<SecurityKeyType, byte[]> keys = new EnumMap<>(SecurityKeyType.class);
+    keys.put(KEY_TYPE, UNENCRYPTED_SECRET);
+
+    when(this.encrypterForSecretManagement.encrypt(UNENCRYPTED_SECRET)).thenReturn(SOAP_SECRET);
+    when(this.secretManagementClient.storeSecretsRequest(same(messageMetadata), any()))
+        .thenThrow(new RuntimeException("Simulated exception"));
+
+    assertThrows(
+        StoreNewKeyException.class,
+        () -> {
+          this.secretManagementTestService.storeNewKeys(
+              messageMetadata, DEVICE_IDENTIFICATION, keys);
+        });
+  }
+
+  @Test
+  void testActivateKeys() {
     final List<SecurityKeyType> keyTypes = Arrays.asList(KEY_TYPE);
     final ArgumentCaptor<ActivateSecretsRequest> activateSecretsCaptor =
         ArgumentCaptor.forClass(ActivateSecretsRequest.class);
@@ -127,7 +143,7 @@ public class SecretManagementServiceTest {
   }
 
   @Test
-  public void testGenerateAndStoreKeys() {
+  void testGenerateAndStoreKeys() {
     final List<SecurityKeyType> keyTypes = Arrays.asList(KEY_TYPE);
     final GenerateAndStoreSecretsResponse response = new GenerateAndStoreSecretsResponse();
     response.setResult(OsgpResultType.OK);
@@ -136,16 +152,16 @@ public class SecretManagementServiceTest {
     when(this.secretManagementClient.generateAndStoreSecrets(same(messageMetadata), any()))
         .thenReturn(response);
     when(this.decrypterForProtocolAdapterDlms.decrypt(SOAP_SECRET)).thenReturn(UNENCRYPTED_SECRET);
-    // EXECUTE
+
     final Map<SecurityKeyType, byte[]> keys =
         this.secretManagementTestService.generate128BitsKeysAndStoreAsNewKeys(
             messageMetadata, DEVICE_IDENTIFICATION, keyTypes);
-    // ASSERT
-    assertThat(keys.get(KEY_TYPE)).isEqualTo(UNENCRYPTED_SECRET);
+
+    assertThat(keys).containsEntry(KEY_TYPE, UNENCRYPTED_SECRET);
   }
 
   @Test
-  public void testHasNewSecretAuthenticationKey() {
+  void testHasNewSecretAuthenticationKey() {
     final HasNewSecretResponse responseTrue = new HasNewSecretResponse();
     responseTrue.setHasNewSecret(true);
     final HasNewSecretResponse responseFalse = new HasNewSecretResponse();
@@ -163,15 +179,14 @@ public class SecretManagementServiceTest {
               }
             });
 
-    // EXECUTE
     final boolean result =
         this.secretManagementTestService.hasNewSecret(messageMetadata, DEVICE_IDENTIFICATION);
-    // ASSERT
+
     assertThat(result).isTrue();
   }
 
   @Test
-  public void testHasNewSecretEncryptionKey() {
+  void testHasNewSecretEncryptionKey() {
     final HasNewSecretResponse responseTrue = new HasNewSecretResponse();
     responseTrue.setHasNewSecret(true);
     final HasNewSecretResponse responseFalse = new HasNewSecretResponse();
@@ -189,10 +204,9 @@ public class SecretManagementServiceTest {
               }
             });
 
-    // EXECUTE
     final boolean result =
         this.secretManagementTestService.hasNewSecret(messageMetadata, DEVICE_IDENTIFICATION);
-    // ASSERT
+
     assertThat(result).isTrue();
   }
 }

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/application/services/SecretManagementServiceTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/application/services/SecretManagementServiceTest.java
@@ -5,14 +5,13 @@
 package org.opensmartgridplatform.adapter.protocol.dlms.application.services;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.Arrays;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
@@ -74,7 +73,7 @@ class SecretManagementServiceTest {
 
   @Test
   void testGetKeys() {
-    final List<SecurityKeyType> keyTypes = Arrays.asList(KEY_TYPE);
+    final List<SecurityKeyType> keyTypes = List.of(KEY_TYPE);
     final GetSecretsResponse response = new GetSecretsResponse();
     response.setResult(OsgpResultType.OK);
     response.setTypedSecrets(new TypedSecrets());
@@ -117,17 +116,17 @@ class SecretManagementServiceTest {
     when(this.secretManagementClient.storeSecretsRequest(same(messageMetadata), any()))
         .thenThrow(new RuntimeException("Simulated exception"));
 
-    assertThrows(
-        StoreNewKeyException.class,
-        () -> {
-          this.secretManagementTestService.storeNewKeys(
-              messageMetadata, DEVICE_IDENTIFICATION, keys);
-        });
+    assertThatThrownBy(
+            () -> {
+              this.secretManagementTestService.storeNewKeys(
+                  messageMetadata, DEVICE_IDENTIFICATION, keys);
+            })
+        .isInstanceOf(StoreNewKeyException.class);
   }
 
   @Test
   void testActivateKeys() {
-    final List<SecurityKeyType> keyTypes = Arrays.asList(KEY_TYPE);
+    final List<SecurityKeyType> keyTypes = List.of(KEY_TYPE);
     final ArgumentCaptor<ActivateSecretsRequest> activateSecretsCaptor =
         ArgumentCaptor.forClass(ActivateSecretsRequest.class);
     // EXECUTE
@@ -144,7 +143,7 @@ class SecretManagementServiceTest {
 
   @Test
   void testGenerateAndStoreKeys() {
-    final List<SecurityKeyType> keyTypes = Arrays.asList(KEY_TYPE);
+    final List<SecurityKeyType> keyTypes = List.of(KEY_TYPE);
     final GenerateAndStoreSecretsResponse response = new GenerateAndStoreSecretsResponse();
     response.setResult(OsgpResultType.OK);
     response.setTypedSecrets(new TypedSecrets());


### PR DESCRIPTION
- the general exception that was thrown in case the storeNewKeys method fails, was not handled correctly. Therefore the retry and handle error process of the shipmentfile process did not receive any feedback and the statusses were not updated.
- a new custom exception is now introduced to handle this

https://jenkins.fdp.osgp.cloud/view/SMHE-cucumber/job/gxf-smhe-cucumber-build/323/

