### PR TITLE
remove-explicite-versioned-netty-and-artemis

### DIFF
--- a/osgp/platform/osgp-throttling-service/pom.xml
+++ b/osgp/platform/osgp-throttling-service/pom.xml
@@ -47,25 +47,6 @@ SPDX-License-Identifier: Apache-2.0
 
   <dependencyManagement>
     <dependencies>
-      <!-- Put any dependencies where the version with Spring Boot should
-        be overridden here before spring-boot-dependencies. -->
-      <!-- artemis version (2.40.0) is out sync with spring-boot-dependencies version (3.5.5)
-           Check on upgrade of spring.boot.version and remove these 3 explicit versioned dependencies-->
-      <dependency>
-        <groupId>org.apache.activemq</groupId>
-        <artifactId>artemis-core-client</artifactId>
-        <version>${artemis.jakarta.client.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.activemq</groupId>
-        <artifactId>artemis-commons</artifactId>
-        <version>${artemis.jakarta.client.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.activemq</groupId>
-        <artifactId>artemis-selector</artifactId>
-        <version>${artemis.jakarta.client.version}</version>
-      </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/pom.xml
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/pom.xml
@@ -236,12 +236,6 @@ SPDX-License-Identifier: Apache-2.0
       <artifactId>logback-core</artifactId>
     </dependency>
 
-    <!-- Netty -->
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-all</artifactId>
-    </dependency>
-
     <!-- Servlet API -->
     <dependency>
       <groupId>jakarta.servlet</groupId>

--- a/osgp/protocol-adapter-dlms/osgp-protocol-simulator-dlms/pom.xml
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-simulator-dlms/pom.xml
@@ -87,24 +87,6 @@ SPDX-License-Identifier: Apache-2.0
       <!-- Spring Boot (N.B. This makes some explicit spring dependencies unnecessary) -->
       <!-- Put any dependencies where the version with Spring Boot should
            be overridden here before spring-boot-dependencies. -->
-      <!-- artemis version (2.40.0) is out sync with spring-boot-dependencies version (3.5.5)
-     Check on upgrade of spring.boot.version and remove these 3 explicit versioned dependencies-->
-
-      <dependency>
-        <groupId>org.apache.activemq</groupId>
-        <artifactId>artemis-core-client</artifactId>
-        <version>${artemis.jakarta.client.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.activemq</groupId>
-        <artifactId>artemis-commons</artifactId>
-        <version>${artemis.jakarta.client.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.activemq</groupId>
-        <artifactId>artemis-selector</artifactId>
-        <version>${artemis.jakarta.client.version}</version>
-      </dependency>
       <dependency>
         <!-- Import dependency management from Spring Boot -->
         <groupId>org.springframework.boot</groupId>

--- a/osgp/protocol-adapter-iec61850/osgp-protocol-adapter-iec61850/pom.xml
+++ b/osgp/protocol-adapter-iec61850/osgp-protocol-adapter-iec61850/pom.xml
@@ -198,12 +198,6 @@ SPDX-License-Identifier: Apache-2.0
       <artifactId>orika-core</artifactId>
     </dependency>
 
-    <!-- Netty -->
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-all</artifactId>
-    </dependency>
-
     <!-- Apache ActiveMQ -->
     <dependency>
       <groupId>org.apache.activemq</groupId>

--- a/osgp/protocol-adapter-oslp/osgp-protocol-adapter-oslp-elster/pom.xml
+++ b/osgp/protocol-adapter-oslp/osgp-protocol-adapter-oslp-elster/pom.xml
@@ -208,12 +208,6 @@ SPDX-License-Identifier: Apache-2.0
       <artifactId>micrometer-registry-jmx</artifactId>
     </dependency>
 
-    <!-- Netty -->
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-all</artifactId>
-    </dependency>
-
     <!-- Lombok -->
     <dependency>
       <groupId>org.projectlombok</groupId>

--- a/osgp/protocol-adapter-oslp/oslp/pom.xml
+++ b/osgp/protocol-adapter-oslp/oslp/pom.xml
@@ -40,10 +40,6 @@ SPDX-License-Identifier: Apache-2.0
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
     </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-all</artifactId>
-    </dependency>
 
     <!-- Logging -->
     <dependency>

--- a/osgp/protocol-adapter-oslp/web-device-simulator/pom.xml
+++ b/osgp/protocol-adapter-oslp/web-device-simulator/pom.xml
@@ -162,12 +162,6 @@ SPDX-License-Identifier: Apache-2.0
       <artifactId>commons-codec</artifactId>
     </dependency>
 
-    <!-- Netty -->
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-all</artifactId>
-    </dependency>
-
     <!-- OSGP -->
     <dependency>
       <groupId>org.opensmartgridplatform</groupId>

--- a/osgp/shared/shared/pom.xml
+++ b/osgp/shared/shared/pom.xml
@@ -255,13 +255,6 @@ SPDX-License-Identifier: Apache-2.0
       <artifactId>micrometer-registry-prometheus</artifactId>
     </dependency>
 
-    <!-- Netty -->
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-all</artifactId>
-      <scope>compile</scope>
-    </dependency>
-
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>

--- a/super/pom.xml
+++ b/super/pom.xml
@@ -110,7 +110,6 @@ SPDX-License-Identifier: Apache-2.0
     <apache.commons.schema>2.3.1</apache.commons.schema>
     <maven.clean.plugin.version>3.5.0</maven.clean.plugin.version>
     <maven.compiler.plugin.version>3.13.0</maven.compiler.plugin.version>
-    <netty.version>4.1.124.Final</netty.version>
     <openmuc.jdlms.version>1.8.0</openmuc.jdlms.version>
     <openmuc.jdlms-annotation.version>1.8.0</openmuc.jdlms-annotation.version>
     <beanit.openiec61850.version>1.8.0</beanit.openiec61850.version>
@@ -798,15 +797,6 @@ SPDX-License-Identifier: Apache-2.0
         <groupId>org.flywaydb</groupId>
         <artifactId>flyway-core</artifactId>
         <version>${flyway.version}</version>
-      </dependency>
-
-      <!-- Netty (TCP server) -->
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-bom</artifactId>
-        <version>${netty.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
       </dependency>
 
       <!-- Jakarta commons codec -->


### PR DESCRIPTION
- Partial rollback of PR #1642  (removed version overruling of _artemis_ libraries in throttling-service and dlms-simulator, version upgrade  remains)
- Removed explicite versioned dependency of _netty_ libraries