### PR TITLE
Ignore k3d properties data folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@
 .metadata
 .gradle
 bin/
-data/
+k3d-config/
 tmp/
 target/
 *.tmp

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 .metadata
 .gradle
 bin/
+data/
 tmp/
 target/
 *.tmp

--- a/integration-tests/cucumber-tests-core/pom.xml
+++ b/integration-tests/cucumber-tests-core/pom.xml
@@ -137,7 +137,7 @@ SPDX-License-Identifier: Apache-2.0
                   <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
                   <resources>
                     <resource>
-                      <directory>${project.basedir}/../../data</directory>
+                      <directory>${project.basedir}/../../k3d-config</directory>
                       <includes>
                         <include>cucumber-tests-core.properties</include>
                       </includes>

--- a/integration-tests/cucumber-tests-platform-common/pom.xml
+++ b/integration-tests/cucumber-tests-platform-common/pom.xml
@@ -213,7 +213,7 @@ SPDX-License-Identifier: Apache-2.0
                   <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
                   <resources>
                     <resource>
-                      <directory>${project.basedir}/../../data</directory>
+                      <directory>${project.basedir}/../../k3d-config</directory>
                       <includes>
                         <include>cucumber-tests-platform-common.properties</include>
                       </includes>

--- a/integration-tests/cucumber-tests-platform-smartmetering/pom.xml
+++ b/integration-tests/cucumber-tests-platform-smartmetering/pom.xml
@@ -277,7 +277,7 @@ SPDX-License-Identifier: Apache-2.0
                   <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
                   <resources>
                     <resource>
-                      <directory>${project.basedir}/../../data</directory>
+                      <directory>${project.basedir}/../../k3d-config</directory>
                       <includes>
                         <include>cucumber-tests-platform-smartmetering.properties</include>
                       </includes>

--- a/integration-tests/cucumber-tests-platform/pom.xml
+++ b/integration-tests/cucumber-tests-platform/pom.xml
@@ -188,7 +188,7 @@ SPDX-License-Identifier: Apache-2.0
                   <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
                   <resources>
                     <resource>
-                      <directory>${project.basedir}/../../data</directory>
+                      <directory>${project.basedir}/../../k3d-config</directory>
                       <includes>
                         <include>cucumber-tests-platform.properties</include>
                       </includes>


### PR DESCRIPTION
Adds ignore for k3d properties data folder and updates references to old "data" name.