### PR TITLE
SMHE-2689-additional-apn-attribute-in-jasper-REST-get-session-info-response

### DIFF
--- a/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/main/java/org/opensmartgridplatform/adapter/protocol/jasper/infra/ws/JasperWirelessTerminalSoapClient.java
+++ b/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/main/java/org/opensmartgridplatform/adapter/protocol/jasper/infra/ws/JasperWirelessTerminalSoapClient.java
@@ -20,6 +20,10 @@ import org.springframework.ws.soap.client.core.SoapActionCallback;
 import org.springframework.ws.soap.security.wss4j2.Wss4jSecurityInterceptor;
 
 @Slf4j
+@Deprecated(forRemoval = true)
+/**
+ * @deprecated
+ */
 public class JasperWirelessTerminalSoapClient implements JasperWirelessTerminalClient {
 
   private static final String SERVICE_SESSION_INFO =
@@ -63,6 +67,10 @@ public class JasperWirelessTerminalSoapClient implements JasperWirelessTerminalC
                 getSessionInfoRequest, new SoapActionCallback(SERVICE_SESSION_INFO)));
   }
 
+  //  @Deprecated(forRemoval = true)
+  //  /**
+  //   * @deprecated
+  //   */
   private org.opensmartgridplatform.adapter.protocol.jasper.response.GetSessionInfoResponse
       convertResponse(final GetSessionInfoResponse response) throws OsgpJasperException {
     this.validateResponse(response);
@@ -80,6 +88,10 @@ public class JasperWirelessTerminalSoapClient implements JasperWirelessTerminalC
     }
   }
 
+  //  @Deprecated(forRemoval = true)
+  //  /**
+  //   * @deprecated
+  //   */
   private org.opensmartgridplatform.adapter.protocol.jasper.response.GetSessionInfoResponse
       convertSessionInfo(final SessionInfoType sessionInfoType) {
     final String ipV6Address = null;
@@ -88,7 +100,8 @@ public class JasperWirelessTerminalSoapClient implements JasperWirelessTerminalC
         sessionInfoType.getIpAddress(),
         ipV6Address,
         sessionInfoType.getDateSessionStarted().toGregorianCalendar().getTime(),
-        sessionInfoType.getDateSessionEnded().toGregorianCalendar().getTime());
+        sessionInfoType.getDateSessionEnded().toGregorianCalendar().getTime(),
+        "APN not available in this version of SOAP client: 5.90 (releaseDate:2015-25-03)");
   }
 
   // Sonar marks 'setSecurementPasswordType(WSS4JConstants.PW_TEXT)' as exposing a password.

--- a/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/main/java/org/opensmartgridplatform/adapter/protocol/jasper/infra/ws/JasperWirelessTerminalSoapClient.java
+++ b/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/main/java/org/opensmartgridplatform/adapter/protocol/jasper/infra/ws/JasperWirelessTerminalSoapClient.java
@@ -19,11 +19,11 @@ import org.springframework.ws.client.support.interceptor.ClientInterceptor;
 import org.springframework.ws.soap.client.core.SoapActionCallback;
 import org.springframework.ws.soap.security.wss4j2.Wss4jSecurityInterceptor;
 
-@Slf4j
-@Deprecated(forRemoval = true)
 /**
  * @deprecated
  */
+@Slf4j
+@Deprecated(forRemoval = true)
 public class JasperWirelessTerminalSoapClient implements JasperWirelessTerminalClient {
 
   private static final String SERVICE_SESSION_INFO =

--- a/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/main/java/org/opensmartgridplatform/adapter/protocol/jasper/response/GetSessionInfoResponse.java
+++ b/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/main/java/org/opensmartgridplatform/adapter/protocol/jasper/response/GetSessionInfoResponse.java
@@ -15,6 +15,7 @@ public class GetSessionInfoResponse {
   private String ipV6Address;
   private Date dateSessionStarted;
   private Date dateSessionEnded;
+  private String apn;
 
   public GetSessionInfoResponse() {}
 
@@ -23,11 +24,13 @@ public class GetSessionInfoResponse {
       final String ipAddress,
       final String ipV6Address,
       final Date dateSessionStarted,
-      final Date dateSessionEnded) {
+      final Date dateSessionEnded,
+      final String apn) {
     this.iccid = iccid;
     this.ipAddress = ipAddress;
     this.ipV6Address = ipV6Address;
     this.dateSessionStarted = dateSessionStarted;
     this.dateSessionEnded = dateSessionEnded;
+    this.apn = apn;
   }
 }

--- a/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/main/java/org/opensmartgridplatform/adapter/protocol/jasper/rest/client/JasperWirelessTerminalRestClient.java
+++ b/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/main/java/org/opensmartgridplatform/adapter/protocol/jasper/rest/client/JasperWirelessTerminalRestClient.java
@@ -80,7 +80,8 @@ public class JasperWirelessTerminalRestClient extends JasperWirelessRestClient
     if (this.hasCurrentSession(getSessionInfoResponse)) {
       return getSessionInfoResponse;
     } else {
-      return new GetSessionInfoResponse(getSessionInfoResponse.getIccid(), null, null, null, null);
+      return new GetSessionInfoResponse(
+          getSessionInfoResponse.getIccid(), null, null, null, null, null);
     }
   }
 

