### PR TITLE
Add rejected permanent/transient exception types

### DIFF
--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/factories/DlmsConnector.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/factories/DlmsConnector.java
@@ -12,6 +12,8 @@ import static org.opensmartgridplatform.shared.exceptionhandling.FunctionalExcep
 import static org.opensmartgridplatform.shared.exceptionhandling.FunctionalExceptionType.CONNECTION_RESET;
 import static org.opensmartgridplatform.shared.exceptionhandling.FunctionalExceptionType.CONNECTION_TIMED_OUT;
 import static org.opensmartgridplatform.shared.exceptionhandling.FunctionalExceptionType.ILLEGAL_RESPONSE;
+import static org.opensmartgridplatform.shared.exceptionhandling.FunctionalExceptionType.REJECTED_PERMANENT;
+import static org.opensmartgridplatform.shared.exceptionhandling.FunctionalExceptionType.REJECTED_TRANSIENT;
 import static org.opensmartgridplatform.shared.exceptionhandling.FunctionalExceptionType.RESPONSE_TIMEOUT;
 import static org.opensmartgridplatform.shared.exceptionhandling.FunctionalExceptionType.SOCKET_CLOSED_BY_REMOTE;
 import static org.opensmartgridplatform.shared.exceptionhandling.FunctionalExceptionType.UNABLE_TO_DECYPHER;
@@ -53,6 +55,8 @@ public abstract class DlmsConnector {
     errorMap.put("ILLEGAL_RESPONSE", ILLEGAL_RESPONSE);
     errorMap.put("RESPONSE_TIMEOUT", RESPONSE_TIMEOUT);
     errorMap.put("UNKNOWN_ASSOCIATION_RESULT", UNKNOWN_ASSOCIATION_RESULT);
+    errorMap.put("REJECTED_PERMANENT", REJECTED_PERMANENT);
+    errorMap.put("REJECTED_TRANSIENT", REJECTED_TRANSIENT);
   }
 
   public abstract DlmsConnection connect(

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/factories/DlmsConnectorTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/test/java/org/opensmartgridplatform/adapter/protocol/dlms/domain/factories/DlmsConnectorTest.java
@@ -26,6 +26,8 @@ class DlmsConnectorTest {
     "Unable to decypher/decrypt xDLMS pdu,UNABLE_TO_DECYPHER",
     "WRAPPER_HEADER_INVALID_VERSION,WRAPPER_HEADER_INVALID",
     "UNKNOWN_ASSOCIATION_RESULT,UNKNOWN_ASSOCIATION_RESULT",
+    "REJECTED_PERMANENT,REJECTED_PERMANENT",
+    "REJECTED_TRANSIENT,REJECTED_TRANSIENT"
   })
   void testGetExceptionWithExceptionType(
       final String message, final FunctionalExceptionType expectedType) {

--- a/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/exceptionhandling/FunctionalExceptionType.java
+++ b/osgp/shared/shared/src/main/java/org/opensmartgridplatform/shared/exceptionhandling/FunctionalExceptionType.java
@@ -4,6 +4,9 @@
 
 package org.opensmartgridplatform.shared.exceptionhandling;
 
+import lombok.Getter;
+
+@Getter
 public enum FunctionalExceptionType {
   // Organisation exceptions
   UNKNOWN_ORGANISATION(101, "UNKNOWN_ORGANISATION"),
@@ -47,6 +50,8 @@ public enum FunctionalExceptionType {
   ILLEGAL_RESPONSE(232, "ILLEGAL_RESPONSE"),
   RESPONSE_TIMEOUT(233, "RESPONSE_TIMEOUT"),
   UNKNOWN_ASSOCIATION_RESULT(234, "UNKNOWN_ASSOCIATION_RESULT"),
+  REJECTED_PERMANENT(235, "REJECTED_PERMANENT"),
+  REJECTED_TRANSIENT(236, "REJECTED_TRANSIENT"),
 
   // Authorization exceptions
   UNAUTHORIZED(301, "UNAUTHORIZED"),
@@ -109,13 +114,5 @@ public enum FunctionalExceptionType {
   FunctionalExceptionType(final int code, final String message) {
     this.code = code;
     this.message = message;
-  }
-
-  public int getCode() {
-    return this.code;
-  }
-
-  public String getMessage() {
-    return this.message;
   }
 }


### PR DESCRIPTION
Exception types "REJECTED_PERMANENT" and "REJECTED_TRANSIENT" are now returned instead of a general "CONNECTION_ERROR".

Updated documentation:
https://alliander.atlassian.net/wiki/spaces/HOUS/pages/4501537616/Exception+codes+en+foutmeldingen