### PR TITLE
simulator-network-address-configurable

### DIFF
--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/CucumberTestsPlatformSmartmeteringProperties.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/CucumberTestsPlatformSmartmeteringProperties.java
@@ -17,14 +17,14 @@ import org.opensmartgridplatform.cucumber.platform.PlatformDefaults;
 @Slf4j
 public class CucumberTestsPlatformSmartmeteringProperties {
 
-  static Properties properties;
+  private final Properties properties;
 
   public CucumberTestsPlatformSmartmeteringProperties() {
-    properties = new Properties();
+    this.properties = new Properties();
     try {
       final InputStream inputStream =
           ClassLoader.getSystemResourceAsStream("cucumber-tests-platform-smartmetering.properties");
-      properties.load(inputStream);
+      this.properties.load(inputStream);
       if (inputStream != null) {
         inputStream.close();
       }
@@ -36,7 +36,8 @@ public class CucumberTestsPlatformSmartmeteringProperties {
   public InetAddress getNetworkAddress() {
     InetAddress inetAddress;
     try {
-      final String configuredAddress = properties.getProperty("simulator.network.inet.address");
+      final String configuredAddress =
+          this.properties.getProperty("simulator.network.inet.address");
       final String simulatorNetworkAddress =
           Objects.requireNonNullElse(configuredAddress, PlatformDefaults.LOCALHOST);
       log.info(
@@ -53,14 +54,14 @@ public class CucumberTestsPlatformSmartmeteringProperties {
   }
 
   public int getAlarmNotificationsPort() {
-    return Integer.parseInt(properties.getProperty("alarm.notifications.port"));
+    return Integer.parseInt(this.properties.getProperty("alarm.notifications.port"));
   }
 
   public String getAlarmNotificationsHost() {
-    return properties.getProperty("alarm.notifications.host");
+    return this.properties.getProperty("alarm.notifications.host");
   }
 
   public String getServiceEndpointHost() {
-    return properties.getProperty("service.endpoint.host");
+    return this.properties.getProperty("service.endpoint.host");
   }
 }

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/CucumberTestsPlatformSmartmeteringProperties.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/CucumberTestsPlatformSmartmeteringProperties.java
@@ -1,0 +1,66 @@
+/*
+ * SPDX-FileCopyrightText: Copyright Contributors to the GXF project
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensmartgridplatform.cucumber.platform.smartmetering;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetAddress;
+import java.util.Objects;
+import java.util.Properties;
+import lombok.extern.slf4j.Slf4j;
+import org.opensmartgridplatform.cucumber.platform.PlatformDefaults;
+
+@Slf4j
+public class CucumberTestsPlatformSmartmeteringProperties {
+
+  static Properties properties;
+
+  public CucumberTestsPlatformSmartmeteringProperties() {
+    properties = new Properties();
+    try {
+      final InputStream inputStream =
+          ClassLoader.getSystemResourceAsStream("cucumber-tests-platform-smartmetering.properties");
+      properties.load(inputStream);
+      if (inputStream != null) {
+        inputStream.close();
+      }
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public InetAddress getNetworkAddress() {
+    InetAddress inetAddress;
+    try {
+      final String configuredAddress = properties.getProperty("simulator.network.inet.address");
+      final String simulatorNetworkAddress =
+          Objects.requireNonNullElse(configuredAddress, PlatformDefaults.LOCALHOST);
+      log.info(
+          "Using {} network address for simulator (simulator.network.inet.address): {}",
+          configuredAddress != null ? "configured" : "default",
+          simulatorNetworkAddress);
+      inetAddress = InetAddress.getByName(simulatorNetworkAddress);
+    } catch (final IOException e) {
+      log.error(
+          "Network address for simulator (simulator.network.inet.address) is not a valid Inet address.");
+      inetAddress = null;
+    }
+    return inetAddress;
+  }
+
+  public int getAlarmNotificationsPort() {
+    return Integer.parseInt(properties.getProperty("alarm.notifications.port"));
+  }
+
+  public String getAlarmNotificationsHost() {
+    return properties.getProperty("alarm.notifications.host");
+  }
+
+  public String getServiceEndpointHost() {
+    return properties.getProperty("service.endpoint.host");
+  }
+}

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/PlatformSmartmeteringDefaults.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/PlatformSmartmeteringDefaults.java
@@ -9,7 +9,6 @@ import java.time.Instant;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
-import lombok.extern.slf4j.Slf4j;
 import org.opensmartgridplatform.domain.core.entities.DeviceModel;
 import org.opensmartgridplatform.domain.core.entities.ProtocolInfo;
 
@@ -17,7 +16,6 @@ import org.opensmartgridplatform.domain.core.entities.ProtocolInfo;
  * Defaults specific for the dlms related data. Note: Keep in mind that generic defaults should be
  * specified in the cucumber-tests-platform project.
  */
-@Slf4j
 public class PlatformSmartmeteringDefaults
     extends org.opensmartgridplatform.cucumber.platform.PlatformDefaults {
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/PlatformSmartmeteringDefaults.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/PlatformSmartmeteringDefaults.java
@@ -4,12 +4,16 @@
 
 package org.opensmartgridplatform.cucumber.platform.smartmetering;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.time.Instant;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import lombok.extern.slf4j.Slf4j;
 import org.opensmartgridplatform.cucumber.platform.PlatformDefaults;
 import org.opensmartgridplatform.domain.core.entities.DeviceModel;
 import org.opensmartgridplatform.domain.core.entities.ProtocolInfo;
@@ -18,6 +22,7 @@ import org.opensmartgridplatform.domain.core.entities.ProtocolInfo;
  * Defaults specific for the dlms related data. Note: Keep in mind that generic defaults should be
  * specified in the cucumber-tests-platform project.
  */
+@Slf4j
 public class PlatformSmartmeteringDefaults
     extends org.opensmartgridplatform.cucumber.platform.PlatformDefaults {
 
@@ -106,12 +111,32 @@ public class PlatformSmartmeteringDefaults
   public static final Byte DEVIATION = -60;
 
   static {
-    InetAddress localhost;
+    InetAddress inetAddress;
     try {
-      localhost = InetAddress.getByName(PlatformDefaults.LOCALHOST);
-    } catch (final UnknownHostException e) {
-      localhost = null;
+      inetAddress = InetAddress.getByName(getSimulatorNetworkAddress());
+    } catch (final IOException e) {
+      log.error(
+          "Network address for simulator (simulator.network.inet.address) is not a valid Inet address.");
+      inetAddress = null;
     }
-    NETWORK_ADDRESS = localhost;
+    NETWORK_ADDRESS = inetAddress;
+  }
+
+  public static String getSimulatorNetworkAddress() throws IOException {
+    final Properties properties = new Properties();
+    final InputStream inputStream =
+        ClassLoader.getSystemResourceAsStream("cucumber-tests-platform-smartmetering.properties");
+    properties.load(inputStream);
+    if (inputStream != null) {
+      inputStream.close();
+    }
+    final String configuredAddress = properties.getProperty("simulator.network.inet.address");
+    final String simulatorNetworkAddress =
+        Objects.requireNonNullElse(configuredAddress, PlatformDefaults.LOCALHOST);
+    log.info(
+        "Using {} network address for simulator (simulator.network.inet.address): {}",
+        configuredAddress != null ? "configured" : "default",
+        simulatorNetworkAddress);
+    return simulatorNetworkAddress;
   }
 }

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/PlatformSmartmeteringDefaults.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/PlatformSmartmeteringDefaults.java
@@ -4,17 +4,12 @@
 
 package org.opensmartgridplatform.cucumber.platform.smartmetering;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.net.InetAddress;
 import java.time.Instant;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Properties;
 import lombok.extern.slf4j.Slf4j;
-import org.opensmartgridplatform.cucumber.platform.PlatformDefaults;
 import org.opensmartgridplatform.domain.core.entities.DeviceModel;
 import org.opensmartgridplatform.domain.core.entities.ProtocolInfo;
 
@@ -111,32 +106,8 @@ public class PlatformSmartmeteringDefaults
   public static final Byte DEVIATION = -60;
 
   static {
-    InetAddress inetAddress;
-    try {
-      inetAddress = InetAddress.getByName(getSimulatorNetworkAddress());
-    } catch (final IOException e) {
-      log.error(
-          "Network address for simulator (simulator.network.inet.address) is not a valid Inet address.");
-      inetAddress = null;
-    }
-    NETWORK_ADDRESS = inetAddress;
-  }
-
-  public static String getSimulatorNetworkAddress() throws IOException {
-    final Properties properties = new Properties();
-    final InputStream inputStream =
-        ClassLoader.getSystemResourceAsStream("cucumber-tests-platform-smartmetering.properties");
-    properties.load(inputStream);
-    if (inputStream != null) {
-      inputStream.close();
-    }
-    final String configuredAddress = properties.getProperty("simulator.network.inet.address");
-    final String simulatorNetworkAddress =
-        Objects.requireNonNullElse(configuredAddress, PlatformDefaults.LOCALHOST);
-    log.info(
-        "Using {} network address for simulator (simulator.network.inet.address): {}",
-        configuredAddress != null ? "configured" : "default",
-        simulatorNetworkAddress);
-    return simulatorNetworkAddress;
+    final CucumberTestsPlatformSmartmeteringProperties properties =
+        new CucumberTestsPlatformSmartmeteringProperties();
+    NETWORK_ADDRESS = properties.getNetworkAddress();
   }
 }

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/hooks/ScenarioHooks.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/hooks/ScenarioHooks.java
@@ -62,7 +62,7 @@ public class ScenarioHooks {
     this.prepareServiceEndpoint();
   }
 
-  private void loadConfiguration() throws IOException {
+  private void loadConfiguration() {
     final CucumberTestsPlatformSmartmeteringProperties properties =
         new CucumberTestsPlatformSmartmeteringProperties();
     this.alarmNotificationsPort = properties.getAlarmNotificationsPort();

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/hooks/ScenarioHooks.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/hooks/ScenarioHooks.java
@@ -14,12 +14,11 @@ import static org.opensmartgridplatform.cucumber.platform.smartmetering.Platform
 import io.cucumber.java.After;
 import io.cucumber.java.Before;
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Properties;
 import lombok.extern.slf4j.Slf4j;
 import org.opensmartgridplatform.cucumber.core.ScenarioContext;
+import org.opensmartgridplatform.cucumber.platform.smartmetering.CucumberTestsPlatformSmartmeteringProperties;
 import org.opensmartgridplatform.cucumber.platform.smartmetering.SecurityKey;
 import org.opensmartgridplatform.cucumber.platform.smartmetering.database.DlmsDatabase;
 import org.opensmartgridplatform.cucumber.platform.smartmetering.database.WsSmartMeteringNotificationDatabase;
@@ -64,18 +63,11 @@ public class ScenarioHooks {
   }
 
   private void loadConfiguration() throws IOException {
-
-    final Properties properties = new Properties();
-    final InputStream inputStream =
-        ClassLoader.getSystemResourceAsStream("cucumber-tests-platform-smartmetering.properties");
-    properties.load(inputStream);
-    if (inputStream != null) {
-      inputStream.close();
-    }
-    this.alarmNotificationsPort =
-        Integer.parseInt(properties.getProperty("alarm.notifications.port"));
-    this.alarmNotificationsHost = properties.getProperty("alarm.notifications.host");
-    this.serviceEndpointHost = properties.getProperty("service.endpoint.host");
+    final CucumberTestsPlatformSmartmeteringProperties properties =
+        new CucumberTestsPlatformSmartmeteringProperties();
+    this.alarmNotificationsPort = properties.getAlarmNotificationsPort();
+    this.alarmNotificationsHost = properties.getAlarmNotificationsHost();
+    this.serviceEndpointHost = properties.getServiceEndpointHost();
   }
 
   /**

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/hooks/ScenarioHooks.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/hooks/ScenarioHooks.java
@@ -13,7 +13,6 @@ import static org.opensmartgridplatform.cucumber.platform.smartmetering.Platform
 
 import io.cucumber.java.After;
 import io.cucumber.java.Before;
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
@@ -54,7 +53,7 @@ public class ScenarioHooks {
    * <p>Order 1000 ensures this will be run as one of the first hooks before the scenario.
    */
   @Before(order = 1000)
-  public void beforeScenario() throws IOException {
+  public void beforeScenario() {
     this.loadConfiguration();
     this.deviceSimulatorSteps.clearDlmsAttributeValues();
     this.dlmsDatabase.prepareDatabaseForScenario();

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/hooks/ScenarioHooks.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/glue/hooks/ScenarioHooks.java
@@ -13,8 +13,12 @@ import static org.opensmartgridplatform.cucumber.platform.smartmetering.Platform
 
 import io.cucumber.java.After;
 import io.cucumber.java.Before;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
+import lombok.extern.slf4j.Slf4j;
 import org.opensmartgridplatform.cucumber.core.ScenarioContext;
 import org.opensmartgridplatform.cucumber.platform.smartmetering.SecurityKey;
 import org.opensmartgridplatform.cucumber.platform.smartmetering.database.DlmsDatabase;
@@ -23,18 +27,17 @@ import org.opensmartgridplatform.cucumber.platform.smartmetering.glue.steps.simu
 import org.opensmartgridplatform.cucumber.platform.smartmetering.glue.steps.ws.smartmetering.smartmeteringconfiguration.ReplaceKeysSteps;
 import org.opensmartgridplatform.cucumber.platform.smartmetering.support.ServiceEndpoint;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 
 /** Class with all the scenario hooks when each scenario runs. */
+@Slf4j
 public class ScenarioHooks {
 
-  @Value("${alarm.notifications.host}")
   private String alarmNotificationsHost;
-
-  @Value("${alarm.notifications.port}")
   private int alarmNotificationsPort;
+  private String serviceEndpointHost;
 
   @Autowired private DlmsDatabase dlmsDatabase;
+
   @Autowired private WsSmartMeteringNotificationDatabase wsSmartMeteringNotificationDatabase;
 
   @Autowired private ReplaceKeysSteps replaceKeysSteps;
@@ -42,9 +45,6 @@ public class ScenarioHooks {
   @Autowired private DeviceSimulatorSteps deviceSimulatorSteps;
 
   @Autowired private ServiceEndpoint serviceEndpoint;
-
-  @Value("${service.endpoint.host}")
-  private String serviceEndpointHost;
 
   /**
    * Executed before each scenario.
@@ -55,11 +55,27 @@ public class ScenarioHooks {
    * <p>Order 1000 ensures this will be run as one of the first hooks before the scenario.
    */
   @Before(order = 1000)
-  public void beforeScenario() {
+  public void beforeScenario() throws IOException {
+    this.loadConfiguration();
     this.deviceSimulatorSteps.clearDlmsAttributeValues();
     this.dlmsDatabase.prepareDatabaseForScenario();
     this.wsSmartMeteringNotificationDatabase.prepareDatabaseForScenario();
     this.prepareServiceEndpoint();
+  }
+
+  private void loadConfiguration() throws IOException {
+
+    final Properties properties = new Properties();
+    final InputStream inputStream =
+        ClassLoader.getSystemResourceAsStream("cucumber-tests-platform-smartmetering.properties");
+    properties.load(inputStream);
+    if (inputStream != null) {
+      inputStream.close();
+    }
+    this.alarmNotificationsPort =
+        Integer.parseInt(properties.getProperty("alarm.notifications.port"));
+    this.alarmNotificationsHost = properties.getProperty("alarm.notifications.host");
+    this.serviceEndpointHost = properties.getProperty("service.endpoint.host");
   }
 
   /**


### PR DESCRIPTION
Makes _NETWORK_ADDRESS_ in _PlatformSmartmeteringDefaults_ configurable using key _simulator.network.inet.address_

Properties below are  now loaded using SystemResourceAsStream because @Value annotation does not works in class that is not managed by Spring
- alarmNotificationsHost;
- alarmNotificationsPort;
- serviceEndpointHost;