### PR TITLE
exclude-dependency-org.skyscreamer.jsonassert

### DIFF
--- a/osgp/platform/osgp-secret-management/pom.xml
+++ b/osgp/platform/osgp-secret-management/pom.xml
@@ -155,20 +155,18 @@ SPDX-License-Identifier: Apache-2.0
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.skyscreamer</groupId>
-                    <artifactId>jsonassert</artifactId>
-                </exclusion>
-            </exclusions>
-      <version>${spring.boot.version}</version>
-      <scope>test</scope>
       <exclusions>
+        <exclusion>
+          <groupId>org.skyscreamer</groupId>
+          <artifactId>jsonassert</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>org.junit.vintage</groupId>
           <artifactId>junit-vintage-engine</artifactId>
         </exclusion>
       </exclusions>
+      <version>${spring.boot.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.ws</groupId>

--- a/osgp/platform/osgp-secret-management/pom.xml
+++ b/osgp/platform/osgp-secret-management/pom.xml
@@ -155,6 +155,12 @@ SPDX-License-Identifier: Apache-2.0
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.skyscreamer</groupId>
+                    <artifactId>jsonassert</artifactId>
+                </exclusion>
+            </exclusions>
       <version>${spring.boot.version}</version>
       <scope>test</scope>
       <exclusions>

--- a/osgp/platform/osgp-throttling-service/pom.xml
+++ b/osgp/platform/osgp-throttling-service/pom.xml
@@ -154,6 +154,12 @@ SPDX-License-Identifier: Apache-2.0
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.skyscreamer</groupId>
+                    <artifactId>jsonassert</artifactId>
+                </exclusion>
+            </exclusions>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/osgp/protocol-adapter-iec60870/osgp-protocol-simulator-iec60870/pom.xml
+++ b/osgp/protocol-adapter-iec60870/osgp-protocol-simulator-iec60870/pom.xml
@@ -88,6 +88,12 @@ SPDX-License-Identifier: Apache-2.0
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.skyscreamer</groupId>
+                    <artifactId>jsonassert</artifactId>
+                </exclusion>
+            </exclusions>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/osgp/protocol-adapter-iec60870/osgp-protocol-simulator-iec60870/pom.xml
+++ b/osgp/protocol-adapter-iec60870/osgp-protocol-simulator-iec60870/pom.xml
@@ -88,14 +88,11 @@ SPDX-License-Identifier: Apache-2.0
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.skyscreamer</groupId>
-                    <artifactId>jsonassert</artifactId>
-                </exclusion>
-            </exclusions>
-      <scope>test</scope>
       <exclusions>
+        <exclusion>
+          <groupId>org.skyscreamer</groupId>
+          <artifactId>jsonassert</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>junit</groupId>
           <artifactId>junit</artifactId>
@@ -105,6 +102,7 @@ SPDX-License-Identifier: Apache-2.0
           <artifactId>junit-vintage-engine</artifactId>
         </exclusion>
       </exclusions>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/osgp/protocol-adapter-iec61850/osgp-protocol-simulator-iec61850/pom.xml
+++ b/osgp/protocol-adapter-iec61850/osgp-protocol-simulator-iec61850/pom.xml
@@ -78,6 +78,12 @@ SPDX-License-Identifier: Apache-2.0
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.skyscreamer</groupId>
+                    <artifactId>jsonassert</artifactId>
+                </exclusion>
+            </exclusions>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
Solved issue below

```
09:43:42  [WARN] org.springframework.boot.test.json.DuplicateJsonObjectContextCustomizerFactory$DuplicateJsonObjectContextCustomizer - 
09:43:42  
09:43:42  Found multiple occurrences of org.json.JSONObject on the class path:
09:43:42  
09:43:42  	jar:file:/root/.m2/repository/org/json/json/20231013/json-20231013.jar!/org/json/JSONObject.class
09:43:42  	jar:file:/root/.m2/repository/com/vaadin/external/google/android-json/0.0.20131108.vaadin1/android-json-0.0.20131108.vaadin1.jar!/org/json/JSONObject.class
09:43:42  
09:43:42  You may wish to exclude one of them to ensure predictable runtime behavior
```

✅ https://jenkins.fdp.osgp.cloud/view/SMHE-cucumber/job/gxf-smhe-cucumber-build/341/