### PR TITLE
sonar-issue-java-s6813-adapter-domain-smartmetering

### DIFF
--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/application/services/ActionMapperService.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/application/services/ActionMapperService.java
@@ -129,7 +129,6 @@ import org.opensmartgridplatform.dto.valueobjects.smartmetering.UpdateFirmwareRe
 import org.opensmartgridplatform.shared.exceptionhandling.ComponentType;
 import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.exceptionhandling.FunctionalExceptionType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.validation.annotation.Validated;
@@ -216,29 +215,38 @@ public class ActionMapperService {
     CLASS_MAP.put(TestAlarmSchedulerRequestData.class, TestAlarmSchedulerRequestDto.class);
   }
 
-  @Autowired
-  @Qualifier("configurationMapper")
-  private ConfigurationMapper configurationMapper;
-
-  @Autowired private ManagementMapper managementMapper;
-
-  @Autowired private MonitoringMapper monitoringMapper;
-
-  @Autowired private CommonMapper commonMapper;
-
-  @Autowired private PeriodicReadsRequestGasDataConverter periodicReadsRequestGasDataConverter;
-
-  @Autowired
-  private ActualMeterReadsRequestGasRequestDataConverter actualReadsRequestGasDataConverter;
-
-  @Autowired private SetKeyOnGMeterDataConverter setKeyOnGMeterDataConverter;
-
-  @Autowired
-  private GetFirmwareVersionGasRequestDataConverter getFirmwareVersionGasRequestDataConverter;
-
-  @Autowired private DomainHelperService domainHelperService;
+  private final ConfigurationMapper configurationMapper;
+  private final ManagementMapper managementMapper;
+  private final MonitoringMapper monitoringMapper;
+  private final CommonMapper commonMapper;
+  private final PeriodicReadsRequestGasDataConverter periodicReadsRequestGasDataConverter;
+  private final ActualMeterReadsRequestGasRequestDataConverter actualReadsRequestGasDataConverter;
+  private final SetKeyOnGMeterDataConverter setKeyOnGMeterDataConverter;
+  private final GetFirmwareVersionGasRequestDataConverter getFirmwareVersionGasRequestDataConverter;
+  private final DomainHelperService domainHelperService;
 
   private final FaultResponseFactory faultResponseFactory = new FaultResponseFactory();
+
+  public ActionMapperService(
+      @Qualifier("configurationMapper") final ConfigurationMapper configurationMapper,
+      final ManagementMapper managementMapper,
+      final MonitoringMapper monitoringMapper,
+      final CommonMapper commonMapper,
+      final PeriodicReadsRequestGasDataConverter periodicReadsRequestGasDataConverter,
+      final ActualMeterReadsRequestGasRequestDataConverter actualReadsRequestGasDataConverter,
+      final SetKeyOnGMeterDataConverter setKeyOnGMeterDataConverter,
+      final GetFirmwareVersionGasRequestDataConverter getFirmwareVersionGasRequestDataConverter,
+      final DomainHelperService domainHelperService) {
+    this.configurationMapper = configurationMapper;
+    this.managementMapper = managementMapper;
+    this.monitoringMapper = monitoringMapper;
+    this.commonMapper = commonMapper;
+    this.periodicReadsRequestGasDataConverter = periodicReadsRequestGasDataConverter;
+    this.actualReadsRequestGasDataConverter = actualReadsRequestGasDataConverter;
+    this.setKeyOnGMeterDataConverter = setKeyOnGMeterDataConverter;
+    this.getFirmwareVersionGasRequestDataConverter = getFirmwareVersionGasRequestDataConverter;
+    this.domainHelperService = domainHelperService;
+  }
 
   /** Specifies which mapper to use for the core class received. */
   @PostConstruct

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/in/messageprocessors/PushNotificationAlarmRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/in/messageprocessors/PushNotificationAlarmRequestMessageProcessor.java
@@ -12,7 +12,6 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.RequestMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
@@ -20,13 +19,14 @@ import org.springframework.stereotype.Component;
 @Component
 public class PushNotificationAlarmRequestMessageProcessor extends BaseRequestMessageProcessor {
 
-  @Autowired private NotificationService notificationService;
+  private final NotificationService notificationService;
 
-  @Autowired
   protected PushNotificationAlarmRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundOsgpCoreRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      final NotificationService notificationService) {
     super(messageProcessorMap, MessageType.PUSH_NOTIFICATION_ALARM);
+    this.notificationService = notificationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/in/messageprocessors/SystemEventRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/in/messageprocessors/SystemEventRequestMessageProcessor.java
@@ -12,7 +12,6 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.RequestMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
@@ -20,13 +19,14 @@ import org.springframework.stereotype.Component;
 @Component
 public class SystemEventRequestMessageProcessor extends BaseRequestMessageProcessor {
 
-  @Autowired private NotificationService notificationService;
+  private final NotificationService notificationService;
 
-  @Autowired
   protected SystemEventRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundOsgpCoreRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      final NotificationService notificationService) {
     super(messageProcessorMap, MessageType.SYSTEM_EVENT);
+    this.notificationService = notificationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/ActualMeterReadsResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/ActualMeterReadsResponseMessageProcessor.java
@@ -15,25 +15,25 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class ActualMeterReadsResponseMessageProcessor extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired private MonitoringService monitoringService;
+  private final MonitoringService monitoringService;
 
-  @Autowired
   protected ActualMeterReadsResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      final MonitoringService monitoringService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.REQUEST_ACTUAL_METER_DATA,
         ComponentType.DOMAIN_SMART_METERING);
+    this.monitoringService = monitoringService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/ActualPowerQualityResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/ActualPowerQualityResponseMessageProcessor.java
@@ -16,27 +16,26 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class ActualPowerQualityResponseMessageProcessor extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringMonitoringService")
-  private MonitoringService monitoringService;
+  private final MonitoringService monitoringService;
 
-  @Autowired
   protected ActualPowerQualityResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringMonitoringService")
+          final MonitoringService monitoringService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.GET_ACTUAL_POWER_QUALITY,
         ComponentType.DOMAIN_SMART_METERING);
+    this.monitoringService = monitoringService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/AddMeterResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/AddMeterResponseMessageProcessor.java
@@ -15,7 +15,6 @@ import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
@@ -26,18 +25,19 @@ public class AddMeterResponseMessageProcessor extends OsgpCoreResponseMessagePro
   private static final Logger LOGGER =
       LoggerFactory.getLogger(AddMeterResponseMessageProcessor.class);
 
-  @Autowired private InstallationService installationService;
+  private final InstallationService installationService;
 
-  @Autowired
   protected AddMeterResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      final InstallationService installationService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.ADD_METER,
         ComponentType.DOMAIN_SMART_METERING);
+    this.installationService = installationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/BundleResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/BundleResponseMessageProcessor.java
@@ -21,7 +21,6 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
@@ -29,22 +28,21 @@ import org.springframework.stereotype.Component;
 @Component
 public class BundleResponseMessageProcessor extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringBundleService")
-  private BundleService bundleService;
+  private final BundleService bundleService;
 
   private final FaultResponseFactory faultResponseFactory;
 
-  @Autowired
   public BundleResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringBundleService") final BundleService bundleService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.HANDLE_BUNDLED_ACTIONS,
         ComponentType.DOMAIN_SMART_METERING);
+    this.bundleService = bundleService;
     this.faultResponseFactory = new FaultResponseFactory();
   }
 

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/ClearAlarmRegisterResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/ClearAlarmRegisterResponseMessageProcessor.java
@@ -13,25 +13,25 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class ClearAlarmRegisterResponseMessageProcessor extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired private MonitoringService monitoringService;
+  private final MonitoringService monitoringService;
 
