### PR TITLE
SMHE-3049-mvn-external-properties

### DIFF
--- a/integration-tests/.gitignore
+++ b/integration-tests/.gitignore
@@ -8,6 +8,7 @@
 .metadata
 .gradle
 bin/
+data/
 tmp/
 target/
 *.tmp

--- a/integration-tests/cucumber-tests-core/pom.xml
+++ b/integration-tests/cucumber-tests-core/pom.xml
@@ -119,4 +119,36 @@ SPDX-License-Identifier: Apache-2.0
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>k3d-properties</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-resources-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>copy-resources</id>
+                <phase>generate-test-resources</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
+                  <resources>
+                    <resource>
+                      <directory>${project.basedir}/../../data</directory>
+                      <includes>
+                        <include>cucumber-tests-core.properties</include>
+                      </includes>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/integration-tests/cucumber-tests-platform-common/pom.xml
+++ b/integration-tests/cucumber-tests-platform-common/pom.xml
@@ -195,4 +195,36 @@ SPDX-License-Identifier: Apache-2.0
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>k3d-properties</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-resources-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>copy-resources</id>
+                <phase>generate-test-resources</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
+                  <resources>
+                    <resource>
+                      <directory>${project.basedir}/../../data</directory>
+                      <includes>
+                        <include>cucumber-tests-platform-common.properties</include>
+                      </includes>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/integration-tests/cucumber-tests-platform-smartmetering/pom.xml
+++ b/integration-tests/cucumber-tests-platform-smartmetering/pom.xml
@@ -259,4 +259,36 @@ SPDX-License-Identifier: Apache-2.0
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>k3d-properties</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-resources-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>copy-resources</id>
+                <phase>generate-test-resources</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
+                  <resources>
+                    <resource>
+                      <directory>${project.basedir}/../../data</directory>
+                      <includes>
+                        <include>cucumber-tests-platform-smartmetering.properties</include>
+                      </includes>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/integration-tests/cucumber-tests-platform/pom.xml
+++ b/integration-tests/cucumber-tests-platform/pom.xml
@@ -170,4 +170,36 @@ SPDX-License-Identifier: Apache-2.0
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>k3d-properties</id>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-resources-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>copy-resources</id>
+                <phase>generate-test-resources</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
+                  <resources>
+                    <resource>
+                      <directory>${project.basedir}/../../data</directory>
+                      <includes>
+                        <include>cucumber-tests-platform.properties</include>
+                      </includes>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
Adds support for using external properties.
Using k3d-properties profile, properties for smartmetering cucumber tests are overwritten by copying from data directory in project root and writing to test jar.
The following properties are supported:
- data/cucumber-tests-core.properties
- data/cucumber-tests-platform.properties
- data/cucumber-tests-platform-common.properties
- data/cucumber-tests-platform-smartmetering.properties

data directory is excluded from git