### PR TITLE
OPS: No group by for maven dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,10 +10,6 @@ updates:
     interval: daily
     time: "04:00"
   open-pull-requests-limit: 10
-  groups:
-    all:
-      patterns:
-        - "*"
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:


### PR DESCRIPTION
Removed groups configuration from Dependabot settings maven