### PR TITLE
Fix OSGP images bugfix

### DIFF
--- a/osgp/platform/osgp-throttling-service/Dockerfile
+++ b/osgp/platform/osgp-throttling-service/Dockerfile
@@ -11,5 +11,5 @@ RUN mkdir -p /var/log/osp && \
     mkdir -p /usr/local/tomcat/webapps/probe/ && \
     touch /usr/local/tomcat/webapps/probe/probe.txt
 
-COPY target/osgp-throttling-service-*/ /usr/local/tomcat/webapps/
+COPY target/gxf /usr/local/tomcat/webapps/
 

--- a/osgp/platform/osgp-throttling-service/pom.xml
+++ b/osgp/platform/osgp-throttling-service/pom.xml
@@ -39,6 +39,7 @@ SPDX-License-Identifier: Apache-2.0
         <artifactId>maven-war-plugin</artifactId>
         <version>${maven.war.plugin.version}</version>
         <configuration>
+          <webappDirectory>${project.build.directory}/gxf/${project.artifactId}</webappDirectory>
           <attachClasses>true</attachClasses>
         </configuration>
       </plugin>

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/Dockerfile
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/Dockerfile
@@ -11,4 +11,4 @@ RUN mkdir -p /var/log/osp && \
     mkdir -p /usr/local/tomcat/webapps/probe/ && \
     touch /usr/local/tomcat/webapps/probe/probe.txt
 
-COPY target/osgp-protocol-adapter-dlms-*/ /usr/local/tomcat/webapps/
+COPY target/gxf /usr/local/tomcat/webapps/

--- a/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/pom.xml
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-adapter-dlms/pom.xml
@@ -41,6 +41,7 @@ SPDX-License-Identifier: Apache-2.0
         <configuration>
           <attachClasses>true</attachClasses>
           <failOnMissingWebXml>false</failOnMissingWebXml>
+          <webappDirectory>${project.build.directory}/gxf/${project.artifactId}</webappDirectory>
           <nonFilteredFileExtensions>
             <nonFilteredFileExtension>gif</nonFilteredFileExtension>
             <nonFilteredFileExtension>ico</nonFilteredFileExtension>

--- a/osgp/protocol-adapter-dlms/osgp-protocol-simulator-dlms/osgp-simulator-dlms-triggered/Dockerfile
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-simulator-dlms/osgp-simulator-dlms-triggered/Dockerfile
@@ -11,4 +11,4 @@ RUN mkdir -p /var/log/osp && \
     mkdir -p /usr/local/tomcat/webapps/probe/ && \
     touch /usr/local/tomcat/webapps/probe/probe.txt
 
-COPY target/osgp-simulator-dlms-triggered-*/ /usr/local/tomcat/webapps/
+COPY target/gxf /usr/local/tomcat/webapps/

--- a/osgp/protocol-adapter-dlms/osgp-protocol-simulator-dlms/osgp-simulator-dlms-triggered/pom.xml
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-simulator-dlms/osgp-simulator-dlms-triggered/pom.xml
@@ -58,6 +58,7 @@ SPDX-License-Identifier: Apache-2.0
           <version>${maven.war.plugin.version}</version>
           <configuration>
             <failOnMissingWebXml>false</failOnMissingWebXml>
+            <webappDirectory>${project.build.directory}/gxf/${project.artifactId}</webappDirectory>
             <nonFilteredFileExtensions>
               <nonFilteredFileExtension>gif</nonFilteredFileExtension>
               <nonFilteredFileExtension>ico</nonFilteredFileExtension>

--- a/osgp/protocol-adapter-dlms/osgp-protocol-simulator-dlms/simulator/dlms-device-simulator-starter/Dockerfile
+++ b/osgp/protocol-adapter-dlms/osgp-protocol-simulator-dlms/simulator/dlms-device-simulator-starter/Dockerfile
@@ -1,4 +1,4 @@
 FROM eclipse-temurin:17-jdk-alpine
 RUN apk add --update coreutils tzdata && rm -rf /var/cache/apk/*
-COPY target/dlms-device-simulator-starter-*.jar /app/
+COPY target/dlms-device-simulator-starter-*.jar /app/dlms-device-simulator-starter.jar
 ENTRYPOINT ["java", "-jar", "/app/dlms-device-simulator-starter.jar", "/config/simulators.json", "start"]


### PR DESCRIPTION
Apply OSGP docker images fix to bugfix:
- Copy dlms-device-simulator-starter-*.jar to /app/dlms-device-simulator.jar
- Copy osgp-protocol-adapter-dlms,osgp-simulator-dlms-triggered,osgp-throttling-service by deploying war to gxf dir and then copying in dockerfile