### PR TITLE
notification service configurable in cucumber tests

### DIFF
--- a/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/config/ws/core/CoreNotificationWebServiceConfig.java
+++ b/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/config/ws/core/CoreNotificationWebServiceConfig.java
@@ -59,11 +59,23 @@ public class CoreNotificationWebServiceConfig extends WsConfigurerAdapter {
   @Value("${web.service.core.notification.target.uri}")
   private String notificationTargetUri;
 
+  @Value("${web.service.core.notification.keystore.use}")
+  private boolean notificationKeystoreUse;
+
+  @Value("${web.service.core.notification.keystore.type}")
+  private String notificationKeystoreType;
+
   @Value("${web.service.core.notification.keystore.location}")
   private String notificationKeystoreLocation;
 
   @Value("${web.service.core.notification.keystore.password}")
   private String notificationKeystorePassword;
+
+  @Value("${web.service.core.notification.truststore.use}")
+  private boolean notificationTruststoreUse;
+
+  @Value("${web.service.core.notification.truststore.type}")
+  private String notificationTruststoreType;
 
   @Value("${web.service.core.notification.truststore.location}")
   private String notificationTruststoreLocation;
@@ -81,6 +93,16 @@ public class CoreNotificationWebServiceConfig extends WsConfigurerAdapter {
     return this.notificationMarshallerContextPath;
   }
 
+  @Bean("wsCoreNotificationKeystoreUse")
+  public boolean notificationKeystoreUse() {
+    return this.notificationKeystoreUse;
+  }
+
+  @Bean("wsCoreNotificationKeystoreType")
+  public String notificationKeystoreType() {
+    return this.notificationKeystoreType;
+  }
+
   @Bean("wsCoreNotificationKeystoreLocation")
   public String notificationKeystoreLocation() {
     return this.notificationKeystoreLocation;
@@ -89,6 +111,16 @@ public class CoreNotificationWebServiceConfig extends WsConfigurerAdapter {
   @Bean("wsCoreNotificationKeystorePassword")
   public String notificationKeystorePassword() {
     return this.notificationKeystorePassword;
+  }
+
+  @Bean("wsCoreNotificationTruststoreUse")
+  public boolean notificationTruststoreUse() {
+    return this.notificationTruststoreUse;
+  }
+
+  @Bean("wsCoreNotificationTruststoreType")
+  public String notificationTruststoreType() {
+    return this.notificationTruststoreType;
   }
 
   @Bean("wsCoreNotificationTruststoreLocation")

--- a/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/database/WsCoreNotificationDatabase.java
+++ b/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/database/WsCoreNotificationDatabase.java
@@ -24,11 +24,28 @@ public class WsCoreNotificationDatabase extends WsNotificationDatabase {
       @Qualifier("wsCoreNotificationApplicationName") final String notificationApplicationName,
       @Qualifier("wsCoreNotificationTargetUri") final String notificationTargetUri,
       @Qualifier("wsCoreNotificationMarshallerContextPath")
-          final String notificationMarshallerContextPath) {
+          final String notificationMarshallerContextPath,
+      @Qualifier("wsCoreNotificationKeystoreUse") final boolean notificationKeystoreUse,
+      @Qualifier("wsCoreNotificationKeystoreType") final String notificationKeystoreType,
+      @Qualifier("wsCoreNotificationKeystoreLocation") final String notificationKeystoreLocation,
+      @Qualifier("wsCoreNotificationKeystorePassword") final String notificationKeystorePassword,
+      @Qualifier("wsCoreNotificationTruststoreUse") final boolean notificationTruststoreUse,
+      @Qualifier("wsCoreNotificationTruststoreType") final String notificationTruststoreType,
+      @Qualifier("wsCoreNotificationTruststoreLocation")
+          final String notificationTruststoreLocation,
+      @Qualifier("wsCoreNotificationTruststorePassword")
+          final String notificationTruststorePassword) {
     super(
         notificationApplicationName,
         notificationTargetUri,
-        false,
+        notificationKeystoreUse,
+        notificationKeystoreType,
+        notificationKeystoreLocation,
+        notificationKeystorePassword,
+        notificationTruststoreUse,
+        notificationTruststoreType,
+        notificationTruststoreLocation,
+        notificationTruststorePassword,
         notificationMarshallerContextPath,
         responseDataRepository,
         responseUrlDataRepository,

--- a/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/database/WsNotificationDatabase.java
+++ b/integration-tests/cucumber-tests-platform-common/src/test/java/org/opensmartgridplatform/cucumber/platform/common/glue/database/WsNotificationDatabase.java
@@ -13,11 +13,23 @@ import org.opensmartgridplatform.adapter.ws.domain.repositories.NotificationWebS
 import org.opensmartgridplatform.adapter.ws.domain.repositories.ResponseDataRepository;
 import org.opensmartgridplatform.adapter.ws.domain.repositories.ResponseUrlDataRepository;
 import org.opensmartgridplatform.cucumber.platform.common.glue.steps.database.ws.NotificationWebServiceConfigurationBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class WsNotificationDatabase {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(WsNotificationDatabase.class);
+
   private final String applicationName;
   private final String targetUri;
-  private final boolean useKeyStore;
+  private final boolean notificationKeystoreUse;
+  private final String notificationKeystoreType;
+  private final String notificationKeystoreLocation;
+  private final String notificationKeystorePassword;
+  private final boolean notificationTruststoreUse;
+  private final String notificationTruststoreType;
+  private final String notificationTruststoreLocation;
+  private final String notificationTruststorePassword;
   private final String marshallerContextPath;
   private final ResponseDataRepository responseDataRepository;
   private final ResponseUrlDataRepository responseUrlDataRepository;
@@ -37,7 +49,49 @@ public class WsNotificationDatabase {
       final ApplicationKeyConfigurationRepository applicationKeyConfigurationRepository) {
     this.applicationName = applicationName;
     this.targetUri = targetUri;
-    this.useKeyStore = useKeyStore;
+    this.marshallerContextPath = marshallerContextPath;
+    this.responseDataRepository = responseDataRepository;
+    this.responseUrlDataRepository = responseUrlDataRepository;
+    this.notificationWebServiceConfigurationRepository =
+        notificationWebServiceConfigurationRepository;
+    this.applicationKeyConfigurationRepository = applicationKeyConfigurationRepository;
+    this.notificationKeystoreUse = useKeyStore;
+    this.notificationKeystoreType = null;
+    this.notificationKeystoreLocation = null;
+    this.notificationKeystorePassword = null;
+    this.notificationTruststoreUse = false;
+    this.notificationTruststoreType = null;
+    this.notificationTruststoreLocation = null;
+    this.notificationTruststorePassword = null;
+  }
+
+  public WsNotificationDatabase(
+      final String applicationName,
+      final String targetUri,
+      final boolean notificationKeystoreUse,
+      final String notificationKeystoreType,
+      final String notificationKeystoreLocation,
+      final String notificationKeystorePassword,
+      final boolean notificationTruststoreUse,
+      final String notificationTruststoreType,
+      final String notificationTruststoreLocation,
+      final String notificationTruststorePassword,
+      final String marshallerContextPath,
+      final ResponseDataRepository responseDataRepository,
+      final ResponseUrlDataRepository responseUrlDataRepository,
+      final NotificationWebServiceConfigurationRepository
+          notificationWebServiceConfigurationRepository,
+      final ApplicationKeyConfigurationRepository applicationKeyConfigurationRepository) {
+    this.applicationName = applicationName;
+    this.targetUri = targetUri;
+    this.notificationKeystoreType = notificationKeystoreType;
+    this.notificationKeystoreLocation = notificationKeystoreLocation;
+    this.notificationKeystorePassword = notificationKeystorePassword;
+    this.notificationTruststoreUse = notificationTruststoreUse;
+    this.notificationTruststoreType = notificationTruststoreType;
+    this.notificationTruststoreLocation = notificationTruststoreLocation;
+    this.notificationTruststorePassword = notificationTruststorePassword;
+    this.notificationKeystoreUse = notificationKeystoreUse;
     this.marshallerContextPath = marshallerContextPath;
     this.responseDataRepository = responseDataRepository;
     this.responseUrlDataRepository = responseUrlDataRepository;
@@ -46,7 +100,7 @@ public class WsNotificationDatabase {
     this.applicationKeyConfigurationRepository = applicationKeyConfigurationRepository;
   }
 
-  public void prepareDatabaseForScenario() {
+  protected void prepareDatabaseForScenario() {
     TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
 
     this.responseDataRepository.deleteAllInBatch();
@@ -69,12 +123,40 @@ public class WsNotificationDatabase {
             .withMarshallerContextPath(this.marshallerContextPath)
             .withTargetUri(this.targetUri)
             .withoutCircuitBreakerConfig();
-    if (!this.useKeyStore) {
-      builder.withoutKeyStoreConfig().withoutTrustStoreConfig();
-    }
+    this.configureNotificationKeystore(builder);
     final NotificationWebServiceConfiguration testOrgConfig = builder.build();
     final NotificationWebServiceConfiguration noOrganisationConfig =
         builder.withOrganisationIdentification("no-organisation").build();
     return Arrays.asList(testOrgConfig, noOrganisationConfig);
+  }
+
+  protected void configureNotificationKeystore(
+      final NotificationWebServiceConfigurationBuilder builder) {
+    if (this.notificationKeystoreUse) {
+      LOGGER.info(
+          "Setting up notification keystore using type {} and location: {}",
+          this.notificationKeystoreType,
+          this.notificationKeystoreLocation);
+      builder.withKeyStoreConfig(
+          this.notificationKeystoreType,
+          this.notificationKeystoreLocation,
+          this.notificationKeystorePassword);
+    } else {
+      LOGGER.info("Setting up notification without keystore");
+      builder.withoutKeyStoreConfig();
+    }
+    if (this.notificationTruststoreUse) {
+      LOGGER.info(
+          "Setting up notification truststore using type {} and location: {}",
+          this.notificationTruststoreType,
+          this.notificationTruststoreLocation);
+      builder.withTrustStoreConfig(
+          this.notificationTruststoreType,
+          this.notificationTruststoreLocation,
+          this.notificationTruststorePassword);
+    } else {
+      LOGGER.info("Setting up notification without truststore");
+      builder.withoutTrustStoreConfig();
+    }
   }
 }

--- a/integration-tests/cucumber-tests-platform-common/src/test/resources/cucumber-tests-platform-common.properties
+++ b/integration-tests/cucumber-tests-platform-common/src/test/resources/cucumber-tests-platform-common.properties
@@ -28,8 +28,12 @@ web.service.core.notification.context=/notifications/
 web.service.core.notification.port=8188
 web.service.core.notification.address=localhost
 web.service.core.notification.target.uri=http://localhost:8188/notifications
+web.service.core.notification.keystore.use=true
+web.service.core.notification.keystore.type=pkcs12
 web.service.core.notification.keystore.location=/etc/ssl/certs/OSGP.pfx
 web.service.core.notification.keystore.password=1234
+web.service.core.notification.truststore.use=true
+web.service.core.notification.truststore.type=jks
 web.service.core.notification.truststore.location=/etc/ssl/certs/trust.jks
 web.service.core.notification.truststore.password=123456
 

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/config/ws/smartmetering/SmartMeteringNotificationWebServiceConfig.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/config/ws/smartmetering/SmartMeteringNotificationWebServiceConfig.java
@@ -56,6 +56,33 @@ public class SmartMeteringNotificationWebServiceConfig extends WsConfigurerAdapt
   @Value("${web.service.smartmetering.notification.address}")
   private String notificationAddress;
 
+  @Value("${web.service.smartmetering.notification.target.uri}")
+  private String notificationTargetUri;
+
+  @Value("${web.service.smartmetering.notification.keystore.use}")
+  private boolean notificationKeystoreUse;
+
+  @Value("${web.service.smartmetering.notification.keystore.type}")
+  private String notificationKeystoreType;
+
+  @Value("${web.service.smartmetering.notification.keystore.location}")
+  private String notificationKeystoreLocation;
+
+  @Value("${web.service.smartmetering.notification.keystore.password}")
+  private String notificationKeystorePassword;
+
+  @Value("${web.service.smartmetering.notification.truststore.use}")
+  private boolean notificationTruststoreUse;
+
+  @Value("${web.service.smartmetering.notification.truststore.type}")
+  private String notificationTruststoreType;
+
+  @Value("${web.service.smartmetering.notification.truststore.location}")
+  private String notificationTruststoreLocation;
+
+  @Value("${web.service.smartmetering.notification.truststore.password}")
+  private String notificationTruststorePassword;
+
   @Bean("wsSmartMeteringNotificationApplicationName")
   public String notificationApplicationName() {
     return this.notificationApplicationName;
@@ -64,6 +91,46 @@ public class SmartMeteringNotificationWebServiceConfig extends WsConfigurerAdapt
   @Bean("wsSmartMeteringNotificationMarshallerContextPath")
   public String notificationMarshallerContextPath() {
     return this.notificationMarshallerContextPath;
+  }
+
+  @Bean("wsSmartMeteringNotificationKeystoreUse")
+  public boolean notificationKeystoreUse() {
+    return this.notificationKeystoreUse;
+  }
+
+  @Bean("wsSmartMeteringNotificationKeystoreType")
+  public String notificationKeystoreType() {
+    return this.notificationKeystoreType;
+  }
+
+  @Bean("wsSmartMeteringNotificationKeystoreLocation")
+  public String notificationKeystoreLocation() {
+    return this.notificationKeystoreLocation;
+  }
+
+  @Bean("wsSmartMeteringNotificationKeystorePassword")
+  public String notificationKeystorePassword() {
+    return this.notificationKeystorePassword;
+  }
+
+  @Bean("wsSmartMeteringNotificationTruststoreUse")
+  public boolean notificationTruststoreUse() {
+    return this.notificationTruststoreUse;
+  }
+
+  @Bean("wsSmartMeteringNotificationTruststoreType")
+  public String notificationTruststoreType() {
+    return this.notificationTruststoreType;
+  }
+
+  @Bean("wsSmartMeteringNotificationTruststoreLocation")
+  public String notificationTruststoreLocation() {
+    return this.notificationTruststoreLocation;
+  }
+
+  @Bean("wsSmartMeteringNotificationTruststorePassword")
+  public String notificationTruststorePassword() {
+    return this.notificationTruststorePassword;
   }
 
   @Bean("wsSmartMeteringNotificationTargetUri")

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/database/WsSmartMeteringNotificationDatabase.java
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/java/org/opensmartgridplatform/cucumber/platform/smartmetering/database/WsSmartMeteringNotificationDatabase.java
@@ -27,11 +27,32 @@ public class WsSmartMeteringNotificationDatabase extends WsNotificationDatabase 
           final String notificationApplicationName,
       @Qualifier("wsSmartMeteringNotificationMarshallerContextPath")
           final String notificationMarshallerContextPath,
-      @Qualifier("wsSmartMeteringNotificationTargetUri") final String notificationTargetUri) {
+      @Qualifier("wsSmartMeteringNotificationTargetUri") final String notificationTargetUri,
+      @Qualifier("wsSmartMeteringNotificationKeystoreUse") final boolean notificationKeystoreUse,
+      @Qualifier("wsSmartMeteringNotificationKeystoreType") final String notificationKeystoreType,
+      @Qualifier("wsSmartMeteringNotificationKeystoreLocation")
+          final String notificationKeystoreLocation,
+      @Qualifier("wsSmartMeteringNotificationKeystorePassword")
+          final String notificationKeystorePassword,
+      @Qualifier("wsSmartMeteringNotificationTruststoreUse")
+          final boolean notificationTruststoreUse,
+      @Qualifier("wsSmartMeteringNotificationTruststoreType")
+          final String notificationTruststoreType,
+      @Qualifier("wsSmartMeteringNotificationTruststoreLocation")
+          final String notificationTruststoreLocation,
+      @Qualifier("wsSmartMeteringNotificationTruststorePassword")
+          final String notificationTruststorePassword) {
     super(
         notificationApplicationName,
         notificationTargetUri,
-        false,
+        notificationKeystoreUse,
+        notificationKeystoreType,
+        notificationKeystoreLocation,
+        notificationKeystorePassword,
+        notificationTruststoreUse,
+        notificationTruststoreType,
+        notificationTruststoreLocation,
+        notificationTruststorePassword,
         notificationMarshallerContextPath,
         responseDataRepository,
         responseUrlDataRepository,

--- a/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/cucumber-tests-platform-smartmetering.properties
+++ b/integration-tests/cucumber-tests-platform-smartmetering/src/test/resources/cucumber-tests-platform-smartmetering.properties
@@ -57,6 +57,15 @@ web.service.smartmetering.notification.application.name=SMART_METERS
 web.service.smartmetering.notification.context=/notifications/
 web.service.smartmetering.notification.port=8189
 web.service.smartmetering.notification.address=localhost
+web.service.smartmetering.notification.target.uri=http://localhost:8188/notifications
+web.service.smartmetering.notification.keystore.use=true
+web.service.smartmetering.notification.keystore.type=pkcs12
+web.service.smartmetering.notification.keystore.location=/etc/ssl/certs/OSGP.pfx
+web.service.smartmetering.notification.keystore.password=1234
+web.service.smartmetering.notification.truststore.use=true
+web.service.smartmetering.notification.truststore.type=jks
+web.service.smartmetering.notification.truststore.location=/etc/ssl/certs/trust.jks
+web.service.smartmetering.notification.truststore.password=123456
 
 #Response notification url
 response.url.notification.context=/notifications/

--- a/osgp/platform/osgp-adapter-ws-shared/src/main/java/org/opensmartgridplatform/adapter/ws/clients/NotificationWebServiceTemplateFactory.java
+++ b/osgp/platform/osgp-adapter-ws-shared/src/main/java/org/opensmartgridplatform/adapter/ws/clients/NotificationWebServiceTemplateFactory.java
@@ -170,6 +170,28 @@ public class NotificationWebServiceTemplateFactory {
       throws WebServiceSecurityException {
 
     final HttpClientBuilder clientBuilder = HttpClientBuilder.create();
+    LOGGER.info(
+        """
+    NotificationWebServiceConfiguration
+    targetUri: {},
+    keystore:   {},
+                {},
+                {},
+                {},
+    truststore: {},
+                {},
+                {},
+                {}
+    """,
+        config.getTargetUri(),
+        config.isUseKeyStore(),
+        config.getKeyStoreType(),
+        config.getKeyStoreLocation(),
+        config.getKeyStorePassword(),
+        config.isUseTrustStore(),
+        config.getTrustStoreType(),
+        config.getTrustStoreLocation(),
+        config.getTrustStorePassword());
     if (config.isUseKeyStore() || config.isUseTrustStore()) {
       clientBuilder.setSSLSocketFactory(this.createSslConnectionSocketFactory(config));
     }

--- a/osgp/platform/osgp-adapter-ws-shared/src/main/java/org/opensmartgridplatform/adapter/ws/clients/NotificationWebServiceTemplateFactory.java
+++ b/osgp/platform/osgp-adapter-ws-shared/src/main/java/org/opensmartgridplatform/adapter/ws/clients/NotificationWebServiceTemplateFactory.java
@@ -173,25 +173,21 @@ public class NotificationWebServiceTemplateFactory {
     LOGGER.info(
         """
     NotificationWebServiceConfiguration
-    targetUri: {},
-    keystore:   {},
-                {},
-                {},
-                {},
-    truststore: {},
-                {},
-                {},
-                {}
+    targetUri: {}
+    keystore:   use:      {}
+                type:     {}
+                location: {}
+    truststore: use:      {}
+                type:     {}
+                location: {}
     """,
         config.getTargetUri(),
         config.isUseKeyStore(),
         config.getKeyStoreType(),
         config.getKeyStoreLocation(),
-        config.getKeyStorePassword(),
         config.isUseTrustStore(),
         config.getTrustStoreType(),
-        config.getTrustStoreLocation(),
-        config.getTrustStorePassword());
+        config.getTrustStoreLocation());
     if (config.isUseKeyStore() || config.isUseTrustStore()) {
       clientBuilder.setSSLSocketFactory(this.createSslConnectionSocketFactory(config));
     }


### PR DESCRIPTION
This PR enables the configuration of the notification services in cucumber tests for modules core and ws-smartmetering
Configuration encomprises target url and the use of key and truststore and their configuration