--- a/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/test/java/org/opensmartgridplatform/adapter/protocol/jasper/rest/client/JasperWirelessTerminalRestClientTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/test/java/org/opensmartgridplatform/adapter/protocol/jasper/rest/client/JasperWirelessTerminalRestClientTest.java
@@ -38,6 +38,7 @@ class JasperWirelessTerminalRestClientTest {
 
   private static final String SERVICE_GET_SESSION_INFO = "/rws/api/%s/devices/%s/sessionInfo";
   private static final String ICCID = "12345";
+  private static final String APN = "apn-1";
   private static final String USERNAME = "user";
   private static final String APIKEY = "1234-abcd-5678-ef";
   private static final String BASEURL = "http://localhost:8081";
@@ -61,7 +62,7 @@ class JasperWirelessTerminalRestClientTest {
   @InjectMocks private JasperWirelessTerminalRestClient jasperWirelessTerminalRestClient;
 
   @BeforeEach
-  private void init() {
+  void init() {
     when(this.jasperWirelessAccess.getUri()).thenReturn(BASEURL);
     when(this.jasperWirelessAccess.getApiVersion()).thenReturn(APIVERSION);
     when(this.jasperWirelessAccess.getUsername()).thenReturn(USERNAME);
@@ -176,7 +177,7 @@ class JasperWirelessTerminalRestClientTest {
         ipAddress = null;
     }
     final GetSessionInfoResponse getSessionInfoResponse =
-        new GetSessionInfoResponse(ICCID, ipAddress, IPV6_ADDRESS, startSession, endSession);
+        new GetSessionInfoResponse(ICCID, ipAddress, IPV6_ADDRESS, startSession, endSession, APN);
     return new ResponseEntity<GetSessionInfoResponse>(getSessionInfoResponse, httpStatus);
   }
 

--- a/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/test/java/org/opensmartgridplatform/adapter/protocol/jasper/sessionproviders/SessionProviderKpnPollJasperTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/test/java/org/opensmartgridplatform/adapter/protocol/jasper/sessionproviders/SessionProviderKpnPollJasperTest.java
@@ -31,6 +31,7 @@ public class SessionProviderKpnPollJasperTest {
   private static final String DEVICE_IDENTIFICATION = "device-identification";
   private static final String ICC_ID = "icc-id";
   private static final String IP_ADDRESS = "1.2.3.4";
+  private static final String APN = "apn-1";
 
   @Mock private SessionProviderMap sessionProviderMap;
   @Mock private JasperWirelessTerminalClient jasperWirelessTerminalClient;
@@ -122,6 +123,6 @@ public class SessionProviderKpnPollJasperTest {
 
   private GetSessionInfoResponse newGetSessionInfoResponse(
       final String iccId, final String ipAddress) {
-    return new GetSessionInfoResponse(iccId, ipAddress, ipAddress, new Date(), new Date());
+    return new GetSessionInfoResponse(iccId, ipAddress, ipAddress, new Date(), new Date(), APN);
   }
 }

--- a/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/test/java/org/opensmartgridplatform/adapter/protocol/jasper/sessionproviders/SessionProviderKpnPushAlarmTest.java
+++ b/osgp/protocol-adapter-dlms/osgp-jasper-interface/src/test/java/org/opensmartgridplatform/adapter/protocol/jasper/sessionproviders/SessionProviderKpnPushAlarmTest.java
@@ -34,6 +34,7 @@ public class SessionProviderKpnPushAlarmTest {
   private static final String DEVICE_IDENTIFICATION = "device-identification";
   private static final String ICC_ID = "icc-id";
   private static final String IP_ADDRESS = "1.2.3.4";
+  private static final String APN = "apn-1";
 
   @Mock private SessionProviderMap sessionProviderMap;
   @Mock private JasperWirelessSmsClient jasperWirelessSmsClient;
@@ -192,6 +193,6 @@ public class SessionProviderKpnPushAlarmTest {
   }
 
   private GetSessionInfoResponse newGetSessionInfoResponse(final String ipAddress) {
-    return new GetSessionInfoResponse(ICC_ID, ipAddress, null, new Date(), new Date());
+    return new GetSessionInfoResponse(ICC_ID, ipAddress, null, new Date(), new Date(), APN);
   }
 }


### PR DESCRIPTION
Er treedt een exception op bij een GetSessionInfoRequest door gewijzigde Jasper Wireless REST interface.
Aan het java GetSessionInfoResponse class is attribute _apn_ (String) toegevoegd