### PR TITLE
security update netty spring-boot and cxf-core

### DIFF
--- a/osgp/platform/osgp-secret-management/pom.xml
+++ b/osgp/platform/osgp-secret-management/pom.xml
@@ -21,7 +21,7 @@ SPDX-License-Identifier: Apache-2.0
 
   <properties>
     <java.version>17</java.version>
-    <spring.boot.version>3.3.7</spring.boot.version>
+    <spring.boot.version>3.3.8</spring.boot.version>
     <osgp-ws-secret-management-version>${project.parent.version}</osgp-ws-secret-management-version>
     <apache.ws.xlmschema.version>2.3.1</apache.ws.xlmschema.version>
     <wsdl4j.version>1.6.3</wsdl4j.version>

--- a/osgp/platform/osgp-throttling-service/pom.xml
+++ b/osgp/platform/osgp-throttling-service/pom.xml
@@ -23,7 +23,7 @@ SPDX-License-Identifier: Apache-2.0
   </parent>
 
   <properties>
-    <spring.boot.version>3.3.7</spring.boot.version>
+    <spring.boot.version>3.3.8</spring.boot.version>
     <failOnMissingWebXml>false</failOnMissingWebXml>
   </properties>
 

--- a/osgp/protocol-adapter-dlms/osgp-protocol-simulator-dlms/pom.xml
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-simulator-dlms/pom.xml
@@ -23,7 +23,7 @@ SPDX-License-Identifier: Apache-2.0
   <properties>
     <display.version>${project.version}-${BUILD_TAG}</display.version>
     <commons.collections.version>4.4</commons.collections.version>
-    <spring.boot.version>3.3.7</spring.boot.version>
+    <spring.boot.version>3.3.8</spring.boot.version>
     <skipITs>true</skipITs>
   </properties>
 

--- a/osgp/protocol-adapter-dlms/osgp-protocol-simulator-dlms/simulator/pom.xml
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-simulator-dlms/simulator/pom.xml
@@ -56,7 +56,7 @@ SPDX-License-Identifier: Apache-2.0
 <!--   </dependencyManagement> -->
 
   <properties>
-    <spring.boot.version>3.3.7</spring.boot.version>
+    <spring.boot.version>3.3.8</spring.boot.version>
   </properties>
 
   <build>

--- a/osgp/protocol-adapter-iec60870/osgp-protocol-simulator-iec60870/pom.xml
+++ b/osgp/protocol-adapter-iec60870/osgp-protocol-simulator-iec60870/pom.xml
@@ -16,7 +16,7 @@ SPDX-License-Identifier: Apache-2.0
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.3.7</version>
+    <version>3.3.8</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
 

--- a/osgp/protocol-adapter-iec61850/osgp-protocol-simulator-iec61850/pom.xml
+++ b/osgp/protocol-adapter-iec61850/osgp-protocol-simulator-iec61850/pom.xml
@@ -43,7 +43,7 @@ SPDX-License-Identifier: Apache-2.0
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.3.7</version>
+    <version>3.3.8</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
 
@@ -52,7 +52,6 @@ SPDX-License-Identifier: Apache-2.0
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>17</java.version>
-    <spring.boot.version>3.2.0</spring.boot.version>
     <beanit.openiec61850.version>1.8.0</beanit.openiec61850.version>
 
     <jxr.version>3.3.2</jxr.version>

--- a/super/pom.xml
+++ b/super/pom.xml
@@ -111,7 +111,7 @@ SPDX-License-Identifier: Apache-2.0
     <apache.commons.schema>2.3.1</apache.commons.schema>
     <maven.clean.plugin.version>3.4.0</maven.clean.plugin.version>
     <maven.compiler.plugin.version>3.13.0</maven.compiler.plugin.version>
-    <netty.version>4.1.108.Final</netty.version>
+    <netty.version>4.1.118.Final</netty.version>
     <openmuc.jdlms.version>1.8.0</openmuc.jdlms.version>
     <openmuc.jdlms-annotation.version>1.8.0</openmuc.jdlms-annotation.version>
     <beanit.openiec61850.version>1.8.0</beanit.openiec61850.version>
@@ -121,7 +121,7 @@ SPDX-License-Identifier: Apache-2.0
     <license.maven.plugin>3.0</license.maven.plugin>
     <jackson.version>2.15.3</jackson.version>
     <cxf.version>4.0.3</cxf.version>
-    <cxf.core.version>4.0.5</cxf.core.version>
+    <cxf.core.version>4.0.6</cxf.core.version>
     <quartz.version>2.3.2</quartz.version>
     <hikaricp.version>3.4.5</hikaricp.version>
     <micrometer.version>1.13.1</micrometer.version>

--- a/super/pom.xml
+++ b/super/pom.xml
@@ -55,7 +55,7 @@ SPDX-License-Identifier: Apache-2.0
     <spring.security.version>6.2.8</spring.security.version>
     <spring.ws.version>4.0.11</spring.ws.version>
     <spring.integration.version>6.3.5</spring.integration.version>
-    <reactor.version>2023.0.7</reactor.version>
+    <reactor.version>2024.0.3</reactor.version>
     <assertj.version>3.16.1</assertj.version>
     <xmlunit.version>1.6</xmlunit.version>
     <mockito.core.version>4.8.0</mockito.core.version>


### PR DESCRIPTION
io.projectreactor:reactor-bom 2023.0.7 ==> 2024.0.3
netty 4.1.108.Final ==> 4.1.118
spring.boot 3.3.7 ==> 3.3.8
cxf.core 4.0.5 ==> 4.0.6
	
✔ https://jenkins.fdp.osgp.cloud/view/SMHE-cucumber/job/gxf-smhe-cucumber-build/325/