### PR TITLE
Enriching JMS queue senders and listeners with correlation uid

### DIFF
--- a/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/infra/jms/domain/outbound/DomainRequestMessageSender.java
+++ b/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/infra/jms/domain/outbound/DomainRequestMessageSender.java
@@ -45,10 +45,11 @@ public class DomainRequestMessageSender implements DomainRequestService {
       final String messageType,
       final JmsTemplate jmsTemplate) {
     LOGGER.info(
-        "Sending request message to incoming domain requests queue, messageType: {} organisationIdentification: {} deviceIdentification: {}",
+        "Sending request message to incoming domain requests queue, messageType: {} organisationIdentification: {} deviceIdentification: {} correlationUid: {}",
         messageType,
         requestMessage.getOrganisationIdentification(),
-        requestMessage.getDeviceIdentification());
+        requestMessage.getDeviceIdentification(),
+        requestMessage.getCorrelationUid());
 
     jmsTemplate.send(
         new MessageCreator() {

--- a/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/infra/jms/protocol/inbound/ProtocolRequestMessageListener.java
+++ b/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/infra/jms/protocol/inbound/ProtocolRequestMessageListener.java
@@ -48,6 +48,7 @@ public class ProtocolRequestMessageListener implements MessageListener {
         final MessageProcessor processor =
             this.protocolRequestMessageProcessorMap.getMessageProcessor(objectMessage);
 
+        LOGGER.info("MessageProcessor found in protocolRequestMessageProcessorMap");
         processor.processMessage(objectMessage);
 
       } catch (final JMSException ex) {

--- a/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/infra/jms/protocol/inbound/ProtocolRequestMessageListener.java
+++ b/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/infra/jms/protocol/inbound/ProtocolRequestMessageListener.java
@@ -39,7 +39,10 @@ public class ProtocolRequestMessageListener implements MessageListener {
   @Override
   public void onMessage(final Message message) {
     try {
-      LOGGER.info("Received message of type: {}", message.getJMSType());
+      LOGGER.info(
+          "Received RequestMessage of type [{}] in core (protocol.inbound) with JMSCorrelationID: [{}]",
+          message.getJMSType(),
+          message.getJMSCorrelationID());
       final ObjectMessage objectMessage = (ObjectMessage) message;
 
       // Check if message can be processed by generic OSGP-CORE
@@ -48,11 +51,16 @@ public class ProtocolRequestMessageListener implements MessageListener {
         final MessageProcessor processor =
             this.protocolRequestMessageProcessorMap.getMessageProcessor(objectMessage);
 
-        LOGGER.info("MessageProcessor found in protocolRequestMessageProcessorMap");
+        LOGGER.info(
+            "MessageProcessor found in protocolRequestMessageProcessorMap. JMSCorrelationID: {}",
+            message.getJMSCorrelationID());
         processor.processMessage(objectMessage);
 
       } catch (final JMSException ex) {
-        LOGGER.error("JMSException", ex);
+        LOGGER.error(
+            "JMSException listening to message with JMSCorrelationID: {}",
+            message.getJMSCorrelationID(),
+            ex);
         // The message needs to be sent to a domain adapter.
         this.sendMessageToDomainAdapter(
             (RequestMessage) objectMessage.getObject(), message.getJMSType());

--- a/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/infra/jms/protocol/inbound/ProtocolRequestMessageListener.java
+++ b/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/infra/jms/protocol/inbound/ProtocolRequestMessageListener.java
@@ -40,7 +40,7 @@ public class ProtocolRequestMessageListener implements MessageListener {
   public void onMessage(final Message message) {
     try {
       LOGGER.info(
-          "Received RequestMessage of type [{}] in core (protocol.inbound) with JMSCorrelationID: [{}]",
+          "Received RequestMessage of type {} in core (protocol.inbound) with JMSCorrelationID {} ",
           message.getJMSType(),
           message.getJMSCorrelationID());
       final ObjectMessage objectMessage = (ObjectMessage) message;

--- a/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/infra/jms/protocol/inbound/ProtocolResponseMessageListener.java
+++ b/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/infra/jms/protocol/inbound/ProtocolResponseMessageListener.java
@@ -29,9 +29,9 @@ public class ProtocolResponseMessageListener implements MessageListener {
   public void onMessage(final Message message) {
     try {
       LOGGER.info(
-          "Received protocol response message with correlationUid [{}] and type [{}]",
-          message.getJMSCorrelationID(),
-          message.getJMSType());
+          "Received ResponseMessage and type [{}] in core (protocol.inbound) with JMSCorrelationID: [{}]",
+          message.getJMSType(),
+          message.getJMSCorrelationID());
 
       final ProtocolResponseMessage protocolResponseMessage = createResponseMessage(message);
 

--- a/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/infra/jms/protocol/inbound/ProtocolResponseMessageListener.java
+++ b/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/infra/jms/protocol/inbound/ProtocolResponseMessageListener.java
@@ -29,7 +29,7 @@ public class ProtocolResponseMessageListener implements MessageListener {
   public void onMessage(final Message message) {
     try {
       LOGGER.info(
-          "Received ResponseMessage and type [{}] in core (protocol.inbound) with JMSCorrelationID: [{}]",
+          "Received ResponseMessage of type {} in core (protocol.inbound) with JMSCorrelationID: {}",
           message.getJMSType(),
           message.getJMSCorrelationID());
 

--- a/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/infra/jms/protocol/outbound/ProtocolRequestMessageSender.java
+++ b/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/infra/jms/protocol/outbound/ProtocolRequestMessageSender.java
@@ -42,19 +42,21 @@ public class ProtocolRequestMessageSender implements ProtocolRequestService {
   public void send(final ProtocolRequestMessage message, final ProtocolInfo protocolInfo) {
 
     LOGGER.info(
-        "Sending protocol request message for device [{}] using protocol [{}] with version [{}]",
+        "Sending protocol request message for device [{}] using protocol [{}] with version [{}]. [correlationUid: {} ].",
         message.getDeviceIdentification(),
         protocolInfo.getProtocol(),
-        protocolInfo.getProtocolVersion());
+        protocolInfo.getProtocolVersion(),
+        message.getCorrelationUid());
 
     final JmsTemplate jmsTemplate =
         this.protocolRequestMessageJmsTemplateFactory.getJmsTemplate(protocolInfo);
 
     LOGGER.info(
-        "Message sender destination queue: [{}] for protocol [{}] with version [{}]",
+        "Message sender destination queue: [{}] for protocol [{}] with version [{}]. [correlationUid: {} ].",
         jmsTemplate.getDefaultDestination(),
         protocolInfo.getProtocol(),
-        protocolInfo.getProtocolVersion());
+        protocolInfo.getProtocolVersion(),
+        message.getCorrelationUid());
 
     this.sendMessage(message, protocolInfo, jmsTemplate);
   }
@@ -63,7 +65,10 @@ public class ProtocolRequestMessageSender implements ProtocolRequestService {
       final ProtocolRequestMessage requestMessage,
       final ProtocolInfo protocolInfo,
       final JmsTemplate jmsTemplate) {
-    LOGGER.info("Sending request message to protocol requests queue");
+    LOGGER.info(
+        "Sending RequestMessage of type {} from core (protocol.outbound) with [correlationUid: {} ] ",
+        requestMessage.getMessageType(),
+        requestMessage.getCorrelationUid());
 
     jmsTemplate.send(session -> this.createObjectMessage(requestMessage, protocolInfo, session));
 
@@ -96,9 +101,10 @@ public class ProtocolRequestMessageSender implements ProtocolRequestService {
       final String messageGroupId =
           ProtocolRequestMessageSender.this.getMessageGroupId(deviceIdentification);
       LOGGER.debug(
-          "Setting message group property for device {} to: {}",
+          "Setting message group property for device {} to: {} [correlationUid: {} ]",
           deviceIdentification,
-          messageGroupId);
+          messageGroupId,
+          requestMessage.getCorrelationUid());
       objectMessage.setStringProperty(Constants.MESSAGE_GROUP, messageGroupId);
     }
     return objectMessage;

--- a/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/infra/jms/protocol/outbound/ProtocolRequestMessageSender.java
+++ b/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/infra/jms/protocol/outbound/ProtocolRequestMessageSender.java
@@ -42,7 +42,7 @@ public class ProtocolRequestMessageSender implements ProtocolRequestService {
   public void send(final ProtocolRequestMessage message, final ProtocolInfo protocolInfo) {
 
     LOGGER.info(
-        "Sending protocol request message for device [{}] using protocol [{}] with version [{}]. [correlationUid: {} ].",
+        "Sending protocol request message for device [{}] using protocol [{}] with version [{}] and  [correlationUid: {} ].",
         message.getDeviceIdentification(),
         protocolInfo.getProtocol(),
         protocolInfo.getProtocolVersion(),
@@ -52,7 +52,7 @@ public class ProtocolRequestMessageSender implements ProtocolRequestService {
         this.protocolRequestMessageJmsTemplateFactory.getJmsTemplate(protocolInfo);
 
     LOGGER.info(
-        "Message sender destination queue: [{}] for protocol [{}] with version [{}]. [correlationUid: {} ].",
+        "Message sender destination queue: [{}] for protocol [{}] with version [{}] and [correlationUid: {} ].",
         jmsTemplate.getDefaultDestination(),
         protocolInfo.getProtocol(),
         protocolInfo.getProtocolVersion(),

--- a/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/infra/jms/protocol/outbound/ProtocolResponseMessageSender.java
+++ b/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/infra/jms/protocol/outbound/ProtocolResponseMessageSender.java
@@ -63,7 +63,10 @@ public class ProtocolResponseMessageSender implements ProtocolResponseService {
       final JmsTemplate jmsTemplate,
       final MessageMetadata messageMetadata,
       final Destination destination) {
-    LOGGER.info("Sending response message to protocol responses incoming queue");
+    LOGGER.info(
+        "Sending ResponseMessage of type {} from core (protocol.outbound) with [correlationUid: {} ] ",
+        messageType,
+        messageMetadata.getCorrelationUid());
 
     jmsTemplate.send(
         destination,

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/services/BundleService.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/services/BundleService.java
@@ -125,6 +125,10 @@ public class BundleService {
       throw ce;
 
     } catch (final DeviceKeyProcessAlreadyRunningException e) {
+      log.info(
+          """
+      This exception will be caught in the DeviceRequestMessageProcessor.
+      The request will NOT be sent back to Core to retry but put back on the queue""");
       // This exception will be caught in the DeviceRequestMessageProcessor.
       // The request will NOT be sent back to Core to retry but put back on the queue
       throw e;

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/services/BundleService.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/services/BundleService.java
@@ -125,10 +125,6 @@ public class BundleService {
       throw ce;
 
     } catch (final DeviceKeyProcessAlreadyRunningException e) {
-      log.info(
-          """
-      This exception will be caught in the DeviceRequestMessageProcessor.
-      The request will NOT be sent back to Core to retry but put back on the queue""");
       // This exception will be caught in the DeviceRequestMessageProcessor.
       // The request will NOT be sent back to Core to retry but put back on the queue
       throw e;

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/services/GetKeysService.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/services/GetKeysService.java
@@ -15,12 +15,16 @@ import org.opensmartgridplatform.dto.valueobjects.smartmetering.SecretTypeDto;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.security.RsaEncrypter;
 import org.opensmartgridplatform.ws.schema.core.secret.management.SecretType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class GetKeysService {
+
+  private static final Logger log = LoggerFactory.getLogger(GetKeysService.class);
 
   private final SecretManagementService secretManagementService;
   private final RsaEncrypter encrypterForGxfSmartMetering;
@@ -42,6 +46,12 @@ public class GetKeysService {
 
     final List<SecurityKeyType> securityKeyTypes =
         getKeysRequestDto.getSecretTypes().stream().map(this::convertToSecurityKeyType).toList();
+
+    log.info(
+        "Getting keys for device {} with security key types {}. CorrelationID: {}",
+        device.getDeviceIdentification(),
+        securityKeyTypes,
+        messageMetadata.getCorrelationUid());
 
     final Map<SecurityKeyType, byte[]> unencryptedKeys =
         this.secretManagementService.getKeys(

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/services/GetKeysService.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/application/services/GetKeysService.java
@@ -6,6 +6,7 @@ package org.opensmartgridplatform.adapter.protocol.dlms.application.services;
 
 import java.util.List;
 import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.entities.DlmsDevice;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.entities.SecurityKeyType;
 import org.opensmartgridplatform.dto.valueobjects.smartmetering.GetKeysRequestDto;
@@ -15,16 +16,13 @@ import org.opensmartgridplatform.dto.valueobjects.smartmetering.SecretTypeDto;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.security.RsaEncrypter;
 import org.opensmartgridplatform.ws.schema.core.secret.management.SecretType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 public class GetKeysService {
-
-  private static final Logger log = LoggerFactory.getLogger(GetKeysService.class);
 
   private final SecretManagementService secretManagementService;
   private final RsaEncrypter encrypterForGxfSmartMetering;
@@ -48,7 +46,7 @@ public class GetKeysService {
         getKeysRequestDto.getSecretTypes().stream().map(this::convertToSecurityKeyType).toList();
 
     log.info(
-        "Getting keys for device {} with security key types {}. CorrelationID: {}",
+        "Getting keys for device {} with security key types {}. CorrelationUid: {}",
         device.getDeviceIdentification(),
         securityKeyTypes,
         messageMetadata.getCorrelationUid());

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/DeviceRequestMessageListener.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/DeviceRequestMessageListener.java
@@ -38,7 +38,16 @@ public class DeviceRequestMessageListener implements MessageListener {
       processor.processMessage(objectMessage);
 
     } catch (final JMSException ex) {
-      LOGGER.error("Exception: {} ", ex.getMessage(), ex);
+      LOGGER.error(
+          "Exception in DeviceRequestMessageListener (osgp-protocol-adapter-dlms): {} ",
+          ex.getMessage(),
+          ex);
+    } catch (final Throwable t) {
+      LOGGER.error(
+          "Throwable in DeviceRequestMessageListener (osgp-protocol-adapter-dlms): {} ",
+          t.getMessage(),
+          t);
+      throw t;
     }
   }
 }

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/DeviceRequestMessageListener.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/DeviceRequestMessageListener.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
+@SuppressWarnings({"java:S1181", "java:S2139"})
 @Component(value = "protocolDlmsInboundOsgpCoreRequestsMessageListener")
 public class DeviceRequestMessageListener implements MessageListener {
 
@@ -42,7 +43,7 @@ public class DeviceRequestMessageListener implements MessageListener {
           "Exception in DeviceRequestMessageListener (osgp-protocol-adapter-dlms): {} ",
           ex.getMessage(),
           ex);
-    } catch (final Throwable t) {
+    } catch (final Exception t) {
       LOGGER.error(
           "Throwable in DeviceRequestMessageListener (osgp-protocol-adapter-dlms): {} ",
           t.getMessage(),

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/DeviceRequestMessageListener.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/DeviceRequestMessageListener.java
@@ -16,7 +16,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
-@SuppressWarnings({"java:S1181", "java:S2139"})
 @Component(value = "protocolDlmsInboundOsgpCoreRequestsMessageListener")
 public class DeviceRequestMessageListener implements MessageListener {
 
@@ -28,27 +27,33 @@ public class DeviceRequestMessageListener implements MessageListener {
 
   @Override
   public void onMessage(final Message message) {
+    String jmsCorrelationID = "<unknown>";
     try {
-      LOGGER.info("Received message of type: {}", message.getJMSType());
+      jmsCorrelationID = message.getJMSCorrelationID();
+
+      LOGGER.info(
+          "Received RequestMessage of type {} in DLMS Protocol Adapter with JMSCorrelationID: {}",
+          message.getJMSType(),
+          message.getJMSCorrelationID());
 
       final ObjectMessage objectMessage = (ObjectMessage) message;
 
       final MessageProcessor processor =
           this.dlmsRequestMessageProcessorMap.getMessageProcessor(objectMessage);
 
-      processor.processMessage(objectMessage);
+      if (processor != null) {
+        processor.processMessage(objectMessage);
+      } else {
+        LOGGER.error(
+            "MessageProcessor not found for message with JMSCorrelationID: {}", jmsCorrelationID);
+      }
 
     } catch (final JMSException ex) {
       LOGGER.error(
-          "Exception in DeviceRequestMessageListener (osgp-protocol-adapter-dlms): {} ",
+          "Exception in dlms.DeviceRequestMessageListener. JMSCorrelationID: {} : {}",
+          jmsCorrelationID,
           ex.getMessage(),
           ex);
-    } catch (final Exception t) {
-      LOGGER.error(
-          "Throwable in DeviceRequestMessageListener (osgp-protocol-adapter-dlms): {} ",
-          t.getMessage(),
-          t);
-      throw t;
     }
   }
 }

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/DeviceRequestMessageProcessor.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/DeviceRequestMessageProcessor.java
@@ -127,7 +127,10 @@ public abstract class DeviceRequestMessageProcessor extends DlmsConnectionMessag
       this.deviceRequestMessageSender.send(messageObject, messageMetadata, permitRejectDelay);
 
     } catch (final DeviceKeyProcessAlreadyRunningException exception) {
-
+      log.info(
+          "Key process is already running for device {}. Sending message {} back to core.",
+          messageMetadata.getDeviceIdentification(),
+          messageMetadata.getCorrelationUid());
       this.deviceRequestMessageSender.send(
           messageObject, messageMetadata, this.deviceKeyProcessingTimeout);
     } catch (final Exception exception) {
@@ -208,6 +211,11 @@ public abstract class DeviceRequestMessageProcessor extends DlmsConnectionMessag
           metadata.getCorrelationUid(),
           exception);
     }
+    log.error(
+        "Handling ErrorResponse with silent exception in DeviceRequestMessageProcessor during {}, correlationUID: {}",
+        this.messageType.name(),
+        metadata.getCorrelationUid(),
+        exception);
     this.sendResponseMessage(
         metadata,
         ResponseMessageResultType.NOT_OK,

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/DeviceRequestMessageProcessor.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/DeviceRequestMessageProcessor.java
@@ -82,18 +82,26 @@ public abstract class DeviceRequestMessageProcessor extends DlmsConnectionMessag
 
   @Override
   public void processMessage(final ObjectMessage message) throws JMSException {
-    log.debug("Processing {} request message", this.messageType);
+    log.info("Processing {} request message", this.messageType);
 
     final MessageMetadata messageMetadata = MessageMetadata.fromMessage(message);
+
+    log.info(
+        "messageMetadata for type {}. CorrelationUid: {}",
+        messageMetadata.getMessageType(),
+        messageMetadata.getCorrelationUid());
     final Serializable messageObject = message.getObject();
 
+    log.info("messageObject from message: {}", messageObject);
     try {
       final DlmsDevice device;
+      log.info("requiresExistingDevice: {}", this.requiresExistingDevice());
       if (this.requiresExistingDevice()) {
         device = this.domainHelperService.findDlmsDevice(messageMetadata);
       } else {
         device = null;
       }
+      log.info("usesDeviceConnection: {}", this.usesDeviceConnection(messageObject));
       if (this.usesDeviceConnection(messageObject)) {
         /*
          * Set up a consumer to be called back with a DlmsConnectionManager for which the connection

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/DeviceRequestMessageProcessor.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/DeviceRequestMessageProcessor.java
@@ -130,19 +130,19 @@ public abstract class DeviceRequestMessageProcessor extends DlmsConnectionMessag
       final Duration permitRejectDelay =
           this.throttlingConfig.permitRejectedDelay(messageMetadata.getMessagePriority());
       log.info(
-          "Throttling permit was denied for deviceIdentification {} for network segment ({}, {}) with priority {} for {}. retry message in {} ms. Correlation UID: {}",
+          "Throttling permit was denied for deviceIdentification {} for network segment ({}, {}) with priority {} for {}. retry message with correlationUid {} in {} ms.",
           messageMetadata.getDeviceIdentification(),
           exception.getBaseTransceiverStationId(),
           exception.getCellId(),
           exception.getPriority(),
           exception.getConfigurationName(),
-          permitRejectDelay.toMillis(),
-          messageMetadata.getCorrelationUid());
+          messageMetadata.getCorrelationUid(),
+          permitRejectDelay.toMillis());
       this.deviceRequestMessageSender.send(messageObject, messageMetadata, permitRejectDelay);
 
     } catch (final DeviceKeyProcessAlreadyRunningException exception) {
       log.info(
-          "Key process is already running for device {}. Sending message with correlation UID {} back to core.",
+          "Key process is already running for device {}. Sending message with correlationUid {} back to core.",
           messageMetadata.getDeviceIdentification(),
           messageMetadata.getCorrelationUid());
       this.deviceRequestMessageSender.send(
@@ -214,7 +214,7 @@ public abstract class DeviceRequestMessageProcessor extends DlmsConnectionMessag
           metadata, ResponseMessageResultType.OK, null, this.responseMessageSender, response);
     } else {
       log.info(
-          "Response is {}. No sending a ResponseMessage for Correlation UID {}",
+          "Response is {}. Not sending a ResponseMessage for correlationUid {}",
           NO_RESPONSE,
           metadata.getCorrelationUid());
     }

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/DeviceRequestMessageProcessor.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/DeviceRequestMessageProcessor.java
@@ -82,26 +82,27 @@ public abstract class DeviceRequestMessageProcessor extends DlmsConnectionMessag
 
   @Override
   public void processMessage(final ObjectMessage message) throws JMSException {
-    log.info("Processing {} request message", this.messageType);
+    log.debug(
+        "Processing {} request message with JMSCorrelationID{}",
+        this.messageType,
+        message.getJMSCorrelationID());
 
     final MessageMetadata messageMetadata = MessageMetadata.fromMessage(message);
 
     log.info(
-        "messageMetadata for type {}. CorrelationUid: {}",
+        "messageMetadata for type {}. CorrelationUid: {} JMSCorrelationID: {}",
         messageMetadata.getMessageType(),
-        messageMetadata.getCorrelationUid());
+        messageMetadata.getCorrelationUid(),
+        message.getJMSCorrelationID());
     final Serializable messageObject = message.getObject();
 
-    log.info("messageObject from message: {}", messageObject);
     try {
       final DlmsDevice device;
-      log.info("requiresExistingDevice: {}", this.requiresExistingDevice());
       if (this.requiresExistingDevice()) {
         device = this.domainHelperService.findDlmsDevice(messageMetadata);
       } else {
         device = null;
       }
-      log.info("usesDeviceConnection: {}", this.usesDeviceConnection(messageObject));
       if (this.usesDeviceConnection(messageObject)) {
         /*
          * Set up a consumer to be called back with a DlmsConnectionManager for which the connection
@@ -125,18 +126,19 @@ public abstract class DeviceRequestMessageProcessor extends DlmsConnectionMessag
       final Duration permitRejectDelay =
           this.throttlingConfig.permitRejectedDelay(messageMetadata.getMessagePriority());
       log.info(
-          "Throttling permit was denied for deviceIdentification {} for network segment ({}, {}) with priority {} for {}. retry message in {} ms",
+          "Throttling permit was denied for deviceIdentification {} for network segment ({}, {}) with priority {} for {}. retry message in {} ms. Correlation UID: {}",
           messageMetadata.getDeviceIdentification(),
           exception.getBaseTransceiverStationId(),
           exception.getCellId(),
           exception.getPriority(),
           exception.getConfigurationName(),
-          permitRejectDelay.toMillis());
+          permitRejectDelay.toMillis(),
+          messageMetadata.getCorrelationUid());
       this.deviceRequestMessageSender.send(messageObject, messageMetadata, permitRejectDelay);
 
     } catch (final DeviceKeyProcessAlreadyRunningException exception) {
       log.info(
-          "Key process is already running for device {}. Sending message {} back to core.",
+          "Key process is already running for device {}. Sending message with correlation UID {} back to core.",
           messageMetadata.getDeviceIdentification(),
           messageMetadata.getCorrelationUid());
       this.deviceRequestMessageSender.send(
@@ -206,6 +208,11 @@ public abstract class DeviceRequestMessageProcessor extends DlmsConnectionMessag
     if (!NO_RESPONSE.equals(response)) {
       this.sendResponseMessage(
           metadata, ResponseMessageResultType.OK, null, this.responseMessageSender, response);
+    } else {
+      log.info(
+          "Response is {}. No sending a ResponseMessage for Correlation UID {}",
+          NO_RESPONSE,
+          metadata.getCorrelationUid());
     }
   }
 
@@ -219,11 +226,6 @@ public abstract class DeviceRequestMessageProcessor extends DlmsConnectionMessag
           metadata.getCorrelationUid(),
           exception);
     }
-    log.error(
-        "Handling ErrorResponse with silent exception in DeviceRequestMessageProcessor during {}, correlationUID: {}",
-        this.messageType.name(),
-        metadata.getCorrelationUid(),
-        exception);
     this.sendResponseMessage(
         metadata,
         ResponseMessageResultType.NOT_OK,

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/DeviceRequestMessageSender.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/DeviceRequestMessageSender.java
@@ -7,6 +7,7 @@ package org.opensmartgridplatform.adapter.protocol.dlms.infra.messaging;
 import jakarta.jms.ObjectMessage;
 import java.io.Serializable;
 import java.time.Duration;
+import lombok.extern.slf4j.Slf4j;
 import org.opensmartgridplatform.shared.infra.jms.JmsMessageCreator;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,6 +15,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jms.core.JmsTemplate;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 public class DeviceRequestMessageSender {
 
@@ -25,6 +27,11 @@ public class DeviceRequestMessageSender {
 
   public void send(
       final Serializable payload, final MessageMetadata messageMetadata, final Duration delay) {
+
+    log.info(
+        "Sending RequestMessage of type {} from DLMS protocol adapter with correlationUid {}",
+        messageMetadata.getMessageType(),
+        messageMetadata.getCorrelationUid());
 
     this.jmsTemplate.send(
         session -> {

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/DeviceResponseMessageSender.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/DeviceResponseMessageSender.java
@@ -35,14 +35,14 @@ public class DeviceResponseMessageSender implements ResponseMessageSender {
 
     if (!(responseMessage instanceof final ProtocolResponseMessage msg)) {
       LOGGER.error(
-          "Only ProtocolResponseMessage type is expected for DeviceResponseMessageSender. Correlation UID = {}",
+          "Only ProtocolResponseMessage type is expected for DeviceResponseMessageSender. CorrelationUid: {}",
           responseMessage.getCorrelationUid());
       return;
     }
 
     if (!ProtocolResponseMessageValidator.isValid(msg, LOGGER)) {
       LOGGER.error(
-          "ProtocolResponseMessage is not valid. DeviceResponseMessageSender is not sending response. Correlation UID = {}",
+          "ProtocolResponseMessage is not valid. DeviceResponseMessageSender is not sending response. CorrelationUid: {}",
           responseMessage.getCorrelationUid());
       return;
     }
@@ -52,7 +52,7 @@ public class DeviceResponseMessageSender implements ResponseMessageSender {
 
   private void sendMessage(final ProtocolResponseMessage responseMessage) {
     LOGGER.info(
-        "Sending ResponseMessage of type {} from DLMS protocol adapter with correlationUID: {}",
+        "Sending ResponseMessage of type {} from DLMS protocol adapter with correlationUid: {}",
         responseMessage.getMessageType(),
         responseMessage.getCorrelationUid());
     this.jmsTemplate.send(new ProtocolResponseMessageCreator(responseMessage));

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/DeviceResponseMessageSender.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/DeviceResponseMessageSender.java
@@ -33,14 +33,17 @@ public class DeviceResponseMessageSender implements ResponseMessageSender {
   @Override
   public void send(final ResponseMessage responseMessage) {
 
-    if (!(responseMessage instanceof ProtocolResponseMessage)) {
-      LOGGER.error("Only ProtocolResponseMessage type is expected for DeviceResponseMessageSender");
+    if (!(responseMessage instanceof final ProtocolResponseMessage msg)) {
+      LOGGER.error(
+          "Only ProtocolResponseMessage type is expected for DeviceResponseMessageSender. Correlation UID = {}",
+          responseMessage.getCorrelationUid());
       return;
     }
 
-    final ProtocolResponseMessage msg = (ProtocolResponseMessage) responseMessage;
-
     if (!ProtocolResponseMessageValidator.isValid(msg, LOGGER)) {
+      LOGGER.error(
+          "ProtocolResponseMessage is not valid. DeviceResponseMessageSender is not sending response. Correlation UID = {}",
+          responseMessage.getCorrelationUid());
       return;
     }
 
@@ -48,6 +51,10 @@ public class DeviceResponseMessageSender implements ResponseMessageSender {
   }
 
   private void sendMessage(final ProtocolResponseMessage responseMessage) {
+    LOGGER.info(
+        "Sending ResponseMessage of type {} from DLMS protocol adapter with correlationUID: {}",
+        responseMessage.getMessageType(),
+        responseMessage.getCorrelationUid());
     this.jmsTemplate.send(new ProtocolResponseMessageCreator(responseMessage));
   }
 

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/DlmsConnectionMessageProcessor.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/DlmsConnectionMessageProcessor.java
@@ -19,6 +19,7 @@ import org.opensmartgridplatform.adapter.protocol.dlms.exceptions.OsgpExceptionC
 import org.opensmartgridplatform.adapter.protocol.dlms.exceptions.ProtocolAdapterException;
 import org.opensmartgridplatform.shared.exceptionhandling.OsgpException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
+import org.opensmartgridplatform.shared.infra.jms.ProtocolResponseMessage;
 import org.opensmartgridplatform.shared.infra.jms.ProtocolResponseMessage.Builder;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessageResultType;
 import org.opensmartgridplatform.throttling.api.Permit;
@@ -170,7 +171,9 @@ public abstract class DlmsConnectionMessageProcessor {
   protected void logJmsException(
       final Logger logger, final JMSException exception, final MessageMetadata messageMetadata) {
     logger.error(
-        "UNRECOVERABLE ERROR, unable to read ObjectMessage instance, giving up.", exception);
+        "UNRECOVERABLE ERROR, unable to read ObjectMessage instance, giving up. correlationUid: {}",
+        messageMetadata.getCorrelationUid(),
+        exception);
     logger.debug("correlationUid: {}", messageMetadata.getCorrelationUid());
     logger.debug("domain: {}", messageMetadata.getDomain());
     logger.debug("domainVersion: {}", messageMetadata.getDomainVersion());
@@ -200,12 +203,6 @@ public abstract class DlmsConnectionMessageProcessor {
         new Builder().messageMetadata(messageMetadata).result(result).dataObject(responseObject);
 
     if (exception != null) {
-
-      LOGGER.error(
-          "DlmsConnectionMessageProcessor.sendResponseMessage (exception) : {}",
-          exception.getMessage(),
-          exception);
-
       messageBuilder.osgpException(
           this.osgpExceptionConverter.ensureOsgpOrTechnicalException(exception));
     }
@@ -215,9 +212,19 @@ public abstract class DlmsConnectionMessageProcessor {
           this.retryHeaderFactory.createRetryHeader(messageMetadata.getRetryCount()));
       messageBuilder.messagePriority(
           this.messagePriorityHandler.recalculatePriority(messageMetadata));
+      LOGGER.info(
+          "Retrying after exception. CorrelationUid: {}", messageMetadata.getCorrelationUid());
+    } else {
+      LOGGER.info(
+          "No retrying after exception. CorrelationUid: {}", messageMetadata.getCorrelationUid());
     }
 
-    responseMessageSender.send(messageBuilder.build());
+    final ProtocolResponseMessage protocolResponseMessage = messageBuilder.build();
+    LOGGER.info(
+        "MessageMetadata [ {} ] converted to ProtocolResponseMessage [ {} ]",
+        messageMetadata.getCorrelationUid(),
+        protocolResponseMessage.getCorrelationUid());
+    responseMessageSender.send(protocolResponseMessage);
   }
 
   /* suppress unused parameter warning, because we need it in override method */

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/DlmsConnectionMessageProcessor.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/DlmsConnectionMessageProcessor.java
@@ -200,6 +200,9 @@ public abstract class DlmsConnectionMessageProcessor {
         new Builder().messageMetadata(messageMetadata).result(result).dataObject(responseObject);
 
     if (exception != null) {
+
+      LOGGER.error(exception.getMessage(), exception);
+
       messageBuilder.osgpException(
           this.osgpExceptionConverter.ensureOsgpOrTechnicalException(exception));
     }

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/DlmsConnectionMessageProcessor.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/DlmsConnectionMessageProcessor.java
@@ -201,7 +201,10 @@ public abstract class DlmsConnectionMessageProcessor {
 
     if (exception != null) {
 
-      LOGGER.error(exception.getMessage(), exception);
+      LOGGER.error(
+          "DlmsConnectionMessageProcessor.sendResponseMessage (exception) : {}",
+          exception.getMessage(),
+          exception);
 
       messageBuilder.osgpException(
           this.osgpExceptionConverter.ensureOsgpOrTechnicalException(exception));

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/processors/GetKeysRequestMessageProcessor.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/processors/GetKeysRequestMessageProcessor.java
@@ -5,6 +5,7 @@
 package org.opensmartgridplatform.adapter.protocol.dlms.infra.messaging.processors;
 
 import java.io.Serializable;
+import lombok.extern.slf4j.Slf4j;
 import org.opensmartgridplatform.adapter.protocol.dlms.application.services.ConfigurationService;
 import org.opensmartgridplatform.adapter.protocol.dlms.domain.entities.DlmsDevice;
 import org.opensmartgridplatform.adapter.protocol.dlms.infra.messaging.DeviceRequestMessageProcessor;
@@ -12,15 +13,12 @@ import org.opensmartgridplatform.dto.valueobjects.smartmetering.GetKeysRequestDt
 import org.opensmartgridplatform.shared.exceptionhandling.OsgpException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 public class GetKeysRequestMessageProcessor extends DeviceRequestMessageProcessor {
-
-  private static final Logger log = LoggerFactory.getLogger(GetKeysRequestMessageProcessor.class);
 
   @Autowired private ConfigurationService configurationService;
 
@@ -41,7 +39,7 @@ public class GetKeysRequestMessageProcessor extends DeviceRequestMessageProcesso
       throws OsgpException {
 
     log.info(
-        "Handling message of type {} with correlationID {}",
+        "Handling message of type {} with correlationUid {}",
         messageMetadata.getMessageType(),
         messageMetadata.getCorrelationUid());
 

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/processors/GetKeysRequestMessageProcessor.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/processors/GetKeysRequestMessageProcessor.java
@@ -12,11 +12,15 @@ import org.opensmartgridplatform.dto.valueobjects.smartmetering.GetKeysRequestDt
 import org.opensmartgridplatform.shared.exceptionhandling.OsgpException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
 public class GetKeysRequestMessageProcessor extends DeviceRequestMessageProcessor {
+
+  private static final Logger log = LoggerFactory.getLogger(GetKeysRequestMessageProcessor.class);
 
   @Autowired private ConfigurationService configurationService;
 
@@ -35,6 +39,11 @@ public class GetKeysRequestMessageProcessor extends DeviceRequestMessageProcesso
       final Serializable requestObject,
       final MessageMetadata messageMetadata)
       throws OsgpException {
+
+    log.info(
+        "Handling message of type {} with correlationID {}",
+        messageMetadata.getMessageType(),
+        messageMetadata.getCorrelationUid());
 
     this.assertRequestObjectType(GetKeysRequestDto.class, requestObject);
 

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/requests/to/core/OsgpRequestMessageSender.java
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/src/main/java/org/opensmartgridplatform/adapter/protocol/dlms/infra/messaging/requests/to/core/OsgpRequestMessageSender.java
@@ -30,7 +30,10 @@ public class OsgpRequestMessageSender {
       final String messageType,
       final MessageMetadata messageMetadata) {
 
-    log.info("Sending request message to GXF.");
+    log.info(
+        "Sending RequestMessage of type {} from DLMS protocol adapter to core with correlationUID: {}",
+        messageType,
+        messageMetadata.getCorrelationUid());
 
     this.jmsTemplate.send(
         (final Session session) -> {


### PR DESCRIPTION
This PR enriches logging in JMS senders and listeners with correlationUids if not  already there.
This PR also reverts some changes and verbose extra logging form previous PRs (#1553, #1556, #1557 and #1558)