-  @Autowired
   protected ClearAlarmRegisterResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      final MonitoringService monitoringService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.CLEAR_ALARM_REGISTER,
         ComponentType.DOMAIN_SMART_METERING);
+    this.monitoringService = monitoringService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/ClearMBusStatusOnAllChannelsResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/ClearMBusStatusOnAllChannelsResponseMessageProcessor.java
@@ -13,7 +13,6 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
@@ -21,20 +20,20 @@ import org.springframework.stereotype.Component;
 public class ClearMBusStatusOnAllChannelsResponseMessageProcessor
     extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringManagementService")
-  private ManagementService managementService;
+  private final ManagementService managementService;
 
-  @Autowired
   protected ClearMBusStatusOnAllChannelsResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringManagementService")
+          final ManagementService managementService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.CLEAR_MBUS_STATUS_ON_ALL_CHANNELS,
         ComponentType.DOMAIN_SMART_METERING);
+    this.managementService = managementService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/ConfigureDefinableLoadProfileResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/ConfigureDefinableLoadProfileResponseMessageProcessor.java
@@ -13,7 +13,6 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
@@ -21,18 +20,19 @@ import org.springframework.stereotype.Component;
 public class ConfigureDefinableLoadProfileResponseMessageProcessor
     extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
 
-  @Autowired
   protected ConfigureDefinableLoadProfileResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      final ConfigurationService configurationService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.CONFIGURE_DEFINABLE_LOAD_PROFILE,
         ComponentType.DOMAIN_SMART_METERING);
+    this.configurationService = configurationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/CoupleMbusDeviceByChannelResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/CoupleMbusDeviceByChannelResponseMessageProcessor.java
@@ -15,7 +15,6 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
@@ -23,18 +22,19 @@ import org.springframework.stereotype.Component;
 public class CoupleMbusDeviceByChannelResponseMessageProcessor
     extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired private InstallationService installationService;
+  private final InstallationService installationService;
 
-  @Autowired
   protected CoupleMbusDeviceByChannelResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      final InstallationService installationService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.COUPLE_MBUS_DEVICE_BY_CHANNEL,
         ComponentType.DOMAIN_SMART_METERING);
+    this.installationService = installationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/CoupleMbusDeviceResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/CoupleMbusDeviceResponseMessageProcessor.java
@@ -15,25 +15,25 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class CoupleMbusDeviceResponseMessageProcessor extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired private InstallationService installationService;
+  private final InstallationService installationService;
 
-  @Autowired
   protected CoupleMbusDeviceResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      final InstallationService installationService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.COUPLE_MBUS_DEVICE,
         ComponentType.DOMAIN_SMART_METERING);
+    this.installationService = installationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/DecoupleMbusDeviceResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/DecoupleMbusDeviceResponseMessageProcessor.java
@@ -15,25 +15,25 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class DecoupleMbusDeviceResponseMessageProcessor extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired private InstallationService installationService;
+  private final InstallationService installationService;
 
-  @Autowired
   protected DecoupleMbusDeviceResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      final InstallationService installationService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.DECOUPLE_MBUS_DEVICE,
         ComponentType.DOMAIN_SMART_METERING);
+    this.installationService = installationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/DisableDebuggingResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/DisableDebuggingResponseMessageProcessor.java
@@ -13,25 +13,25 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class DisableDebuggingResponseMessageProcessor extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired private ManagementService managementService;
+  private final ManagementService managementService;
 
-  @Autowired
   public DisableDebuggingResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      final ManagementService managementService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.DISABLE_DEBUGGING,
         ComponentType.DOMAIN_SMART_METERING);
+    this.managementService = managementService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/EnableDebuggingResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/EnableDebuggingResponseMessageProcessor.java
@@ -13,25 +13,25 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class EnableDebuggingResponseMessageProcessor extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired private ManagementService managementService;
+  private final ManagementService managementService;
 
-  @Autowired
   public EnableDebuggingResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      final ManagementService managementService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.ENABLE_DEBUGGING,
         ComponentType.DOMAIN_SMART_METERING);
+    this.managementService = managementService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/FindEventsResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/FindEventsResponseMessageProcessor.java
@@ -15,27 +15,26 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class FindEventsResponseMessageProcessor extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringManagementService")
-  private ManagementService managementService;
+  private final ManagementService managementService;
 
-  @Autowired
   public FindEventsResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringManagementService")
+          final ManagementService managementService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.FIND_EVENTS,
         ComponentType.DOMAIN_SMART_METERING);
+    this.managementService = managementService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/GenerateAndReplaceKeysResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/GenerateAndReplaceKeysResponseMessageProcessor.java
@@ -21,18 +21,20 @@ import org.springframework.stereotype.Component;
 public class GenerateAndReplaceKeysResponseMessageProcessor
     extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
 
   @Autowired
   protected GenerateAndReplaceKeysResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      final ConfigurationService configurationService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.GENERATE_AND_REPLACE_KEYS,
         ComponentType.DOMAIN_SMART_METERING);
+    this.configurationService = configurationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/GetAdministrativeStateResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/GetAdministrativeStateResponseMessageProcessor.java
@@ -14,7 +14,6 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
@@ -22,18 +21,19 @@ import org.springframework.stereotype.Component;
 public class GetAdministrativeStateResponseMessageProcessor
     extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
 
-  @Autowired
   public GetAdministrativeStateResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      final ConfigurationService configurationService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.GET_ADMINISTRATIVE_STATUS,
         ComponentType.DOMAIN_SMART_METERING);
+    this.configurationService = configurationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/GetAllAttributeValuesResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/GetAllAttributeValuesResponseMessageProcessor.java
@@ -13,7 +13,6 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
@@ -21,20 +20,19 @@ import org.springframework.stereotype.Component;
 public class GetAllAttributeValuesResponseMessageProcessor
     extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringAdhocService")
-  private AdhocService adhocService;
+  private final AdhocService adhocService;
 
-  @Autowired
   public GetAllAttributeValuesResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringAdhocService") final AdhocService adhocService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.GET_ALL_ATTRIBUTE_VALUES,
         ComponentType.DOMAIN_SMART_METERING);
+    this.adhocService = adhocService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/GetAssociationLnObjectsResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/GetAssociationLnObjectsResponseMessageProcessor.java
@@ -22,20 +22,20 @@ import org.springframework.stereotype.Component;
 public class GetAssociationLnObjectsResponseMessageProcessor
     extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringAdhocService")
-  private AdhocService adhocService;
+  private final AdhocService adhocService;
 
   @Autowired
   public GetAssociationLnObjectsResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringAdhocService") final AdhocService adhocService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.GET_ASSOCIATION_LN_OBJECTS,
         ComponentType.DOMAIN_SMART_METERING);
+    this.adhocService = adhocService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/GetConfigurationObjectResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/GetConfigurationObjectResponseMessageProcessor.java
@@ -14,7 +14,6 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
@@ -22,20 +21,20 @@ import org.springframework.stereotype.Component;
 public class GetConfigurationObjectResponseMessageProcessor
     extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringConfigurationService")
-  private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
 
-  @Autowired
   protected GetConfigurationObjectResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringConfigurationService")
+          final ConfigurationService configurationService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.GET_CONFIGURATION_OBJECT,
         ComponentType.DOMAIN_SMART_METERING);
+    this.configurationService = configurationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/GetFirmwareVersionResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/GetFirmwareVersionResponseMessageProcessor.java
@@ -19,25 +19,26 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class GetFirmwareVersionResponseMessageProcessor extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
 
