### PR TITLE
upgrade-msal

### DIFF
--- a/super/pom.xml
+++ b/super/pom.xml
@@ -82,7 +82,7 @@ SPDX-License-Identifier: Apache-2.0
     <apache.httpcomponents.httpasyncclient.version>4.1.5</apache.httpcomponents.httpasyncclient.version>
     <commons.codec.version>1.17.0</commons.codec.version>
     <orika.version>1.5.4</orika.version>
-    <msal.version>1.15.1</msal.version>
+    <msal.version>1.20.1</msal.version>
     <jxr.version>3.3.2</jxr.version>
     <maven.project.info.reports.plugin.version>3.5.0</maven.project.info.reports.plugin.version>
     <maven.site.plugin>3.12.1</maven.site.plugin>


### PR DESCRIPTION
Upgrading _com.microsoft.azure:msal4j_ library in _osgp-kafka-config_ module. Current msal4j library version has dependency on  _net.minidev:json-smart 2.5.0_ which has a high vulnerability https://github.com/advisories/GHSA-493p-pfq6-5258
