### PR TITLE
Remove tag build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,6 @@ on:
     branches:
       - development
       - 'release-*'
-    tags:
-      - '**'
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
 


### PR DESCRIPTION
Too many images are being build. Therefore this workflow will not run on tag creation. Release are created through branches.