-  @Autowired
   protected GetFirmwareVersionResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringConfigurationService")
+          final ConfigurationService configurationService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.GET_FIRMWARE_VERSION,
         ComponentType.DOMAIN_SMART_METERING);
+    this.configurationService = configurationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/GetGsmDiagnosticResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/GetGsmDiagnosticResponseMessageProcessor.java
@@ -14,27 +14,26 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class GetGsmDiagnosticResponseMessageProcessor extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringManagementService")
-  private ManagementService managementService;
+  private final ManagementService managementService;
 
-  @Autowired
   protected GetGsmDiagnosticResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringManagementService")
+          final ManagementService managementService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.GET_GSM_DIAGNOSTIC,
         ComponentType.DOMAIN_SMART_METERING);
+    this.managementService = managementService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/GetKeysResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/GetKeysResponseMessageProcessor.java
@@ -14,27 +14,26 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class GetKeysResponseMessageProcessor extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringConfigurationService")
-  private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
 
-  @Autowired
   protected GetKeysResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringConfigurationService")
+          final ConfigurationService configurationService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.GET_KEYS,
         ComponentType.DOMAIN_SMART_METERING);
+    this.configurationService = configurationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/GetMbusEncryptionKeyStatusByChannelResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/GetMbusEncryptionKeyStatusByChannelResponseMessageProcessor.java
@@ -14,7 +14,6 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
@@ -22,18 +21,19 @@ import org.springframework.stereotype.Component;
 public class GetMbusEncryptionKeyStatusByChannelResponseMessageProcessor
     extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
 
-  @Autowired
   public GetMbusEncryptionKeyStatusByChannelResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      final ConfigurationService configurationService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.GET_MBUS_ENCRYPTION_KEY_STATUS_BY_CHANNEL,
         ComponentType.DOMAIN_SMART_METERING);
+    this.configurationService = configurationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/GetMbusEncryptionKeyStatusResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/GetMbusEncryptionKeyStatusResponseMessageProcessor.java
@@ -14,7 +14,6 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
@@ -22,18 +21,19 @@ import org.springframework.stereotype.Component;
 public class GetMbusEncryptionKeyStatusResponseMessageProcessor
     extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
 
-  @Autowired
   public GetMbusEncryptionKeyStatusResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      final ConfigurationService configurationService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.GET_MBUS_ENCRYPTION_KEY_STATUS,
         ComponentType.DOMAIN_SMART_METERING);
+    this.configurationService = configurationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/GetPowerQualityProfileResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/GetPowerQualityProfileResponseMessageProcessor.java
@@ -16,7 +16,6 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
@@ -24,20 +23,20 @@ import org.springframework.stereotype.Component;
 public class GetPowerQualityProfileResponseMessageProcessor
     extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringMonitoringService")
-  private MonitoringService monitoringService;
+  private final MonitoringService monitoringService;
 
-  @Autowired
   protected GetPowerQualityProfileResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringMonitoringService")
+          final MonitoringService monitoringService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.GET_PROFILE_GENERIC_DATA,
         ComponentType.DOMAIN_SMART_METERING);
+    this.monitoringService = monitoringService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/GetSpecificAttributeValueResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/GetSpecificAttributeValueResponseMessageProcessor.java
@@ -13,7 +13,6 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
@@ -21,20 +20,19 @@ import org.springframework.stereotype.Component;
 public class GetSpecificAttributeValueResponseMessageProcessor
     extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringAdhocService")
-  private AdhocService adhocService;
+  private final AdhocService adhocService;
 
-  @Autowired
   public GetSpecificAttributeValueResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringAdhocService") final AdhocService adhocService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.GET_SPECIFIC_ATTRIBUTE_VALUE,
         ComponentType.DOMAIN_SMART_METERING);
+    this.adhocService = adhocService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/GetThdFingerprintResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/GetThdFingerprintResponseMessageProcessor.java
@@ -14,27 +14,26 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class GetThdFingerprintResponseMessageProcessor extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringMonitoringService")
-  private MonitoringService monitoringService;
+  private final MonitoringService monitoringService;
 
-  @Autowired
   protected GetThdFingerprintResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringMonitoringService")
+          final MonitoringService monitoringService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.GET_THD_FINGERPRINT,
         ComponentType.DOMAIN_SMART_METERING);
+    this.monitoringService = monitoringService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/PeriodicMeterReadsresponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/PeriodicMeterReadsresponseMessageProcessor.java
@@ -15,27 +15,26 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class PeriodicMeterReadsresponseMessageProcessor extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringMonitoringService")
-  private MonitoringService monitoringService;
+  private final MonitoringService monitoringService;
 
-  @Autowired
   protected PeriodicMeterReadsresponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringMonitoringService")
+          final MonitoringService monitoringService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.REQUEST_PERIODIC_METER_DATA,
         ComponentType.DOMAIN_SMART_METERING);
+    this.monitoringService = monitoringService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/ReadAlarmRegisterResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/ReadAlarmRegisterResponseMessageProcessor.java
@@ -14,25 +14,25 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class ReadAlarmRegisterResponseMessageProcessor extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired private MonitoringService monitoringService;
+  private final MonitoringService monitoringService;
 
-  @Autowired
   protected ReadAlarmRegisterResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      final MonitoringService monitoringService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.READ_ALARM_REGISTER,
         ComponentType.DOMAIN_SMART_METERING);
+    this.monitoringService = monitoringService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/ReplaceKeysResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/ReplaceKeysResponseMessageProcessor.java
@@ -13,25 +13,25 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class ReplaceKeysResponseMessageProcessor extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
 
-  @Autowired
   protected ReplaceKeysResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      final ConfigurationService configurationService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.REPLACE_KEYS,
         ComponentType.DOMAIN_SMART_METERING);
+    this.configurationService = configurationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/ScanMbusChannelsResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/ScanMbusChannelsResponseMessageProcessor.java
@@ -16,27 +16,25 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class ScanMbusChannelsResponseMessageProcessor extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringAdhocService")
-  private AdhocService adhocService;
+  private final AdhocService adhocService;
 
-  @Autowired
   public ScanMbusChannelsResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringAdhocService") final AdhocService adhocService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.SCAN_MBUS_CHANNELS,
         ComponentType.DOMAIN_SMART_METERING);
+    this.adhocService = adhocService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SetActivityCalendarResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SetActivityCalendarResponseMessageProcessor.java
@@ -13,7 +13,6 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
@@ -21,18 +20,19 @@ import org.springframework.stereotype.Component;
 @Component
 public class SetActivityCalendarResponseMessageProcessor extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
 
-  @Autowired
   protected SetActivityCalendarResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      final ConfigurationService configurationService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.SET_ACTIVITY_CALENDAR,
         ComponentType.DOMAIN_SMART_METERING);
+    this.configurationService = configurationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SetAdministrativeStatusResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SetAdministrativeStatusResponseMessageProcessor.java
@@ -13,7 +13,6 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
@@ -21,18 +20,19 @@ import org.springframework.stereotype.Component;
 public class SetAdministrativeStatusResponseMessageProcessor
     extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
 
-  @Autowired
   public SetAdministrativeStatusResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      final ConfigurationService configurationService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.SET_ADMINISTRATIVE_STATUS,
         ComponentType.DOMAIN_SMART_METERING);
