### PR TITLE
Feature/smhe 2453 bij een retry de actuele ip gegevens gebruiken

### DIFF
--- a/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/application/services/DeviceResponseMessageService.java
+++ b/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/application/services/DeviceResponseMessageService.java
@@ -308,11 +308,15 @@ public class DeviceResponseMessageService {
     final Serializable messageData = message.getDataObject();
     final Timestamp scheduleTimeStamp = new Timestamp(scheduledRetryTime.getTime());
 
-    final MessageMetadata messageMetadata = message.messageMetadata();
+    final Device device =
+        this.deviceService.findByDeviceIdentification(message.getDeviceIdentification());
+
+    final MessageMetadata updatedMessageMetadata =
+        message.messageMetadata().builder().withNetworkAddress(getNetworkAddress(device)).build();
 
     final ScheduledTask task =
         new ScheduledTask(
-            messageMetadata,
+            updatedMessageMetadata,
             message.getDomain(),
             message.getDomainVersion(),
             messageData,

--- a/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/application/services/DeviceResponseMessageService.java
+++ b/osgp/platform/osgp-core/src/main/java/org/opensmartgridplatform/core/application/services/DeviceResponseMessageService.java
@@ -308,15 +308,11 @@ public class DeviceResponseMessageService {
     final Serializable messageData = message.getDataObject();
     final Timestamp scheduleTimeStamp = new Timestamp(scheduledRetryTime.getTime());
 
-    final Device device =
-        this.deviceService.findByDeviceIdentification(message.getDeviceIdentification());
-
-    final MessageMetadata updatedMessageMetadata =
-        message.messageMetadata().builder().withNetworkAddress(getNetworkAddress(device)).build();
+    final MessageMetadata messageMetadata = message.messageMetadata();
 
     final ScheduledTask task =
         new ScheduledTask(
-            updatedMessageMetadata,
+            messageMetadata,
             message.getDomain(),
             message.getDomainVersion(),
             messageData,

--- a/osgp/platform/osgp-core/src/test/java/org/opensmartgridplatform/core/application/services/DeviceResponseMessageServiceTest.java
+++ b/osgp/platform/osgp-core/src/test/java/org/opensmartgridplatform/core/application/services/DeviceResponseMessageServiceTest.java
@@ -7,18 +7,16 @@ package org.opensmartgridplatform.core.application.services;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.io.Serializable;
 import java.sql.Timestamp;
 import java.util.Calendar;
 import java.util.Date;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -34,7 +32,7 @@ import org.opensmartgridplatform.shared.infra.jms.RetryHeader;
 
 /** test class for DeviceResponseMessageService */
 @ExtendWith(MockitoExtension.class)
-public class DeviceResponseMessageServiceTest {
+class DeviceResponseMessageServiceTest {
 
   private static final String DOMAIN = "Domain";
   private static final String DOMAIN_VERSION = "1.0";
@@ -59,14 +57,11 @@ public class DeviceResponseMessageServiceTest {
 
   @Mock private ScheduledTaskService scheduledTaskService;
 
-  @Mock private DeviceCommunicationInformationService deviceCommunicationInformationService;
-
   @InjectMocks private DeviceResponseMessageService deviceResponseMessageService;
-  @Captor private ArgumentCaptor<ScheduledTask> scheduledTaskArgumentCaptor;
 
   /** test processMessage with a scheduled task that failed */
   @Test
-  public void testProcessScheduledMessageFailed() {
+  void testProcessScheduledMessageFailed() {
     final ResponseMessageResultType result = ResponseMessageResultType.NOT_OK;
     final Calendar calendar = Calendar.getInstance();
     calendar.add(Calendar.DATE, 1);
@@ -95,7 +90,7 @@ public class DeviceResponseMessageServiceTest {
 
   /** test processMessage with a scheduled task that must be retried */
   @Test
-  public void testProcessScheduledMessageRetry() {
+  void testProcessScheduledMessageRetry() {
     final String exceptionMessage = "message";
     this.testProcessScheduledMessageRetry(exceptionMessage, exceptionMessage);
   }
@@ -147,7 +142,7 @@ public class DeviceResponseMessageServiceTest {
    * than 255 characters
    */
   @Test
-  public void testProcessScheduledMessageRetryWithTruncatedError() {
+  void testProcessScheduledMessageRetryWithTruncatedError() {
     final String exceptionMessageWith255Characters = StringUtils.repeat('x', 255);
     final String tooLongExceptionMessage = exceptionMessageWith255Characters + "extra";
     this.testProcessScheduledMessageRetry(
@@ -156,7 +151,7 @@ public class DeviceResponseMessageServiceTest {
 
   /** test processMessage with a scheduled task that has been successful */
   @Test
-  public void testProcessScheduledMessageSuccess() {
+  void testProcessScheduledMessageSuccess() {
     final ProtocolResponseMessage message =
         new ProtocolResponseMessage.Builder()
             .messageMetadata(MESSAGE_METADATA.builder().withScheduled(true).build())
@@ -175,7 +170,7 @@ public class DeviceResponseMessageServiceTest {
   }
 
   @Test
-  public void testProcessMessageReschedule() {
+  void testProcessMessageRescheduleDeviceIsRefreshed() {
     final Calendar calendar = Calendar.getInstance();
     calendar.add(Calendar.DATE, 1);
     final Date scheduledRetryTime = calendar.getTime();
@@ -198,8 +193,7 @@ public class DeviceResponseMessageServiceTest {
 
     this.deviceResponseMessageService.processMessage(message);
 
-    verify(this.scheduledTaskService).saveScheduledTask(this.scheduledTaskArgumentCaptor.capture());
-    final ScheduledTask savedTask = this.scheduledTaskArgumentCaptor.getValue();
-    final Serializable messageData = savedTask.getMessageData();
+    verify(this.deviceService, times(1))
+        .findByDeviceIdentification(message.getDeviceIdentification());
   }
 }

--- a/osgp/platform/osgp-core/src/test/java/org/opensmartgridplatform/core/application/services/DeviceResponseMessageServiceTest.java
+++ b/osgp/platform/osgp-core/src/test/java/org/opensmartgridplatform/core/application/services/DeviceResponseMessageServiceTest.java
@@ -167,5 +167,4 @@ class DeviceResponseMessageServiceTest {
     verify(this.domainResponseMessageSender).send(message);
     verify(this.scheduledTaskService).deleteScheduledTask(scheduledTask);
   }
-
 }

--- a/osgp/platform/osgp-core/src/test/java/org/opensmartgridplatform/core/application/services/DeviceResponseMessageServiceTest.java
+++ b/osgp/platform/osgp-core/src/test/java/org/opensmartgridplatform/core/application/services/DeviceResponseMessageServiceTest.java
@@ -10,16 +10,20 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.Serializable;
 import java.sql.Timestamp;
 import java.util.Calendar;
 import java.util.Date;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensmartgridplatform.core.domain.model.domain.DomainResponseService;
+import org.opensmartgridplatform.domain.core.entities.Device;
 import org.opensmartgridplatform.domain.core.entities.ScheduledTask;
 import org.opensmartgridplatform.shared.exceptionhandling.ComponentType;
 import org.opensmartgridplatform.shared.exceptionhandling.OsgpException;
@@ -43,6 +47,7 @@ public class DeviceResponseMessageServiceTest {
           .withDomain(DOMAIN)
           .withDomainVersion(DOMAIN_VERSION)
           .withMessagePriority(4)
+          .withNetworkAddress("oldNetworkAddress")
           .build();
   private static final String DATA_OBJECT = "data object";
   private static final Timestamp SCHEDULED_TIME =
@@ -57,6 +62,7 @@ public class DeviceResponseMessageServiceTest {
   @Mock private DeviceCommunicationInformationService deviceCommunicationInformationService;
 
   @InjectMocks private DeviceResponseMessageService deviceResponseMessageService;
+  @Captor private ArgumentCaptor<ScheduledTask> scheduledTaskArgumentCaptor;
 
   /** test processMessage with a scheduled task that failed */
   @Test
@@ -166,5 +172,34 @@ public class DeviceResponseMessageServiceTest {
     // check if message is send and task is deleted
     verify(this.domainResponseMessageSender).send(message);
     verify(this.scheduledTaskService).deleteScheduledTask(scheduledTask);
+  }
+
+  @Test
+  public void testProcessMessageReschedule() {
+    final Calendar calendar = Calendar.getInstance();
+    calendar.add(Calendar.DATE, 1);
+    final Date scheduledRetryTime = calendar.getTime();
+    final String newNetworkAddress = "newNetworkAddress";
+
+    final RetryHeader retryHeader = new RetryHeader(1, 2, scheduledRetryTime);
+    final Device device = new Device();
+    device.setNetworkAddress(newNetworkAddress);
+
+    final ProtocolResponseMessage message =
+        new ProtocolResponseMessage.Builder()
+            .messageMetadata(MESSAGE_METADATA.builder().withScheduled(false).build())
+            .result(ResponseMessageResultType.OK)
+            .dataObject(MESSAGE_METADATA)
+            .retryHeader(retryHeader)
+            .build();
+
+    when(this.deviceService.findByDeviceIdentification(message.getDeviceIdentification()))
+        .thenReturn(device);
+
+    this.deviceResponseMessageService.processMessage(message);
+
+    verify(this.scheduledTaskService).saveScheduledTask(this.scheduledTaskArgumentCaptor.capture());
+    final ScheduledTask savedTask = this.scheduledTaskArgumentCaptor.getValue();
+    final Serializable messageData = savedTask.getMessageData();
   }
 }

--- a/osgp/platform/osgp-core/src/test/java/org/opensmartgridplatform/core/application/services/DeviceResponseMessageServiceTest.java
+++ b/osgp/platform/osgp-core/src/test/java/org/opensmartgridplatform/core/application/services/DeviceResponseMessageServiceTest.java
@@ -45,7 +45,6 @@ class DeviceResponseMessageServiceTest {
           .withDomain(DOMAIN)
           .withDomainVersion(DOMAIN_VERSION)
           .withMessagePriority(4)
-          .withNetworkAddress("oldNetworkAddress")
           .build();
   private static final String DATA_OBJECT = "data object";
   private static final Timestamp SCHEDULED_TIME =
@@ -56,6 +55,8 @@ class DeviceResponseMessageServiceTest {
   @Mock private DomainResponseService domainResponseMessageSender;
 
   @Mock private ScheduledTaskService scheduledTaskService;
+
+  @Mock private DeviceCommunicationInformationService deviceCommunicationInformationService;
 
   @InjectMocks private DeviceResponseMessageService deviceResponseMessageService;
 

--- a/osgp/platform/osgp-core/src/test/java/org/opensmartgridplatform/core/application/services/DeviceResponseMessageServiceTest.java
+++ b/osgp/platform/osgp-core/src/test/java/org/opensmartgridplatform/core/application/services/DeviceResponseMessageServiceTest.java
@@ -7,7 +7,6 @@ package org.opensmartgridplatform.core.application.services;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -21,7 +20,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensmartgridplatform.core.domain.model.domain.DomainResponseService;
-import org.opensmartgridplatform.domain.core.entities.Device;
 import org.opensmartgridplatform.domain.core.entities.ScheduledTask;
 import org.opensmartgridplatform.shared.exceptionhandling.ComponentType;
 import org.opensmartgridplatform.shared.exceptionhandling.OsgpException;
@@ -170,31 +168,4 @@ class DeviceResponseMessageServiceTest {
     verify(this.scheduledTaskService).deleteScheduledTask(scheduledTask);
   }
 
-  @Test
-  void testProcessMessageRescheduleDeviceIsRefreshed() {
-    final Calendar calendar = Calendar.getInstance();
-    calendar.add(Calendar.DATE, 1);
-    final Date scheduledRetryTime = calendar.getTime();
-    final String newNetworkAddress = "newNetworkAddress";
-
-    final RetryHeader retryHeader = new RetryHeader(1, 2, scheduledRetryTime);
-    final Device device = new Device();
-    device.setNetworkAddress(newNetworkAddress);
-
-    final ProtocolResponseMessage message =
-        new ProtocolResponseMessage.Builder()
-            .messageMetadata(MESSAGE_METADATA.builder().withScheduled(false).build())
-            .result(ResponseMessageResultType.OK)
-            .dataObject(MESSAGE_METADATA)
-            .retryHeader(retryHeader)
-            .build();
-
-    when(this.deviceService.findByDeviceIdentification(message.getDeviceIdentification()))
-        .thenReturn(device);
-
-    this.deviceResponseMessageService.processMessage(message);
-
-    verify(this.deviceService, times(1))
-        .findByDeviceIdentification(message.getDeviceIdentification());
-  }
 }

--- a/osgp/platform/osgp-core/src/test/java/org/opensmartgridplatform/core/application/tasks/ScheduledTaskExecutorServiceTest.java
+++ b/osgp/platform/osgp-core/src/test/java/org/opensmartgridplatform/core/application/tasks/ScheduledTaskExecutorServiceTest.java
@@ -207,7 +207,7 @@ class ScheduledTaskExecutorServiceTest {
     final String deviceIdentification = "device-1";
     final String deviceModelCode = "E,M1,M2,M3,M4";
     final MessageMetadata messageMetadata =
-        this.createMessageMetadata(deviceIdentification, deviceModelCode);
+        this.createMessageMetadata(deviceIdentification, deviceModelCode, null);
     final ScheduledTask scheduledTask =
         new ScheduledTask(messageMetadata, DOMAIN, DOMAIN, DATA_OBJECT, INITIAL_SCHEDULED_TIME);
     final Device device = new Device();
@@ -239,6 +239,50 @@ class ScheduledTaskExecutorServiceTest {
     assertThat(protocolRequestMessage).isNotNull();
     assertThat(protocolRequestMessage.getDeviceIdentification()).isEqualTo(deviceIdentification);
     assertThat(protocolRequestMessage.getDeviceModelCode()).isEqualTo(deviceModelCode);
+  }
+
+  @Test
+  void testRequestFromScheduledTaskIsCreatedWithLatestDeviceNetworkAddress()
+      throws FunctionalException {
+    final String deviceIdentification = "device-1";
+    final String deviceModelCode = "E,M1,M2,M3,M4";
+    final String oldNetworkAddress = "oldNetworkAddress";
+    final String newNetworkAddress = "newNetworkAddress";
+    final MessageMetadata messageMetadata =
+        this.createMessageMetadata(deviceIdentification, deviceModelCode, oldNetworkAddress);
+
+    final ScheduledTask scheduledTask =
+        new ScheduledTask(messageMetadata, DOMAIN, DOMAIN, DATA_OBJECT, INITIAL_SCHEDULED_TIME);
+    final Device device = new Device();
+    device.setNetworkAddress(newNetworkAddress);
+
+    when(this.scheduledTaskExecutorJobConfig.scheduledTaskPendingDurationMaxSeconds())
+        .thenReturn(-1L);
+    when(this.scheduledTaskExecutorJobConfig.scheduledTaskPageSize()).thenReturn(30);
+    when(this.scheduledTaskRepository.updateStatus(
+            scheduledTask.getId(), ScheduledTaskStatusType.PENDING))
+        .thenReturn(1);
+    when(this.deviceRepository.findByDeviceIdentification(deviceIdentification)).thenReturn(device);
+    when(this.scheduledTaskRepository.findByStatusAndScheduledTimeLessThan(
+            eq(ScheduledTaskStatusType.PENDING), any(Timestamp.class), any(Pageable.class)))
+        .thenReturn(new ArrayList<>());
+    when(this.scheduledTaskRepository.findByStatusAndScheduledTimeLessThan(
+            eq(ScheduledTaskStatusType.NEW), any(Timestamp.class), any(Pageable.class)))
+        .thenReturn(List.of(scheduledTask), Collections.emptyList());
+    when(this.scheduledTaskRepository.findByStatusAndScheduledTimeLessThan(
+            eq(ScheduledTaskStatusType.RETRY), any(Timestamp.class), any(Pageable.class)))
+        .thenReturn(new ArrayList<>());
+    when(this.scheduledTaskExecutorJobConfig.getScheduledTaskThreadPoolSize()).thenReturn(1);
+
+    this.scheduledTaskExecutorService.processScheduledTasks();
+
+    verify(this.deviceRequestMessageService)
+        .processMessage(this.protocolRequestMessageCaptor.capture());
+    final ProtocolRequestMessage protocolRequestMessage =
+        this.protocolRequestMessageCaptor.getValue();
+    assertThat(protocolRequestMessage).isNotNull();
+
+    assertThat(protocolRequestMessage.getIpAddress()).isEqualTo(newNetworkAddress);
   }
 
   private void whenFindByStatusAndScheduledTime(
@@ -295,14 +339,17 @@ class ScheduledTaskExecutorServiceTest {
   }
 
   private MessageMetadata createMessageMetadata() {
-    return this.createMessageMetadata("retryable", null);
+    return this.createMessageMetadata("retryable", null, null);
   }
 
   private MessageMetadata createMessageMetadata(
-      final String deviceIdentification, final String deviceModelCode) {
+      final String deviceIdentification,
+      final String deviceModelCode,
+      final String networkAddress) {
     return this.createMessageMetadataBuilder()
         .withDeviceIdentification(deviceIdentification)
         .withDeviceModelCode(deviceModelCode)
+        .withNetworkAddress(networkAddress)
         .build();
   }
 

--- a/osgp/platform/osgp-core/src/test/java/org/opensmartgridplatform/core/application/tasks/ScheduledTaskExecutorServiceTest.java
+++ b/osgp/platform/osgp-core/src/test/java/org/opensmartgridplatform/core/application/tasks/ScheduledTaskExecutorServiceTest.java
@@ -27,8 +27,6 @@ import java.util.concurrent.ExecutorService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -243,12 +241,9 @@ class ScheduledTaskExecutorServiceTest {
     assertThat(protocolRequestMessage.getDeviceModelCode()).isEqualTo(deviceModelCode);
   }
 
-  @ParameterizedTest
-  @EnumSource(
-      value = ScheduledTaskStatusType.class,
-      names = {"NEW", "RETRY"})
-  void testRequestFromScheduledTaskIsCreatedWithLatestDeviceNetworkAddress(
-      final ScheduledTaskStatusType statusType) throws FunctionalException {
+  @Test
+  void testRequestFromScheduledTaskIsCreatedWithLatestDeviceNetworkAddress()
+      throws FunctionalException {
     final String deviceIdentification = "device-1";
     final String deviceModelCode = "E,M1,M2,M3,M4";
     final String oldNetworkAddress = "oldNetworkAddress";
@@ -272,15 +267,10 @@ class ScheduledTaskExecutorServiceTest {
             eq(ScheduledTaskStatusType.PENDING), any(Timestamp.class), any(Pageable.class)))
         .thenReturn(new ArrayList<>());
     when(this.scheduledTaskRepository.findByStatusAndScheduledTimeLessThan(
-            eq(statusType), any(Timestamp.class), any(Pageable.class)))
+            eq(ScheduledTaskStatusType.NEW), any(Timestamp.class), any(Pageable.class)))
         .thenReturn(List.of(scheduledTask), Collections.emptyList());
     when(this.scheduledTaskRepository.findByStatusAndScheduledTimeLessThan(
-            eq(
-                statusType == ScheduledTaskStatusType.NEW
-                    ? ScheduledTaskStatusType.RETRY
-                    : ScheduledTaskStatusType.NEW),
-            any(Timestamp.class),
-            any(Pageable.class)))
+            eq(ScheduledTaskStatusType.RETRY), any(Timestamp.class), any(Pageable.class)))
         .thenReturn(new ArrayList<>());
     when(this.scheduledTaskExecutorJobConfig.getScheduledTaskThreadPoolSize()).thenReturn(1);
 
@@ -291,6 +281,7 @@ class ScheduledTaskExecutorServiceTest {
     final ProtocolRequestMessage protocolRequestMessage =
         this.protocolRequestMessageCaptor.getValue();
     assertThat(protocolRequestMessage).isNotNull();
+
     assertThat(protocolRequestMessage.getIpAddress()).isEqualTo(newNetworkAddress);
   }
 

--- a/osgp/platform/osgp-core/src/test/java/org/opensmartgridplatform/core/application/tasks/ScheduledTaskExecutorServiceTest.java
+++ b/osgp/platform/osgp-core/src/test/java/org/opensmartgridplatform/core/application/tasks/ScheduledTaskExecutorServiceTest.java
@@ -27,6 +27,8 @@ import java.util.concurrent.ExecutorService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -241,9 +243,12 @@ class ScheduledTaskExecutorServiceTest {
     assertThat(protocolRequestMessage.getDeviceModelCode()).isEqualTo(deviceModelCode);
   }
 
-  @Test
-  void testRequestFromScheduledTaskIsCreatedWithLatestDeviceNetworkAddress()
-      throws FunctionalException {
+  @ParameterizedTest
+  @EnumSource(
+      value = ScheduledTaskStatusType.class,
+      names = {"NEW", "RETRY"})
+  void testRequestFromScheduledTaskIsCreatedWithLatestDeviceNetworkAddress(
+      final ScheduledTaskStatusType statusType) throws FunctionalException {
     final String deviceIdentification = "device-1";
     final String deviceModelCode = "E,M1,M2,M3,M4";
     final String oldNetworkAddress = "oldNetworkAddress";
@@ -267,10 +272,15 @@ class ScheduledTaskExecutorServiceTest {
             eq(ScheduledTaskStatusType.PENDING), any(Timestamp.class), any(Pageable.class)))
         .thenReturn(new ArrayList<>());
     when(this.scheduledTaskRepository.findByStatusAndScheduledTimeLessThan(
-            eq(ScheduledTaskStatusType.NEW), any(Timestamp.class), any(Pageable.class)))
+            eq(statusType), any(Timestamp.class), any(Pageable.class)))
         .thenReturn(List.of(scheduledTask), Collections.emptyList());
     when(this.scheduledTaskRepository.findByStatusAndScheduledTimeLessThan(
-            eq(ScheduledTaskStatusType.RETRY), any(Timestamp.class), any(Pageable.class)))
+            eq(
+                statusType == ScheduledTaskStatusType.NEW
+                    ? ScheduledTaskStatusType.RETRY
+                    : ScheduledTaskStatusType.NEW),
+            any(Timestamp.class),
+            any(Pageable.class)))
         .thenReturn(new ArrayList<>());
     when(this.scheduledTaskExecutorJobConfig.getScheduledTaskThreadPoolSize()).thenReturn(1);
 
@@ -281,7 +291,6 @@ class ScheduledTaskExecutorServiceTest {
     final ProtocolRequestMessage protocolRequestMessage =
         this.protocolRequestMessageCaptor.getValue();
     assertThat(protocolRequestMessage).isNotNull();
-
     assertThat(protocolRequestMessage.getIpAddress()).isEqualTo(newNetworkAddress);
   }
 


### PR DESCRIPTION
Add unit test for SchedulerTaskExecutorService to verify that the current ip address from the device is used to create a new request.