### PR TITLE
Maven user properties

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -61,6 +61,24 @@ SPDX-License-Identifier: Apache-2.0
         <artifactId>maven-site-plugin</artifactId>
         <version>${maven.site.plugin}</version>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>properties-maven-plugin</artifactId>
+        <version>1.2.1</version>
+        <executions>
+          <execution>
+            <phase>initialize</phase>
+            <goals>
+              <goal>read-project-properties</goal>
+            </goals>
+            <configuration>
+              <files>
+                <file>${user.properties.file}</file>
+              </files>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
Externe properties kunnen nu geladen worden via de variabele user.properties.file
https://www.baeldung.com/maven-read-external-properties