+    this.configurationService = configurationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SetAlarmNotificationsResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SetAlarmNotificationsResponseMessageProcessor.java
@@ -13,7 +13,6 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
@@ -22,18 +21,19 @@ import org.springframework.stereotype.Component;
 public class SetAlarmNotificationsResponseMessageProcessor
     extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
 
-  @Autowired
   protected SetAlarmNotificationsResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      final ConfigurationService configurationService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.SET_ALARM_NOTIFICATIONS,
         ComponentType.DOMAIN_SMART_METERING);
+    this.configurationService = configurationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SetClockConfigurationResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SetClockConfigurationResponseMessageProcessor.java
@@ -13,7 +13,6 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
@@ -21,18 +20,19 @@ import org.springframework.stereotype.Component;
 public class SetClockConfigurationResponseMessageProcessor
     extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
 
-  @Autowired
   protected SetClockConfigurationResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      final ConfigurationService configurationService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.SET_CLOCK_CONFIGURATION,
         ComponentType.DOMAIN_SMART_METERING);
+    this.configurationService = configurationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SetConfigurationObjectResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SetConfigurationObjectResponseMessageProcessor.java
@@ -13,7 +13,6 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
@@ -21,20 +20,20 @@ import org.springframework.stereotype.Component;
 public class SetConfigurationObjectResponseMessageProcessor
     extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringConfigurationService")
-  private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
 
-  @Autowired
   protected SetConfigurationObjectResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringConfigurationService")
+          final ConfigurationService configurationService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.SET_CONFIGURATION_OBJECT,
         ComponentType.DOMAIN_SMART_METERING);
+    this.configurationService = configurationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SetDeviceCommunicationSettingsResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SetDeviceCommunicationSettingsResponseMessageProcessor.java
@@ -13,7 +13,6 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
@@ -21,18 +20,19 @@ import org.springframework.stereotype.Component;
 public class SetDeviceCommunicationSettingsResponseMessageProcessor
     extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired private ManagementService managementService;
+  private final ManagementService managementService;
 
-  @Autowired
   protected SetDeviceCommunicationSettingsResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      final ManagementService managementService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.SET_DEVICE_COMMUNICATION_SETTINGS,
         ComponentType.DOMAIN_SMART_METERING);
+    this.managementService = managementService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SetDeviceLifecycleStatusByChannelResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SetDeviceLifecycleStatusByChannelResponseMessageProcessor.java
@@ -15,7 +15,6 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
@@ -23,18 +22,19 @@ import org.springframework.stereotype.Component;
 public class SetDeviceLifecycleStatusByChannelResponseMessageProcessor
     extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired private ManagementService managementService;
+  private final ManagementService managementService;
 
-  @Autowired
   protected SetDeviceLifecycleStatusByChannelResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      final ManagementService managementService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.SET_DEVICE_LIFECYCLE_STATUS_BY_CHANNEL,
         ComponentType.DOMAIN_SMART_METERING);
+    this.managementService = managementService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SetKeyOnGMeterResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SetKeyOnGMeterResponseMessageProcessor.java
@@ -13,25 +13,25 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class SetKeyOnGMeterResponseMessageProcessor extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
 
-  @Autowired
   protected SetKeyOnGMeterResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      final ConfigurationService configurationService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.SET_KEY_ON_G_METER,
         ComponentType.DOMAIN_SMART_METERING);
+    this.configurationService = configurationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SetMbusUserKeyByChannelResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SetMbusUserKeyByChannelResponseMessageProcessor.java
@@ -13,7 +13,6 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
@@ -22,18 +21,19 @@ import org.springframework.stereotype.Component;
 public class SetMbusUserKeyByChannelResponseMessageProcessor
     extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
 
-  @Autowired
   protected SetMbusUserKeyByChannelResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      final ConfigurationService configurationService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.SET_MBUS_USER_KEY_BY_CHANNEL,
         ComponentType.DOMAIN_SMART_METERING);
+    this.configurationService = configurationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SetPushSetupAlarmResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SetPushSetupAlarmResponseMessageProcessor.java
@@ -13,7 +13,6 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
@@ -21,18 +20,19 @@ import org.springframework.stereotype.Component;
 @Component
 public class SetPushSetupAlarmResponseMessageProcessor extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
 
-  @Autowired
   protected SetPushSetupAlarmResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      final ConfigurationService configurationService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.SET_PUSH_SETUP_ALARM,
         ComponentType.DOMAIN_SMART_METERING);
+    this.configurationService = configurationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SetPushSetupLastGaspResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SetPushSetupLastGaspResponseMessageProcessor.java
@@ -13,7 +13,6 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
@@ -21,18 +20,19 @@ import org.springframework.stereotype.Component;
 @Component
 public class SetPushSetupLastGaspResponseMessageProcessor extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
 
-  @Autowired
   protected SetPushSetupLastGaspResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      final ConfigurationService configurationService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.SET_PUSH_SETUP_LAST_GASP,
         ComponentType.DOMAIN_SMART_METERING);
+    this.configurationService = configurationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SetPushSetupSmsResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SetPushSetupSmsResponseMessageProcessor.java
@@ -13,7 +13,6 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
@@ -21,18 +20,19 @@ import org.springframework.stereotype.Component;
 @Component
 public class SetPushSetupSmsResponseMessageProcessor extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
 
-  @Autowired
   protected SetPushSetupSmsResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      final ConfigurationService configurationService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.SET_PUSH_SETUP_SMS,
         ComponentType.DOMAIN_SMART_METERING);
+    this.configurationService = configurationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SetPushSetupUdpResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SetPushSetupUdpResponseMessageProcessor.java
@@ -18,7 +18,6 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
@@ -26,18 +25,19 @@ import org.springframework.stereotype.Component;
 @Component
 public class SetPushSetupUdpResponseMessageProcessor extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
 
-  @Autowired
   protected SetPushSetupUdpResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      final ConfigurationService configurationService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.SET_PUSH_SETUP_UDP,
         ComponentType.DOMAIN_SMART_METERING);
+    this.configurationService = configurationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SetRandomisationSettingsResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SetRandomisationSettingsResponseMessageProcessor.java
@@ -13,7 +13,6 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
@@ -21,20 +20,20 @@ import org.springframework.stereotype.Component;
 public class SetRandomisationSettingsResponseMessageProcessor
     extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringConfigurationService")
-  private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
 
-  @Autowired
   protected SetRandomisationSettingsResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringConfigurationService")
+          final ConfigurationService configurationService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.SET_RANDOMISATION_SETTINGS,
         ComponentType.DOMAIN_SMART_METERING);
+    this.configurationService = configurationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SetSpecificAttributeValueResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SetSpecificAttributeValueResponseMessageProcessor.java
@@ -13,7 +13,6 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
@@ -23,7 +22,6 @@ public class SetSpecificAttributeValueResponseMessageProcessor
 
   private final AdhocService adhocService;
 
-  @Autowired
   public SetSpecificAttributeValueResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SpecialDaysResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SpecialDaysResponseMessageProcessor.java
@@ -13,27 +13,26 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class SpecialDaysResponseMessageProcessor extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringConfigurationService")
-  private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
 
-  @Autowired
   protected SpecialDaysResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringConfigurationService")
+          final ConfigurationService configurationService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.SET_SPECIAL_DAYS,
         ComponentType.DOMAIN_SMART_METERING);
+    this.configurationService = configurationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SynchronizeTimeResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/SynchronizeTimeResponseMessageProcessor.java
@@ -13,27 +13,25 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class SynchronizeTimeResponseMessageProcessor extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringAdhocService")
-  private AdhocService adhocService;
+  private final AdhocService adhocService;
 
