### PR TITLE
SMHE-2452-Quartz-job-resend-notifications-speed-up-on-large-numbers

### DIFF
--- a/osgp/platform/osgp-adapter-ws-shared/src/main/java/org/opensmartgridplatform/adapter/ws/shared/services/AbstractResendNotificationService.java
+++ b/osgp/platform/osgp-adapter-ws-shared/src/main/java/org/opensmartgridplatform/adapter/ws/shared/services/AbstractResendNotificationService.java
@@ -20,23 +20,31 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.domain.Sort.Direction;
 
 public abstract class AbstractResendNotificationService<T extends Enum<T>> {
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(AbstractResendNotificationService.class);
 
-  @Autowired private int resendNotificationMultiplier;
+  @SuppressWarnings("java:S6813")
+  @Autowired // Convenient use of autowire annotation in abstract class with many inheritors
+  private int resendNotificationMultiplier;
 
-  @Autowired private Short resendNotificationMaximum;
+  @SuppressWarnings("java:S6813")
+  @Autowired // Convenient use of autowire annotation in abstract class with many inheritors
+  private Short resendNotificationMaximum;
 
-  @Autowired private int resendThresholdInMinutes;
+  @SuppressWarnings("java:S6813")
+  @Autowired // Convenient use of autowire annotation in abstract class with many inheritors
+  private int resendThresholdInMinutes;
 
-  @Autowired private ResponseDataRepository responseDataRepository;
+  @SuppressWarnings("java:S6813")
+  @Autowired // Convenient use of autowire annotation in abstract class with many inheritors
+  private ResponseDataRepository responseDataRepository;
 
-  @Autowired private int resendPageSize;
+  @SuppressWarnings("java:S6813")
+  @Autowired // Convenient use of autowire annotation in abstract class with many inheritors
+  private int resendPageSize;
 
   private final Class<T> notificationClass;
 
@@ -44,15 +52,15 @@ public abstract class AbstractResendNotificationService<T extends Enum<T>> {
 
   private NotificationService notificationServiceReference;
 
-  public AbstractResendNotificationService(final Class<T> notificationClass) {
+  protected AbstractResendNotificationService(final Class<T> notificationClass) {
     this.notificationClass = notificationClass;
   }
 
-  public void setNotificationService(final NotificationService notificationService) {
+  protected void setNotificationService(final NotificationService notificationService) {
     this.notificationServiceReference = notificationService;
   }
 
-  public void setApplicationName(final String applicationName) {
+  protected void setApplicationName(final String applicationName) {
     this.applicationName = applicationName;
   }
 
@@ -127,7 +135,7 @@ public abstract class AbstractResendNotificationService<T extends Enum<T>> {
     }
   }
 
-  public void resendNotificationAndUpdateResponseData(final ResponseData responseData) {
+  private void resendNotificationAndUpdateResponseData(final ResponseData responseData) {
 
     try {
       this.resendNotification(responseData);
@@ -144,7 +152,7 @@ public abstract class AbstractResendNotificationService<T extends Enum<T>> {
     }
   }
 
-  protected void logUnknownNotificationTypeError(
+  private void logUnknownNotificationTypeError(
       final String correlationUid, final String messageType, final String notificationServiceName) {
 
     LOGGER.error(
@@ -206,7 +214,7 @@ public abstract class AbstractResendNotificationService<T extends Enum<T>> {
     return delay;
   }
 
-  public void resendNotification(final ResponseData responseData) {
+  private void resendNotification(final ResponseData responseData) {
 
     if (!EnumUtils.isValidEnum(this.notificationClass, responseData.getMessageType())) {
       this.logUnknownNotificationTypeError(
@@ -232,7 +240,7 @@ public abstract class AbstractResendNotificationService<T extends Enum<T>> {
         notificationWebServiceLookupKey, genericNotification);
   }
 
-  public String getNotificationMessage(final String responseData) {
+  private String getNotificationMessage(final String responseData) {
     return String.format("Response of type %s is available.", responseData);
   }
 
@@ -243,10 +251,9 @@ public abstract class AbstractResendNotificationService<T extends Enum<T>> {
    */
   private List<ResponseData> getResponseDataForNotifying(
       final short notificationsResent, final ZonedDateTime createdBefore) {
-    final Pageable pageable =
-        PageRequest.of(0, this.resendPageSize, Sort.by(Direction.ASC, "creationTime"));
+    final Pageable unsortedPageable = PageRequest.of(0, this.resendPageSize);
 
     return this.responseDataRepository.findByNumberOfNotificationsSentAndCreationTimeBefore(
-        notificationsResent, createdBefore.toInstant(), pageable);
+        notificationsResent, createdBefore.toInstant(), unsortedPageable);
   }
 }

--- a/osgp/platform/osgp-adapter-ws-shared/src/main/java/org/opensmartgridplatform/adapter/ws/shared/services/ResendNotificationJob.java
+++ b/osgp/platform/osgp-adapter-ws-shared/src/main/java/org/opensmartgridplatform/adapter/ws/shared/services/ResendNotificationJob.java
@@ -11,13 +11,17 @@ import org.quartz.JobExecutionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
+@Component
 @DisallowConcurrentExecution
 public class ResendNotificationJob implements Job {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ResendNotificationJob.class);
 
-  @Autowired private AbstractResendNotificationService<?> resendNotificationService;
+  @SuppressWarnings("java:S6813")
+  @Autowired // Constructor injection doesn't work with quartz jobs
+  private AbstractResendNotificationService<?> resendNotificationService;
 
   @Override
   public void execute(final JobExecutionContext context) throws JobExecutionException {

--- a/osgp/platform/osgp-adapter-ws-smartmetering/src/test/java/org/opensmartgridplatform/adapter/ws/smartmetering/application/services/ResendNotificationServiceTest.java
+++ b/osgp/platform/osgp-adapter-ws-smartmetering/src/test/java/org/opensmartgridplatform/adapter/ws/smartmetering/application/services/ResendNotificationServiceTest.java
@@ -1,0 +1,77 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Contributors to the GXF project
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensmartgridplatform.adapter.ws.smartmetering.application.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensmartgridplatform.adapter.ws.domain.repositories.ResponseDataRepository;
+import org.opensmartgridplatform.adapter.ws.shared.services.NotificationService;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class ResendNotificationServiceTest {
+
+  private final int resendPageSize = 100;
+  private final short resendNotificationMaximum = 3;
+  @Mock private ResponseDataRepository responseDataRepository;
+  @Mock private NotificationService smartMeteringNotificationService;
+
+  private ResendNotificationService resendNotificationService;
+
+  @BeforeEach
+  void setUp() {
+    final int resendNotificationMultiplier = 2;
+    final int resendThresholdInMinutes = 2;
+    final String webserviceNotificationApplicationName = "application-1";
+    this.resendNotificationService =
+        new ResendNotificationService(
+            this.smartMeteringNotificationService, webserviceNotificationApplicationName);
+    ReflectionTestUtils.setField(
+        this.resendNotificationService,
+        "resendNotificationMultiplier",
+        resendNotificationMultiplier);
+    ReflectionTestUtils.setField(
+        this.resendNotificationService,
+        "resendNotificationMaximum",
+        this.resendNotificationMaximum);
+    ReflectionTestUtils.setField(
+        this.resendNotificationService, "resendThresholdInMinutes", resendThresholdInMinutes);
+    ReflectionTestUtils.setField(
+        this.resendNotificationService, "resendPageSize", this.resendPageSize);
+    ReflectionTestUtils.setField(
+        this.resendNotificationService, "responseDataRepository", this.responseDataRepository);
+  }
+
+  @Test
+  void testResponseDataPageIsNotSorted() {
+    final ArgumentCaptor<Pageable> pageableArgumentCaptor = ArgumentCaptor.forClass(Pageable.class);
+    when(this.responseDataRepository.findByNumberOfNotificationsSentAndCreationTimeBefore(
+            any(Short.class), any(Instant.class), any(Pageable.class)))
+        .thenReturn(List.of());
+    this.resendNotificationService.execute();
+    verify(this.responseDataRepository, times(this.resendNotificationMaximum))
+        .findByNumberOfNotificationsSentAndCreationTimeBefore(
+            any(Short.class), any(Instant.class), pageableArgumentCaptor.capture());
+    final Pageable pageable = pageableArgumentCaptor.getValue();
+    assertThat(pageable).isNotNull();
+    assertThat(pageable.getPageSize()).isEqualTo(this.resendPageSize);
+    assertThat(pageable.getSort().isSorted()).isFalse();
+  }
+}


### PR DESCRIPTION
The AbstractResendNotificationService queries the ResponseData table with a combination of SortOrder and Limit which results in poor performance in case of large number of records in this table. For current use there is no need for a sorted result. Therefor the sort is removed.
This AbstractResendNotificationService is used in webservice adapters of
- Core
- PublicLighting
- SmartMetering
- TariffSwitching

Test of unsorted paging is added to the Smartmetering module