### PR TITLE
fix-cucumber-test-set-network-address

### DIFF
--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/builders/entities/BaseDeviceBuilder.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/builders/entities/BaseDeviceBuilder.java
@@ -34,6 +34,7 @@ public abstract class BaseDeviceBuilder<T extends BaseDeviceBuilder<T>> {
   ProtocolInfo protocolInfo = null;
   Integer baseTransceiverStationId = null;
   Integer cellId = null;
+  String networkAddress;
   String containerMunicipality = PlatformSmartmeteringDefaults.CONTAINER_MUNICIPALITY;
   String alias = PlatformSmartmeteringDefaults.ALIAS;
   boolean inMaintenance = PlatformSmartmeteringDefaults.IN_MAINTENANCE;
@@ -111,6 +112,11 @@ public abstract class BaseDeviceBuilder<T extends BaseDeviceBuilder<T>> {
 
   public T setCellId(final Integer cellId) {
     this.cellId = cellId;
+    return (T) this;
+  }
+
+  public T setNetworkAddress(final String networkAddress) {
+    this.networkAddress = networkAddress;
     return (T) this;
   }
 
@@ -219,6 +225,10 @@ public abstract class BaseDeviceBuilder<T extends BaseDeviceBuilder<T>> {
     this.setCellId(
         ReadSettingsHelper.getInteger(inputSettings, PlatformSmartmeteringKeys.KEY_CELL_ID, null));
 
+    if (inputSettings.containsKey(PlatformSmartmeteringKeys.NETWORK_ADDRESS)) {
+      this.setNetworkAddress(
+          inputSettings.get(PlatformSmartmeteringKeys.NETWORK_ADDRESS));
+    }
     return (T) this;
   }
 }

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/builders/entities/BaseDeviceBuilder.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/builders/entities/BaseDeviceBuilder.java
@@ -226,8 +226,7 @@ public abstract class BaseDeviceBuilder<T extends BaseDeviceBuilder<T>> {
         ReadSettingsHelper.getInteger(inputSettings, PlatformSmartmeteringKeys.KEY_CELL_ID, null));
 
     if (inputSettings.containsKey(PlatformSmartmeteringKeys.NETWORK_ADDRESS)) {
-      this.setNetworkAddress(
-          inputSettings.get(PlatformSmartmeteringKeys.NETWORK_ADDRESS));
+      this.setNetworkAddress(inputSettings.get(PlatformSmartmeteringKeys.NETWORK_ADDRESS));
     }
     return (T) this;
   }

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/builders/entities/DeviceBuilder.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/builders/entities/DeviceBuilder.java
@@ -14,12 +14,11 @@ import org.opensmartgridplatform.domain.core.valueobjects.GpsCoordinates;
 public class DeviceBuilder extends BaseDeviceBuilder<DeviceBuilder>
     implements CucumberBuilder<Device> {
 
-  private final String simulatorNetworkAddress;
   private final DeviceRepository deviceRepository;
 
   public DeviceBuilder(
-      final String simulatorNetworkAddress, final DeviceRepository deviceRepository) {
-    this.simulatorNetworkAddress = simulatorNetworkAddress;
+      final String networkAddress, final DeviceRepository deviceRepository) {
+    this.networkAddress = networkAddress;
     this.deviceRepository = deviceRepository;
   }
 
@@ -56,7 +55,7 @@ public class DeviceBuilder extends BaseDeviceBuilder<DeviceBuilder>
     device.setTechnicalInstallationDate(this.technicalInstallationDate);
     // updateRegistrationData sets the status to IN_USE, so setting of any
     // other status has to be done after that.
-    device.updateRegistrationData(this.simulatorNetworkAddress, this.deviceType);
+    device.updateRegistrationData(this.networkAddress, this.deviceType);
     device.setDeviceLifecycleStatus(this.deviceLifeCycleStatus);
 
     return device;

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/builders/entities/DeviceBuilder.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/builders/entities/DeviceBuilder.java
@@ -16,8 +16,7 @@ public class DeviceBuilder extends BaseDeviceBuilder<DeviceBuilder>
 
   private final DeviceRepository deviceRepository;
 
-  public DeviceBuilder(
-      final String networkAddress, final DeviceRepository deviceRepository) {
+  public DeviceBuilder(final String networkAddress, final DeviceRepository deviceRepository) {
     this.networkAddress = networkAddress;
     this.deviceRepository = deviceRepository;
   }

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/builders/entities/SmartMeterBuilder.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/builders/entities/SmartMeterBuilder.java
@@ -18,8 +18,6 @@ import org.opensmartgridplatform.domain.core.valueobjects.GpsCoordinates;
 public class SmartMeterBuilder extends BaseDeviceBuilder<SmartMeterBuilder>
     implements CucumberBuilder<SmartMeter> {
 
-  private final String simulatorNetworkAddress;
-
   private String supplier;
   private Short channel;
   private String mbusIdentificationNumber;
@@ -28,9 +26,9 @@ public class SmartMeterBuilder extends BaseDeviceBuilder<SmartMeterBuilder>
   private Short mbusDeviceTypeIdentification;
   private Short mbusPrimaryAddress;
 
-  public SmartMeterBuilder(final String simulatorNetworkAddress) {
+  public SmartMeterBuilder(final String networkAddress) {
     super();
-    this.simulatorNetworkAddress = simulatorNetworkAddress;
+    this.networkAddress = networkAddress;
   }
 
   public SmartMeterBuilder setSupplier(final String supplier) {
@@ -84,7 +82,7 @@ public class SmartMeterBuilder extends BaseDeviceBuilder<SmartMeterBuilder>
             new GpsCoordinates(this.gpsLatitude, this.gpsLongitude));
 
     device.setActivated(this.isActivated);
-    device.updateRegistrationData(this.simulatorNetworkAddress, this.deviceType);
+    device.updateRegistrationData(this.networkAddress, this.deviceType);
     device.setBtsId(this.baseTransceiverStationId);
     device.setCellId(this.cellId);
 


### PR DESCRIPTION
PR https://github.com/OSGP/open-smart-grid-platform/pull/1635  enabled configuring default simulator network address but   removed the ability to set simulator network address in specific tests. This PR restored this.