-  @Autowired
   protected SynchronizeTimeResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringAdhocService") final AdhocService adhocService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.SYNCHRONIZE_TIME,
         ComponentType.DOMAIN_SMART_METERING);
+    this.adhocService = adhocService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/TestAlarmSchedulerResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/TestAlarmSchedulerResponseMessageProcessor.java
@@ -13,27 +13,25 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class TestAlarmSchedulerResponseMessageProcessor extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringAdhocService")
-  private AdhocService adhocService;
+  private final AdhocService adhocService;
 
-  @Autowired
   protected TestAlarmSchedulerResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringAdhocService") final AdhocService adhocService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.SCHEDULE_TEST_ALARM,
         ComponentType.DOMAIN_SMART_METERING);
+    this.adhocService = adhocService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/UpdateFirmwareResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/UpdateFirmwareResponseMessageProcessor.java
@@ -16,25 +16,25 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class UpdateFirmwareResponseMessageProcessor extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
 
-  @Autowired
   protected UpdateFirmwareResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      final ConfigurationService configurationService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.UPDATE_FIRMWARE,
         ComponentType.DOMAIN_SMART_METERING);
+    this.configurationService = configurationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/UpdateProtocolResponseMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/core/messageprocessors/UpdateProtocolResponseMessageProcessor.java
@@ -15,25 +15,25 @@ import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
 import org.opensmartgridplatform.shared.infra.jms.ResponseMessage;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class UpdateProtocolResponseMessageProcessor extends OsgpCoreResponseMessageProcessor {
 
-  @Autowired private ManagementService managementService;
+  private final ManagementService managementService;
 
-  @Autowired
   protected UpdateProtocolResponseMessageProcessor(
       final WebServiceResponseMessageSender responseMessageSender,
       @Qualifier("domainSmartMeteringInboundOsgpCoreResponsesMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      final ManagementService managementService) {
     super(
         responseMessageSender,
         messageProcessorMap,
         MessageType.UPDATE_PROTOCOL,
         ComponentType.DOMAIN_SMART_METERING);
+    this.managementService = managementService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/ActualMeterReadsRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/ActualMeterReadsRequestMessageProcessor.java
@@ -11,22 +11,21 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class ActualMeterReadsRequestMessageProcessor extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringMonitoringService")
-  private MonitoringService monitoringService;
+  private final MonitoringService monitoringService;
 
-  @Autowired
   public ActualMeterReadsRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringMonitoringService")
+          final MonitoringService monitoringService) {
     super(messageProcessorMap, MessageType.REQUEST_ACTUAL_METER_DATA);
+    this.monitoringService = monitoringService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/ActualPowerQualityRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/ActualPowerQualityRequestMessageProcessor.java
@@ -11,22 +11,21 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class ActualPowerQualityRequestMessageProcessor extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringMonitoringService")
-  private MonitoringService monitoringService;
+  private final MonitoringService monitoringService;
 
-  @Autowired
   public ActualPowerQualityRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringMonitoringService")
+          final MonitoringService monitoringService) {
     super(messageProcessorMap, MessageType.GET_ACTUAL_POWER_QUALITY);
+    this.monitoringService = monitoringService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/AddMeterRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/AddMeterRequestMessageProcessor.java
@@ -11,22 +11,21 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class AddMeterRequestMessageProcessor extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringInstallationService")
-  private InstallationService installationService;
+  private final InstallationService installationService;
 
-  @Autowired
   protected AddMeterRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringInstallationService")
+          final InstallationService installationService) {
     super(messageProcessorMap, MessageType.ADD_METER);
+    this.installationService = installationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/BundleMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/BundleMessageProcessor.java
@@ -11,22 +11,20 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class BundleMessageProcessor extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringBundleService")
-  private BundleService bundleService;
+  private final BundleService bundleService;
 
-  @Autowired
   protected BundleMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringBundleService") final BundleService bundleService) {
     super(messageProcessorMap, MessageType.HANDLE_BUNDLED_ACTIONS);
+    this.bundleService = bundleService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/ClearAlarmRegisterRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/ClearAlarmRegisterRequestMessageProcessor.java
@@ -11,22 +11,21 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class ClearAlarmRegisterRequestMessageProcessor extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringMonitoringService")
-  private MonitoringService monitoringService;
+  private final MonitoringService monitoringService;
 
-  @Autowired
   protected ClearAlarmRegisterRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringMonitoringService")
+          final MonitoringService monitoringService) {
     super(messageProcessorMap, MessageType.CLEAR_ALARM_REGISTER);
+    this.monitoringService = monitoringService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/ClearMBusStatusOnAllChannelsRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/ClearMBusStatusOnAllChannelsRequestMessageProcessor.java
@@ -11,7 +11,6 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
@@ -19,15 +18,15 @@ import org.springframework.stereotype.Component;
 public class ClearMBusStatusOnAllChannelsRequestMessageProcessor
     extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringManagementService")
-  private ManagementService managementService;
+  private final ManagementService managementService;
 
-  @Autowired
   protected ClearMBusStatusOnAllChannelsRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringManagementService")
+          final ManagementService managementService) {
     super(messageProcessorMap, MessageType.CLEAR_MBUS_STATUS_ON_ALL_CHANNELS);
+    this.managementService = managementService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/ConfigureDefinableLoadProfileRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/ConfigureDefinableLoadProfileRequestMessageProcessor.java
@@ -11,7 +11,6 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
@@ -19,15 +18,15 @@ import org.springframework.stereotype.Component;
 public class ConfigureDefinableLoadProfileRequestMessageProcessor
     extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringConfigurationService")
-  private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
 
-  @Autowired
   protected ConfigureDefinableLoadProfileRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringConfigurationService")
+          final ConfigurationService configurationService) {
     super(messageProcessorMap, MessageType.CONFIGURE_DEFINABLE_LOAD_PROFILE);
+    this.configurationService = configurationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/CoupleMbusDeviceByChannelRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/CoupleMbusDeviceByChannelRequestMessageProcessor.java
@@ -11,22 +11,21 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class CoupleMbusDeviceByChannelRequestMessageProcessor extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringInstallationService")
-  private InstallationService installationService;
+  private final InstallationService installationService;
 
-  @Autowired
   protected CoupleMbusDeviceByChannelRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringInstallationService")
+          final InstallationService installationService) {
     super(messageProcessorMap, MessageType.COUPLE_MBUS_DEVICE_BY_CHANNEL);
+    this.installationService = installationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/CoupleMbusDeviceRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/CoupleMbusDeviceRequestMessageProcessor.java
@@ -11,7 +11,6 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
@@ -22,15 +21,15 @@ import org.springframework.stereotype.Component;
 @Component
 public class CoupleMbusDeviceRequestMessageProcessor extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringInstallationService")
-  private InstallationService installationService;
+  private final InstallationService installationService;
 
-  @Autowired
   protected CoupleMbusDeviceRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringInstallationService")
+          final InstallationService installationService) {
     super(messageProcessorMap, MessageType.COUPLE_MBUS_DEVICE);
+    this.installationService = installationService;
   }
 
   /*

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/DecoupleMbusDeviceAdministrativeRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/DecoupleMbusDeviceAdministrativeRequestMessageProcessor.java
@@ -11,7 +11,6 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
@@ -23,15 +22,15 @@ import org.springframework.stereotype.Component;
 public class DecoupleMbusDeviceAdministrativeRequestMessageProcessor
     extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringInstallationService")
-  private InstallationService installationService;
+  private final InstallationService installationService;
 
-  @Autowired
   protected DecoupleMbusDeviceAdministrativeRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringInstallationService")
+          final InstallationService installationService) {
     super(messageProcessorMap, MessageType.DECOUPLE_MBUS_DEVICE_ADMINISTRATIVE);
+    this.installationService = installationService;
   }
 
   /*

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/DecoupleMbusDeviceRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/DecoupleMbusDeviceRequestMessageProcessor.java
@@ -11,7 +11,6 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
@@ -22,15 +21,15 @@ import org.springframework.stereotype.Component;
 @Component
 public class DecoupleMbusDeviceRequestMessageProcessor extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringInstallationService")
-  private InstallationService installationService;
+  private final InstallationService installationService;
 
-  @Autowired
   protected DecoupleMbusDeviceRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringInstallationService")
+          final InstallationService installationService) {
     super(messageProcessorMap, MessageType.DECOUPLE_MBUS_DEVICE);
+    this.installationService = installationService;
   }
 
   /*

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/DisableDebuggingRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/DisableDebuggingRequestMessageProcessor.java
@@ -10,22 +10,21 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class DisableDebuggingRequestMessageProcessor extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringManagementService")
-  private ManagementService managementService;
+  private final ManagementService managementService;
 
-  @Autowired
   protected DisableDebuggingRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringManagementService")
+          final ManagementService managementService) {
     super(messageProcessorMap, MessageType.DISABLE_DEBUGGING);
+    this.managementService = managementService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/EnableDebuggingRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/EnableDebuggingRequestMessageProcessor.java
@@ -10,22 +10,21 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class EnableDebuggingRequestMessageProcessor extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringManagementService")
-  private ManagementService managementService;
+  private final ManagementService managementService;
 
-  @Autowired
   protected EnableDebuggingRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringManagementService")
+          final ManagementService managementService) {
     super(messageProcessorMap, MessageType.ENABLE_DEBUGGING);
+    this.managementService = managementService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/FindEventsRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/FindEventsRequestMessageProcessor.java
@@ -11,22 +11,21 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class FindEventsRequestMessageProcessor extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringManagementService")
-  private ManagementService managementService;
+  private final ManagementService managementService;
 
-  @Autowired
   protected FindEventsRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringManagementService")
+          final ManagementService managementService) {
     super(messageProcessorMap, MessageType.FIND_EVENTS);
+    this.managementService = managementService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/GenerateAndReplaceKeysRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/GenerateAndReplaceKeysRequestMessageProcessor.java
@@ -10,22 +10,21 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class GenerateAndReplaceKeysRequestMessageProcessor extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringConfigurationService")
-  private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
 
-  @Autowired
   protected GenerateAndReplaceKeysRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringConfigurationService")
+          final ConfigurationService configurationService) {
     super(messageProcessorMap, MessageType.GENERATE_AND_REPLACE_KEYS);
+    this.configurationService = configurationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/GetAdministrativeStatusRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/GetAdministrativeStatusRequestMessageProcessor.java
@@ -11,22 +11,21 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class GetAdministrativeStatusRequestMessageProcessor extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringConfigurationService")
-  private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
 
-  @Autowired
   protected GetAdministrativeStatusRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringConfigurationService")
+          final ConfigurationService configurationService) {
     super(messageProcessorMap, MessageType.GET_ADMINISTRATIVE_STATUS);
+    this.configurationService = configurationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/GetAllAttributeValuesRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/GetAllAttributeValuesRequestMessageProcessor.java
@@ -10,22 +10,20 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class GetAllAttributeValuesRequestMessageProcessor extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringAdhocService")
-  private AdhocService adhocService;
+  private final AdhocService adhocService;
 
-  @Autowired
   protected GetAllAttributeValuesRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringAdhocService") final AdhocService adhocService) {
     super(messageProcessorMap, MessageType.GET_ALL_ATTRIBUTE_VALUES);
+    this.adhocService = adhocService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/GetAssociationLnObjectsRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/GetAssociationLnObjectsRequestMessageProcessor.java
@@ -10,22 +10,20 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class GetAssociationLnObjectsRequestMessageProcessor extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringAdhocService")
-  private AdhocService adhocService;
+  private final AdhocService adhocService;
 
-  @Autowired
   protected GetAssociationLnObjectsRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringAdhocService") final AdhocService adhocService) {
     super(messageProcessorMap, MessageType.GET_ASSOCIATION_LN_OBJECTS);
+    this.adhocService = adhocService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/GetConfigurationObjectRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/GetConfigurationObjectRequestMessageProcessor.java
@@ -11,22 +11,21 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class GetConfigurationObjectRequestMessageProcessor extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringConfigurationService")
-  private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
 
-  @Autowired
   protected GetConfigurationObjectRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringConfigurationService")
+          final ConfigurationService configurationService) {
     super(messageProcessorMap, MessageType.GET_CONFIGURATION_OBJECT);
+    this.configurationService = configurationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/GetFirmwareRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/GetFirmwareRequestMessageProcessor.java
@@ -11,7 +11,6 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
@@ -19,15 +18,15 @@ import org.springframework.stereotype.Component;
 @Component
 public class GetFirmwareRequestMessageProcessor extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringConfigurationService")
-  private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
 
-  @Autowired
   public GetFirmwareRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringConfigurationService")
+          final ConfigurationService configurationService) {
     super(messageProcessorMap, MessageType.GET_FIRMWARE_VERSION);
+    this.configurationService = configurationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/GetGsmDiagnosticRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/GetGsmDiagnosticRequestMessageProcessor.java
@@ -11,22 +11,21 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class GetGsmDiagnosticRequestMessageProcessor extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringManagementService")
-  private ManagementService managementService;
+  private final ManagementService managementService;
 
-  @Autowired
   protected GetGsmDiagnosticRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringManagementService")
+          final ManagementService managementService) {
     super(messageProcessorMap, MessageType.GET_GSM_DIAGNOSTIC);
+    this.managementService = managementService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/GetKeysRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/GetKeysRequestMessageProcessor.java
@@ -11,22 +11,21 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class GetKeysRequestMessageProcessor extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringConfigurationService")
-  private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
 
-  @Autowired
   protected GetKeysRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringConfigurationService")
+          final ConfigurationService configurationService) {
     super(messageProcessorMap, MessageType.GET_KEYS);
+    this.configurationService = configurationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/GetMbusEncryptionKeyStatusByChannelRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/GetMbusEncryptionKeyStatusByChannelRequestMessageProcessor.java
@@ -11,7 +11,6 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
@@ -19,15 +18,15 @@ import org.springframework.stereotype.Component;
 public class GetMbusEncryptionKeyStatusByChannelRequestMessageProcessor
     extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringConfigurationService")
-  private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
 
-  @Autowired
   protected GetMbusEncryptionKeyStatusByChannelRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringConfigurationService")
+          final ConfigurationService configurationService) {
     super(messageProcessorMap, MessageType.GET_MBUS_ENCRYPTION_KEY_STATUS_BY_CHANNEL);
+    this.configurationService = configurationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/GetMbusEncryptionKeyStatusRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/GetMbusEncryptionKeyStatusRequestMessageProcessor.java
@@ -10,22 +10,21 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class GetMbusEncryptionKeyStatusRequestMessageProcessor extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringConfigurationService")
-  private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
 
-  @Autowired
   protected GetMbusEncryptionKeyStatusRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringConfigurationService")
+          final ConfigurationService configurationService) {
     super(messageProcessorMap, MessageType.GET_MBUS_ENCRYPTION_KEY_STATUS);
+    this.configurationService = configurationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/GetPowerQualityProfileRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/GetPowerQualityProfileRequestMessageProcessor.java
@@ -11,22 +11,21 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class GetPowerQualityProfileRequestMessageProcessor extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringMonitoringService")
-  private MonitoringService monitoringService;
+  private final MonitoringService monitoringService;
 
-  @Autowired
   protected GetPowerQualityProfileRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringMonitoringService")
+          final MonitoringService monitoringService) {
     super(messageProcessorMap, MessageType.GET_PROFILE_GENERIC_DATA);
+    this.monitoringService = monitoringService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/GetSpecificAttributeValueRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/GetSpecificAttributeValueRequestMessageProcessor.java
@@ -11,22 +11,20 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class GetSpecificAttributeValueRequestMessageProcessor extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringAdhocService")
-  private AdhocService adhocService;
+  private final AdhocService adhocService;
 
-  @Autowired
   protected GetSpecificAttributeValueRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringAdhocService") final AdhocService adhocService) {
     super(messageProcessorMap, MessageType.GET_SPECIFIC_ATTRIBUTE_VALUE);
+    this.adhocService = adhocService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/GetThdFingerprintRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/GetThdFingerprintRequestMessageProcessor.java
@@ -11,22 +11,21 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class GetThdFingerprintRequestMessageProcessor extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringMonitoringService")
-  private MonitoringService monitoringService;
+  private final MonitoringService monitoringService;
 
-  @Autowired
   protected GetThdFingerprintRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringMonitoringService")
+          final MonitoringService monitoringService) {
     super(messageProcessorMap, MessageType.GET_THD_FINGERPRINT);
+    this.monitoringService = monitoringService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/PeriodicMeterReadsRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/PeriodicMeterReadsRequestMessageProcessor.java
@@ -11,22 +11,21 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class PeriodicMeterReadsRequestMessageProcessor extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringMonitoringService")
-  private MonitoringService monitoringService;
+  private final MonitoringService monitoringService;
 
-  @Autowired
   protected PeriodicMeterReadsRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringMonitoringService")
+          final MonitoringService monitoringService) {
     super(messageProcessorMap, MessageType.REQUEST_PERIODIC_METER_DATA);
+    this.monitoringService = monitoringService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/ReadAlarmRegisterRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/ReadAlarmRegisterRequestMessageProcessor.java
@@ -11,22 +11,21 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class ReadAlarmRegisterRequestMessageProcessor extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringMonitoringService")
-  private MonitoringService monitoringService;
+  private final MonitoringService monitoringService;
 
-  @Autowired
   public ReadAlarmRegisterRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringMonitoringService")
+          final MonitoringService monitoringService) {
     super(messageProcessorMap, MessageType.READ_ALARM_REGISTER);
+    this.monitoringService = monitoringService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/ReplaceKeysRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/ReplaceKeysRequestMessageProcessor.java
@@ -11,22 +11,21 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class ReplaceKeysRequestMessageProcessor extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringConfigurationService")
-  private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
 
-  @Autowired
   protected ReplaceKeysRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringConfigurationService")
+          final ConfigurationService configurationService) {
     super(messageProcessorMap, MessageType.REPLACE_KEYS);
+    this.configurationService = configurationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/ScanMbusChannelsRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/ScanMbusChannelsRequestMessageProcessor.java
@@ -10,22 +10,20 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class ScanMbusChannelsRequestMessageProcessor extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringAdhocService")
-  private AdhocService adhocService;
+  private final AdhocService adhocService;
 
-  @Autowired
   protected ScanMbusChannelsRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringAdhocService") final AdhocService adhocService) {
     super(messageProcessorMap, MessageType.SCAN_MBUS_CHANNELS);
+    this.adhocService = adhocService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/SetActivityCalendarRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/SetActivityCalendarRequestMessageProcessor.java
@@ -11,22 +11,21 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class SetActivityCalendarRequestMessageProcessor extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringConfigurationService")
-  private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
 
-  @Autowired
   protected SetActivityCalendarRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringConfigurationService")
+          final ConfigurationService configurationService) {
     super(messageProcessorMap, MessageType.SET_ACTIVITY_CALENDAR);
+    this.configurationService = configurationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/SetAdministrativeStatusRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/SetAdministrativeStatusRequestMessageProcessor.java
@@ -11,22 +11,21 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class SetAdministrativeStatusRequestMessageProcessor extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringConfigurationService")
-  private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
 
-  @Autowired
   protected SetAdministrativeStatusRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringConfigurationService")
+          final ConfigurationService configurationService) {
     super(messageProcessorMap, MessageType.SET_ADMINISTRATIVE_STATUS);
+    this.configurationService = configurationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/SetAlarmNotificationsRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/SetAlarmNotificationsRequestMessageProcessor.java
@@ -11,22 +11,21 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class SetAlarmNotificationsRequestMessageProcessor extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringConfigurationService")
-  private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
 
-  @Autowired
   protected SetAlarmNotificationsRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringConfigurationService")
+          final ConfigurationService configurationService) {
     super(messageProcessorMap, MessageType.SET_ALARM_NOTIFICATIONS);
+    this.configurationService = configurationService;
   }
 
   /*

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/SetClockConfigurationRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/SetClockConfigurationRequestMessageProcessor.java
@@ -11,22 +11,21 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class SetClockConfigurationRequestMessageProcessor extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringConfigurationService")
-  private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
 
-  @Autowired
   protected SetClockConfigurationRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringConfigurationService")
+          final ConfigurationService configurationService) {
     super(messageProcessorMap, MessageType.SET_CLOCK_CONFIGURATION);
+    this.configurationService = configurationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/SetConfigurationObjectRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/SetConfigurationObjectRequestMessageProcessor.java
@@ -11,22 +11,21 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class SetConfigurationObjectRequestMessageProcessor extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringConfigurationService")
-  private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
 
-  @Autowired
   protected SetConfigurationObjectRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringConfigurationService")
+          final ConfigurationService configurationService) {
     super(messageProcessorMap, MessageType.SET_CONFIGURATION_OBJECT);
+    this.configurationService = configurationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/SetDeviceCommunicationSettingsRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/SetDeviceCommunicationSettingsRequestMessageProcessor.java
@@ -11,7 +11,6 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
@@ -19,15 +18,15 @@ import org.springframework.stereotype.Component;
 public class SetDeviceCommunicationSettingsRequestMessageProcessor
     extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringManagementService")
-  private ManagementService managementService;
+  private final ManagementService managementService;
 
-  @Autowired
   protected SetDeviceCommunicationSettingsRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringManagementService")
+          final ManagementService managementService) {
     super(messageProcessorMap, MessageType.SET_DEVICE_COMMUNICATION_SETTINGS);
+    this.managementService = managementService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/SetDeviceLifecycleStatusByChannelRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/SetDeviceLifecycleStatusByChannelRequestMessageProcessor.java
@@ -11,7 +11,6 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
@@ -19,15 +18,15 @@ import org.springframework.stereotype.Component;
 public class SetDeviceLifecycleStatusByChannelRequestMessageProcessor
     extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringManagementService")
-  private ManagementService managementService;
+  private final ManagementService managementService;
 
-  @Autowired
   protected SetDeviceLifecycleStatusByChannelRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringManagementService")
+          final ManagementService managementService) {
     super(messageProcessorMap, MessageType.SET_DEVICE_LIFECYCLE_STATUS_BY_CHANNEL);
+    this.managementService = managementService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/SetKeyOnGMeterRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/SetKeyOnGMeterRequestMessageProcessor.java
@@ -11,22 +11,21 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class SetKeyOnGMeterRequestMessageProcessor extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringConfigurationService")
-  private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
 
-  @Autowired
   protected SetKeyOnGMeterRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringConfigurationService")
+          final ConfigurationService configurationService) {
     super(messageProcessorMap, MessageType.SET_KEY_ON_G_METER);
+    this.configurationService = configurationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/SetMbusUserKeyByChannelRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/SetMbusUserKeyByChannelRequestMessageProcessor.java
@@ -11,22 +11,21 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class SetMbusUserKeyByChannelRequestMessageProcessor extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringConfigurationService")
-  private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
 
-  @Autowired
   protected SetMbusUserKeyByChannelRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringConfigurationService")
+          final ConfigurationService configurationService) {
     super(messageProcessorMap, MessageType.SET_MBUS_USER_KEY_BY_CHANNEL);
+    this.configurationService = configurationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/SetPushSetupAlarmRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/SetPushSetupAlarmRequestMessageProcessor.java
@@ -11,22 +11,21 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class SetPushSetupAlarmRequestMessageProcessor extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringConfigurationService")
-  private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
 
-  @Autowired
   protected SetPushSetupAlarmRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringConfigurationService")
+          final ConfigurationService configurationService) {
     super(messageProcessorMap, MessageType.SET_PUSH_SETUP_ALARM);
+    this.configurationService = configurationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/SetPushSetupLastGaspRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/SetPushSetupLastGaspRequestMessageProcessor.java
@@ -11,22 +11,21 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class SetPushSetupLastGaspRequestMessageProcessor extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringConfigurationService")
-  private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
 
-  @Autowired
   protected SetPushSetupLastGaspRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringConfigurationService")
+          final ConfigurationService configurationService) {
     super(messageProcessorMap, MessageType.SET_PUSH_SETUP_LAST_GASP);
+    this.configurationService = configurationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/SetPushSetupSmsRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/SetPushSetupSmsRequestMessageProcessor.java
@@ -11,22 +11,21 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class SetPushSetupSmsRequestMessageProcessor extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringConfigurationService")
-  private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
 
-  @Autowired
   protected SetPushSetupSmsRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringConfigurationService")
+          final ConfigurationService configurationService) {
     super(messageProcessorMap, MessageType.SET_PUSH_SETUP_SMS);
+    this.configurationService = configurationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/SetPushSetupUdpRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/SetPushSetupUdpRequestMessageProcessor.java
@@ -16,22 +16,21 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class SetPushSetupUdpRequestMessageProcessor extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringConfigurationService")
-  private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
 
-  @Autowired
   protected SetPushSetupUdpRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringConfigurationService")
+          final ConfigurationService configurationService) {
     super(messageProcessorMap, MessageType.SET_PUSH_SETUP_UDP);
+    this.configurationService = configurationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/SetRandomisationSettingsRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/SetRandomisationSettingsRequestMessageProcessor.java
@@ -11,22 +11,21 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class SetRandomisationSettingsRequestMessageProcessor extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringConfigurationService")
-  private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
 
-  @Autowired
   protected SetRandomisationSettingsRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringConfigurationService")
+          final ConfigurationService configurationService) {
     super(messageProcessorMap, MessageType.SET_RANDOMISATION_SETTINGS);
+    this.configurationService = configurationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/SetSpecificAttributeValueRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/SetSpecificAttributeValueRequestMessageProcessor.java
@@ -11,7 +11,6 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
@@ -20,7 +19,6 @@ public class SetSpecificAttributeValueRequestMessageProcessor extends BaseReques
 
   private final AdhocService adhocService;
 
-  @Autowired
   protected SetSpecificAttributeValueRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
           final MessageProcessorMap messageProcessorMap,

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/SpecialDaysRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/SpecialDaysRequestMessageProcessor.java
@@ -11,22 +11,21 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class SpecialDaysRequestMessageProcessor extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringConfigurationService")
-  private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
 
-  @Autowired
   protected SpecialDaysRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringConfigurationService")
+          final ConfigurationService configurationService) {
     super(messageProcessorMap, MessageType.SET_SPECIAL_DAYS);
+    this.configurationService = configurationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/SynchronizeTimeRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/SynchronizeTimeRequestMessageProcessor.java
@@ -11,22 +11,20 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class SynchronizeTimeRequestMessageProcessor extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringAdhocService")
-  private AdhocService adhocService;
+  private final AdhocService adhocService;
 
-  @Autowired
   protected SynchronizeTimeRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringAdhocService") final AdhocService adhocService) {
     super(messageProcessorMap, MessageType.SYNCHRONIZE_TIME);
+    this.adhocService = adhocService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/TestAlarmSchedulerRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/TestAlarmSchedulerRequestMessageProcessor.java
@@ -11,22 +11,20 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class TestAlarmSchedulerRequestMessageProcessor extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringAdhocService")
-  private AdhocService adhocService;
+  private final AdhocService adhocService;
 
-  @Autowired
   protected TestAlarmSchedulerRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringAdhocService") final AdhocService adhocService) {
     super(messageProcessorMap, MessageType.SCHEDULE_TEST_ALARM);
+    this.adhocService = adhocService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/UpdateFirmwareRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/UpdateFirmwareRequestMessageProcessor.java
@@ -11,7 +11,6 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
@@ -19,15 +18,15 @@ import org.springframework.stereotype.Component;
 @Component
 public class UpdateFirmwareRequestMessageProcessor extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringConfigurationService")
-  private ConfigurationService configurationService;
+  private final ConfigurationService configurationService;
 
-  @Autowired
   public UpdateFirmwareRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringConfigurationService")
+          final ConfigurationService configurationService) {
     super(messageProcessorMap, MessageType.UPDATE_FIRMWARE);
+    this.configurationService = configurationService;
   }
 
   @Override

--- a/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/UpdateProtocolRequestMessageProcessor.java
+++ b/osgp/platform/osgp-adapter-domain-smartmetering/src/main/java/org/opensmartgridplatform/adapter/domain/smartmetering/infra/jms/ws/messageprocessors/UpdateProtocolRequestMessageProcessor.java
@@ -11,22 +11,21 @@ import org.opensmartgridplatform.shared.exceptionhandling.FunctionalException;
 import org.opensmartgridplatform.shared.infra.jms.MessageMetadata;
 import org.opensmartgridplatform.shared.infra.jms.MessageProcessorMap;
 import org.opensmartgridplatform.shared.infra.jms.MessageType;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class UpdateProtocolRequestMessageProcessor extends BaseRequestMessageProcessor {
 
-  @Autowired
-  @Qualifier("domainSmartMeteringManagementService")
-  private ManagementService managementService;
+  private final ManagementService managementService;
 
-  @Autowired
   protected UpdateProtocolRequestMessageProcessor(
       @Qualifier("domainSmartMeteringInboundWebServiceRequestsMessageProcessorMap")
-          final MessageProcessorMap messageProcessorMap) {
+          final MessageProcessorMap messageProcessorMap,
+      @Qualifier("domainSmartMeteringManagementService")
+          final ManagementService managementService) {
     super(messageProcessorMap, MessageType.UPDATE_PROTOCOL);
+    this.managementService = managementService;
   }
 
   @Override


### PR DESCRIPTION
Field dependency injection should be avoided [java:S6813](https://sonarcloud.io/organizations/gxf/rules?open=java%3AS6813&rule_key=java%3AS6813)

✅ https://jenkins.fdp.osgp.cloud/view/SMHE-cucumber/job/gxf-smhe-cucumber-build/334/